### PR TITLE
pass the pixel ratio to Ogre from Qt

### DIFF
--- a/rviz_rendering/src/rviz_rendering/render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window_impl.cpp
@@ -190,8 +190,9 @@ void
 RenderWindowImpl::initialize()
 {
   render_system_ = RenderSystem::get();
-  ogre_render_window_ =
-    render_system_->makeRenderWindow(parent_->winId(), parent_->width(), parent_->height());
+  double pixel_ratio = parent_->devicePixelRatio();
+  ogre_render_window_ = render_system_->makeRenderWindow(
+    parent_->winId(), parent_->width(), parent_->height(), pixel_ratio);
 
   Ogre::Root * ogre_root = render_system_->getOgreRoot();
   if (!ogre_root) {


### PR DESCRIPTION
This is needed to support retina displays and some other high resolution displays.

This is based on what we do in rviz, see:

https://github.com/ros-visualization/rviz/blob/2801067f62ca2bc171df73764964cff3b3d40b54/src/rviz/ogre_helpers/render_widget.cpp#L87-L89