### PR TITLE
fixup rendering example and resizing

### DIFF
--- a/rviz_rendering/src/examples/rendering_example.cpp
+++ b/rviz_rendering/src/examples/rendering_example.cpp
@@ -43,15 +43,8 @@ int main(int argc, char *argv[])
 
   rviz_rendering::RenderWindow render_window;
   QWidget * containing_widget = QWidget::createWindowContainer(&render_window, window);
-  // Q_UNUSED(containing_widget);
-  // QTabWidget * tabs = new QTabWidget(containing_widget);
-  QTabWidget * tabs = new QTabWidget(window);
-  tabs->setFixedSize(245, 245);
-  tabs->addTab(new QWidget(), "TAB 1");
-  tabs->addTab(containing_widget, "TAB 2");
-  // containing_widget->show();
 
-  window->setCentralWidget(tabs);
+  window->setCentralWidget(containing_widget);
   window->show();
 
   return a.exec();

--- a/rviz_rendering/src/rviz_rendering/render_window.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window.cpp
@@ -56,9 +56,6 @@ RenderWindow::RenderWindow(QWindow * parent)
 : QWindow(parent), impl_(new RenderWindowImpl(this))
 {
   this->installEventFilter(this);
-  QTimer * timer = new QTimer(this);
-  connect(timer, SIGNAL(timeout()), this, SLOT(renderNow()));
-  timer->start(1000);
 }
 
 RenderWindow::~RenderWindow()

--- a/rviz_rendering/src/rviz_rendering/render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window_impl.cpp
@@ -221,6 +221,7 @@ RenderWindowImpl::resize(size_t width, size_t height)
   if (ogre_render_window_) {
     ogre_render_window_->resize(width, height);
   }
+  this->renderLater();
 }
 
 }  // namespace rviz_rendering


### PR DESCRIPTION
I also removed the timer doing a periodic render and added a renderLater to the resize event, since I noticed that the window would sometimes not get refreshed after a resize, leaving blank bars and stuff.

Fixes #2.

The rendering is pretty laggy too, at least on my work desktop. It's not a slouch either, GTX 1070 and 12-core i7. Not sure what that's about.