### PR TITLE
Get ogre_media folder from ament_index

### DIFF
--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(ament_cmake REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
+find_package(ament_index_cpp REQUIRED)
 # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
 find_package(rviz_ogre_vendor REQUIRED)
 
@@ -72,11 +73,11 @@ target_link_libraries(${PROJECT_NAME}
   rviz_ogre_vendor::RenderSystem_GL
   rviz_ogre_vendor::OgreGLSupport
   Qt5::Widgets
+  ament_index_cpp::ament_index_cpp
 )
+
 # This will give the library a default directory to fallback to, but it should be overridden.
 target_compile_definitions(${PROJECT_NAME}
-  # TODO(wjwwood): replace this with ament_index
-  PRIVATE "-DRVIZ_RENDERING_DEFAULT_RESOURCE_DIRECTORY=\"${CMAKE_CURRENT_SOURCE_DIR}\""
   # TODO(wjwwood): this might not be required anymore with static linking
   PRIVATE "-DRVIZ_RENDERING_OGRE_PLUGIN_DIR=\"${OGRE_PLUGIN_DIR}\""
 )
@@ -109,6 +110,10 @@ if(TARGET Qt5::windeployqt)
 endif()
 
 install(TARGETS rendering_example DESTINATION bin)
+
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/ogre_media"
+        DESTINATION "share/rviz_rendering"
+        USE_SOURCE_PERMISSIONS)
 
 if(BUILD_TESTING)
     # TODO(wjwwood): replace this with ament_lint_auto() and/or add the copyright linter back

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -39,6 +39,7 @@
 #include <GL/glx.h>
 #endif
 
+#include <ament_index_cpp/get_resource.hpp>
 #include <rviz_rendering/logging.hpp>
 #include <rviz_rendering/resource_config.hpp>
 
@@ -124,6 +125,7 @@ RenderSystem::RenderSystem()
 {
   OgreLogging::configureLogging();
 
+  setResourceDirectory();
   setupDummyWindowId();
   ogre_root_ = new Ogre::Root(get_resource_directory() + "/ogre_media/plugins.cfg");
 #if ((OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 9) || OGRE_VERSION_MAJOR >= 2 )
@@ -272,6 +274,15 @@ RenderSystem::setupRenderSystem()
   }
 
   ogre_root_->setRenderSystem(render_system);
+}
+
+void
+RenderSystem::setResourceDirectory()
+{
+  std::string content;
+  std::string prefix_path;
+  ament_index_cpp::get_resource("packages", "rviz_rendering", content, &prefix_path);
+  set_resource_directory(prefix_path + "/share/rviz_rendering");
 }
 
 void

--- a/rviz_rendering/src/rviz_rendering/render_system.hpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.hpp
@@ -136,6 +136,8 @@ private:
   void
   setupRenderSystem();
   void
+  setResourceDirectory();
+  void
   setupResources();
   void
   detectGlVersion();


### PR DESCRIPTION
- move ogre_media folder in installation step in CMake
- set resource directory before building the rendering system
- get the path to set the directory from ament_index

Closes #3