### PR TITLE
[rviz_rendering] Scale rendering window correctly on Windows

### DIFF
--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -388,6 +388,10 @@ RenderSystem::makeRenderWindow(
   //   Ogre::StringConverter::toString(static_cast<unsigned long>(window_id));
   params["parentWindowHandle"] = Ogre::StringConverter::toString(window_id);
 
+  // Scale rendering window correctly on Windows
+  params["left"] = std::to_string(0);
+  params["top"] = std::to_string(0);
+
   // params["externalGLControl"] = Ogre::String("true");
 
   // Enable antialiasing


### PR DESCRIPTION
Adding the "left" and "top" parameter positions the render window correctly inside the QWindow.