### PR TITLE
Remove try-catch block with unknown errors

### DIFF
--- a/rviz_common/src/rviz_common/frame_manager.cpp
+++ b/rviz_common/src/rviz_common/frame_manager.cpp
@@ -91,13 +91,7 @@ void FrameManager::update()
       case SyncApprox:
         // adjust current time offset to sync source
         current_delta_ = 0.7 * current_delta_ + 0.3 * sync_delta_;
-        try {
-          sync_time_ = rclcpp::Time(rclcpp::Time::now().nanoseconds() - current_delta_);
-        } catch (...) {
-          // TODO(wjwwood): what? figure out what this is for... until then log it...
-          RVIZ_COMMON_LOG_ERROR("unknown exception in FrameManager::update()");
-          sync_time_ = rclcpp::Time::now();
-        }
+        sync_time_ = rclcpp::Time(rclcpp::Time::now().nanoseconds() - current_delta_);
         break;
     }
   }


### PR DESCRIPTION
Resolves #53 
I removed the try catch block since:

- it uses only default ROS2 behaviour (specific errors are thrown)
- if it fails, ROS2 fails and no valid fallback can be provided (the function now() uses the same calls and would fail, too)
- hence we shouldn't catch the error at this point