### PR TITLE
Fix dependencies on Windows

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -27,13 +27,27 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 
-find_package(PkgConfig)
-pkg_check_modules(YAMLCPP yaml-cpp>=0.5 REQUIRED)
-# if(YAMLCPP_FOUND)
-#   add_definitions(-DRVIZ_HAVE_YAMLCPP_05)
-# endif(YAMLCPP_FOUND)
+if(NOT WIN32)
+  find_package(PkgConfig)
+  pkg_check_modules(YAMLCPP yaml-cpp>=0.5 REQUIRED)
+  # if(YAMLCPP_FOUND)
+  #   add_definitions(-DRVIZ_HAVE_YAMLCPP_05)
+  # endif(YAMLCPP_FOUND)
+else()
+  find_path(YAMLCPP_INCLUDE_DIRS NAMES yaml-cpp/yaml.h)
+  find_library(YAMLCPP_LIBRARIES NAMES libyaml-cppmdd libyaml-cppmd)
+endif()
+
+find_library(TINYXML_LIBRARIES NAMES tinyxmld tinyxml)
+
+# TODO(greimela) Remove as soon as boost is not required anymore (in temp files)
+find_package(Boost REQUIRED)
 
 find_package(ASSIMP REQUIRED)
+if(WIN32)
+  set(ASSIMP_LIBRARIES "${ASSIMP_ROOT_DIR}/lib/${ASSIMP_LIBRARIES}.lib")
+endif()
+
 include(FindCURL)
 if(NOT CURL_FOUND)
   message("CURL not found!  Aborting...")
@@ -242,6 +256,8 @@ target_include_directories(rviz_common
     ${CURL_INCLUDE_DIRS}
     ${ASSIMP_INCLUDE_DIRS}
     ${urdf_INCLUDE_DIRS}
+    # TODO(greimela) Remove as soon as boost is not required anymore (in temp files)
+    ${Boost_INCLUDE_DIRS}
 )
 target_link_libraries(rviz_common
   rviz_rendering::rviz_rendering
@@ -249,7 +265,7 @@ target_link_libraries(rviz_common
   ${YAMLCPP_LIBRARIES}
   ${CURL_LIBRARIES}
   ${ASSIMP_LIBRARIES}
-  tinyxml
+  ${TINYXML_LIBRARIES}
   ${urdf_LIBRARIES}
 )
 ament_target_dependencies(rviz_common geometry_msgs rclcpp tf2 tf2_geometry_msgs tf2_ros)

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -44,8 +44,10 @@ find_library(TINYXML_LIBRARIES NAMES tinyxmld tinyxml)
 find_package(Boost REQUIRED)
 
 find_package(ASSIMP REQUIRED)
+
+# TODO(greimela): Temporary fix for Windows, remove this later
 if(WIN32)
-  set(ASSIMP_LIBRARIES "${ASSIMP_ROOT_DIR}/lib/${ASSIMP_LIBRARIES}.lib")
+  set(ASSIMP_LIBRARIES "${ASSIMP_LIBRARY_DIRS}/${ASSIMP_LIBRARIES}.lib")
 endif()
 
 include(FindCURL)

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -399,8 +399,8 @@ RenderSystem::makeRenderWindow(
 
   params["currentGLContext"] = Ogre::String("false");
 
-  // params["externalWindowHandle"] =
-  //   Ogre::StringConverter::toString(static_cast<unsigned long>(window_id));
+  // This line is needed to receive mouse events on Windows
+  params["externalWindowHandle"] = Ogre::StringConverter::toString(window_id);
   params["parentWindowHandle"] = Ogre::StringConverter::toString(window_id);
 
   // Scale rendering window correctly on Windows

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -399,8 +399,10 @@ RenderSystem::makeRenderWindow(
 
   params["currentGLContext"] = Ogre::String("false");
 
-  // This line is needed to receive mouse events on Windows
+  // This line is needed to receive mouse events on Windows, but results in a crash on OS X
+#ifdef _WIN32
   params["externalWindowHandle"] = Ogre::StringConverter::toString(window_id);
+#endif
   params["parentWindowHandle"] = Ogre::StringConverter::toString(window_id);
 
   // Scale rendering window correctly on Windows


### PR DESCRIPTION
With this PR we are again able to build RViz on windows.
It also fixes an issue where the render window did not receive mouse events.