### PR TITLE
fixes resize when using maximize

### DIFF
--- a/rviz_rendering/src/rviz_rendering/render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window_impl.cpp
@@ -220,6 +220,7 @@ RenderWindowImpl::resize(size_t width, size_t height)
   printf("in RenderWindowImpl::resize(size_t %zu, size_t %zu)\n", width, height);
   if (ogre_render_window_) {
     ogre_render_window_->resize(width, height);
+    ogre_render_window_->windowMovedOrResized();
   }
   this->renderLater();
 }


### PR DESCRIPTION
Before this, if you maximized the window, you would sometimes get a weird bug where the ogre render area was a different size than the Qt window, e.g.:

![screenshot from 2017-08-30 15-09-49](https://user-images.githubusercontent.com/100427/29897462-d25680b8-8d95-11e7-9c68-abc078c8b05a.png)

(the sphere should be in the center)