### PR TITLE
fix md5 sum of archive that changed

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -36,7 +36,7 @@ macro(build_ogre)
   include(ExternalProject)
   ExternalProject_Add(ogre-1.10.7
     URL https://github.com/OGRECave/ogre/archive/v1.10.7.tar.gz
-    URL_MD5 69b92a5e87ef72afaa578c241c861666
+    URL_MD5 cbedd0320ea4c723a7bbc4560a94fbd7
     TIMEOUT 600
     CMAKE_ARGS
       -DOGRE_STATIC:BOOL=ON


### PR DESCRIPTION
I asked about it, but through separate channels I found out that this might be expected (that the md5 changes for these links with a recent git update).

https://github.com/OGRECave/ogre/issues/522