### PR TITLE
Use clock.now() instead of Time::now() to work with latest rclcpp

### DIFF
--- a/rviz_common/include/rviz_common/display_context.hpp
+++ b/rviz_common/include/rviz_common/display_context.hpp
@@ -46,6 +46,7 @@ class SceneManager;
 
 namespace rclcpp
 {
+class Clock;
 namespace node
 {
 class Node;
@@ -195,6 +196,10 @@ public:
   virtual
   void
   setStatus(const QString & message) = 0;
+
+  virtual
+  std::shared_ptr<rclcpp::Clock>
+  getClock() = 0;
 
 public Q_SLOTS:
   /// Queue a render.

--- a/rviz_common/include/rviz_common/frame_manager.hpp
+++ b/rviz_common/include/rviz_common/frame_manager.hpp
@@ -42,6 +42,7 @@
 #include <QObject>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "geometry_msgs/msg/pose.hpp"
+#include "rclcpp/clock.hpp"
 #include "rclcpp/time.hpp"
 
 // TODO(wjwwood): reenable this when message_filters is ported.
@@ -85,7 +86,8 @@ public:
   explicit
   FrameManager(
     std::shared_ptr<tf2_ros::TransformListener> tf,
-    std::shared_ptr<tf2_ros::Buffer> buffer
+    std::shared_ptr<tf2_ros::Buffer> buffer,
+    rclcpp::Clock::SharedPtr clock
   );
 
   /// Destructor.
@@ -377,6 +379,8 @@ private:
 
   // the current synchronized time, used to overwrite ros:Time(0)
   rclcpp::Time sync_time_;
+
+  rclcpp::Clock::SharedPtr clock_;
 
   // used for approx. syncing (in nanoseconds)
   int64_t sync_delta_;

--- a/rviz_common/include/rviz_common/frame_manager.hpp
+++ b/rviz_common/include/rviz_common/frame_manager.hpp
@@ -149,6 +149,20 @@ public:
   /// Return the pose for a frame relative to the fixed frame, in Ogre classes, at a given time.
   /**
    * \param[in] frame The frame to find the pose of.
+   * \param[out] position The position of the frame relative to the fixed frame.
+   * \param[out] orientation The orientation of the frame relative to the
+   *   fixed frame.
+   * \return true on success, false on failure.
+   */
+  bool
+  getTransform(const std::string & frame, Ogre::Vector3 & position, Ogre::Quaternion & orientation)
+  {
+    return getTransform(frame, rclcpp::Time(0, 0, clock_->get_clock_type()), position, orientation);
+  }
+
+  /// Return the pose for a frame relative to the fixed frame, in Ogre classes, at a given time.
+  /**
+   * \param[in] frame The frame to find the pose of.
    * \param[in] time The time at which to get the pose.
    * \param[out] position The position of the frame relative to the fixed frame.
    * \param[out] orientation The orientation of the frame relative to the
@@ -208,13 +222,23 @@ public:
   /// Check to see if a frame exists in the tf::TransformListener.
   /**
    * \param[in] frame The name of the frame to check.
-   * \param[in] time Dummy parameter, not actually used.
    * \param[out] error If the frame does not exist, an error message is
    *   stored here.
    * \return true if the frame does not exist, false if it does exist.
    */
   bool
-  frameHasProblems(const std::string & frame, rclcpp::Time time, std::string & error);
+  frameHasProblems(const std::string & frame, std::string & error);
+
+  /// Check to see if a transform is known between a given frame and the fixed frame.
+  /**
+   * \param[in] frame The name of the frame to check.
+   * \param[out] error If the transform is not known, an error message is stored here.
+   * \return true if the transform is not known, false if it is. */
+  bool
+  transformHasProblems(const std::string & frame, std::string & error)
+  {
+    return transformHasProblems(frame, rclcpp::Time(0, 0, clock_->get_clock_type()), error);
+  }
 
   /// Check to see if a transform is known between a given frame and the fixed frame.
   /**

--- a/rviz_common/src/rviz_common/frame_position_tracking_view_controller.cpp
+++ b/rviz_common/src/rviz_common/frame_position_tracking_view_controller.cpp
@@ -123,8 +123,7 @@ bool FramePositionTrackingViewController::getNewTransform()
   Ogre::Quaternion new_reference_orientation;
 
   bool got_transform = context_->getFrameManager()->getTransform(
-    target_frame_property_->getFrameStd(), rclcpp::Time(),
-    new_reference_position, new_reference_orientation);
+    target_frame_property_->getFrameStd(), new_reference_position, new_reference_orientation);
   if (got_transform) {
     reference_position_ = new_reference_position;
     reference_orientation_ = new_reference_orientation;

--- a/rviz_common/src/rviz_common/temp/default_plugins/displays/grid_display.cpp
+++ b/rviz_common/src/rviz_common/temp/default_plugins/displays/grid_display.cpp
@@ -155,13 +155,13 @@ void GridDisplay::update(float dt, float ros_dt)
 
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
-  if (context_->getFrameManager()->getTransform(frame, rclcpp::Time(), position, orientation)) {
+  if (context_->getFrameManager()->getTransform(frame, position, orientation)) {
     scene_node_->setPosition(position);
     scene_node_->setOrientation(orientation);
     setStatus(StatusProperty::Ok, "Transform", "Transform OK");
   } else {
     std::string error;
-    if (context_->getFrameManager()->transformHasProblems(frame, rclcpp::Time(), error)) {
+    if (context_->getFrameManager()->transformHasProblems(frame, error)) {
       setStatus(StatusProperty::Error, "Transform", QString::fromStdString(error));
     } else {
       setStatus(StatusProperty::Error, "Transform",

--- a/rviz_common/src/rviz_common/temp/default_plugins/displays/tf_display.cpp
+++ b/rviz_common/src/rviz_common/temp/default_plugins/displays/tf_display.cpp
@@ -599,9 +599,7 @@ void TFDisplay::updateFrame(FrameInfo * frame)
   orientation.x = 0;
   orientation.y = 0;
   orientation.z = 0;
-  if (!context_->getFrameManager()->getTransform(frame->name_, rclcpp::Time(), position,
-    orientation))
-  {
+  if (!context_->getFrameManager()->getTransform(frame->name_, position, orientation)) {
     std::stringstream ss;
     ss << "No transform from [" << frame->name_ << "] to frame [" << fixed_frame_.toStdString() <<
       "]";
@@ -709,10 +707,7 @@ void TFDisplay::updateFrame(FrameInfo * frame)
       parent_orientation.y = 0.0;
       parent_orientation.z = 0.0;
       if (!context_->getFrameManager()->getTransform(
-          frame->parent_,
-          rclcpp::Time(),
-          parent_position,
-          parent_orientation))
+          frame->parent_, parent_position, parent_orientation))
       {
         RVIZ_COMMON_LOG_DEBUG_STREAM(
           "Error3 transforming frame '" << frame->parent_.c_str() <<

--- a/rviz_common/src/rviz_common/temp/robot/tf_link_updater.cpp
+++ b/rviz_common/src/rviz_common/temp/robot/tf_link_updater.cpp
@@ -67,7 +67,7 @@ bool TFLinkUpdater::getLinkTransforms(
 
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
-  if (!frame_manager_->getTransform(link_name, rclcpp::Time(), position, orientation)) {
+  if (!frame_manager_->getTransform(link_name, position, orientation)) {
     std::stringstream ss;
     ss << "No transform from [" << link_name << "] to [" << frame_manager_->getFixedFrame() << "]";
     setLinkStatus(StatusProperty::Error, link_name, ss.str());

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -67,6 +67,7 @@
 #include <QToolButton>
 // #include <QUrl>
 
+#include "rclcpp/clock.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
@@ -343,9 +344,10 @@ void VisualizationFrame::initialize(const QString & display_config_file)
   render_panel_->getRenderWindow()->initialize();
 
   auto buffer = std::make_shared<tf2_ros::Buffer>();
+  auto clock = std::make_shared<rclcpp::Clock>();
   // TODO(wjwwood): pass the rviz node so tf2 doesn't create it's own...
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*buffer);
-  manager_ = new VisualizationManager(render_panel_, this, tf_listener, buffer);
+  manager_ = new VisualizationManager(render_panel_, this, tf_listener, buffer, clock);
   manager_->setHelpPath(help_path_);
 
   // Periodically process events for the splash screen.

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -344,7 +344,7 @@ void VisualizationFrame::initialize(const QString & display_config_file)
   render_panel_->getRenderWindow()->initialize();
 
   auto buffer = std::make_shared<tf2_ros::Buffer>();
-  auto clock = std::make_shared<rclcpp::Clock>();
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
   // TODO(wjwwood): pass the rviz node so tf2 doesn't create it's own...
   auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*buffer);
   manager_ = new VisualizationManager(render_panel_, this, tf_listener, buffer, clock);

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -508,7 +508,7 @@ void VisualizationManager::updateFrames()
 
   // Check the fixed frame to see if it's ok
   std::string error;
-  if (frame_manager_->frameHasProblems(getFixedFrame().toStdString(), rclcpp::Time(), error)) {
+  if (frame_manager_->frameHasProblems(getFixedFrame().toStdString(), error)) {
     if (frames.empty()) {
       // fixed_prop->setToWarn();
       std::stringstream ss;
@@ -542,7 +542,7 @@ void VisualizationManager::resetTime()
   root_display_group_->reset();
   frame_manager_->getTFBufferPtr()->clear();
 
-  ros_time_begin_ = rclcpp::Time();
+  ros_time_begin_ = rclcpp::Time(0, 0, clock_->get_clock_type());
   wall_clock_begin_ = std::chrono::system_clock::time_point();
 
   queueRender();

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -64,6 +64,7 @@
 #endif
 
 // #include "tf/transform_listener.h"
+#include "rclcpp/clock.hpp"
 #include "rclcpp/time.hpp"
 #include "rviz_rendering/render_window.hpp"
 
@@ -145,7 +146,8 @@ VisualizationManager::VisualizationManager(
   RenderPanel * render_panel,
   WindowManagerInterface * wm,
   std::shared_ptr<tf2_ros::TransformListener> tf,
-  std::shared_ptr<tf2_ros::Buffer> buffer)
+  std::shared_ptr<tf2_ros::Buffer> buffer,
+  rclcpp::Clock::SharedPtr clock)
 : ogre_root_(Ogre::Root::getSingletonPtr()),
   update_timer_(0),
   shutting_down_(false),
@@ -155,6 +157,7 @@ VisualizationManager::VisualizationManager(
   render_requested_(1),
   frame_count_(0),
   window_manager_(wm),
+  clock_(clock),
   private_(new VisualizationManagerPrivate),
   executor_(std::make_shared<rclcpp::executors::SingleThreadedExecutor>())
 {
@@ -162,7 +165,7 @@ VisualizationManager::VisualizationManager(
   // (and thus initialized later be default):
   default_visibility_bit_ = visibility_bit_allocator_.allocBit();
 
-  frame_manager_ = new FrameManager(tf, buffer);
+  frame_manager_ = new FrameManager(tf, buffer, clock);
 
 // TODO(wjwwood): is this needed?
 #if 0
@@ -290,7 +293,7 @@ void VisualizationManager::initialize()
   selection_manager_->initialize();
   tool_manager_->initialize();
 
-  last_update_ros_time_ = rclcpp::Time::now();
+  last_update_ros_time_ = clock_->now();
   last_update_wall_time_ = std::chrono::system_clock::now();
 }
 
@@ -423,7 +426,7 @@ void VisualizationManager::onUpdate()
   auto wall_now = std::chrono::system_clock::now();
   auto wall_diff = wall_now - last_update_wall_time_;
   uint64_t wall_dt = std::chrono::duration_cast<std::chrono::nanoseconds>(wall_diff).count();
-  auto ros_now = rclcpp::Time::now();
+  auto ros_now = clock_->now();
   uint64_t ros_dt = ros_now.nanoseconds() - last_update_ros_time_.nanoseconds();
   last_update_ros_time_ = ros_now;
   last_update_wall_time_ = wall_now;
@@ -485,10 +488,10 @@ void VisualizationManager::onUpdate()
 void VisualizationManager::updateTime()
 {
   if (ros_time_begin_.nanoseconds() == 0) {
-    ros_time_begin_ = rclcpp::Time::now();
+    ros_time_begin_ = clock_->now();
   }
 
-  ros_time_elapsed_ = (rclcpp::Time::now() - ros_time_begin_).nanoseconds();
+  ros_time_elapsed_ = (clock_->now() - ros_time_begin_).nanoseconds();
 
   if (wall_clock_begin_.time_since_epoch().count() == 0) {
     wall_clock_begin_ = std::chrono::system_clock::now();
@@ -744,6 +747,11 @@ void VisualizationManager::setHelpPath(const QString & help_path)
 QString VisualizationManager::getHelpPath() const
 {
   return help_path_;
+}
+
+rclcpp::Clock::SharedPtr VisualizationManager::getClock()
+{
+  return clock_;
 }
 
 }  // namespace rviz_common

--- a/rviz_common/src/rviz_common/visualization_manager.hpp
+++ b/rviz_common/src/rviz_common/visualization_manager.hpp
@@ -35,6 +35,7 @@
 #include <deque>
 #include <memory>
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/time.hpp"
 #include "tf2_ros/transform_listener.h"
 
@@ -100,7 +101,8 @@ public:
     RenderPanel * render_panel,
     WindowManagerInterface * wm = 0,
     std::shared_ptr<tf2_ros::TransformListener> tf = nullptr,
-    std::shared_ptr<tf2_ros::Buffer> buffer = nullptr
+    std::shared_ptr<tf2_ros::Buffer> buffer = nullptr,
+    rclcpp::Clock::SharedPtr clock = nullptr
   );
 
   /// Destructor.
@@ -292,6 +294,8 @@ public:
 
   virtual QString getHelpPath() const;
 
+  rclcpp::Clock::SharedPtr getClock() override;
+
 Q_SIGNALS:
 
   /// Emitted before updating all Displays.
@@ -374,6 +378,8 @@ protected:
   FrameManager * frame_manager_;
 
   OgreRenderQueueClearer * ogre_render_queue_clearer_;
+
+  rclcpp::Clock::SharedPtr clock_;
 
 private Q_SLOTS:
   void updateFixedFrame();

--- a/rviz_common/src/rviz_default_plugins/point_cloud_common.cpp
+++ b/rviz_common/src/rviz_default_plugins/point_cloud_common.cpp
@@ -39,6 +39,7 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 #include <OgreWireBoundingBox.h>
+#include "rclcpp/clock.hpp"
 
 // #include <tf/transform_listener.h>
 
@@ -403,6 +404,7 @@ void PointCloudCommon::initialize(
 
   context_ = context;
   scene_node_ = scene_node;
+  clock_ = context->getClock();
 
   updateStyle();
   updateBillboardSize();
@@ -600,7 +602,7 @@ void PointCloudCommon::update(float wall_dt, float ros_dt)
   // and put them into obsolete_cloud_infos, so active selections
   // are preserved
 
-  rclcpp::Time now = rclcpp::Time::now();
+  rclcpp::Time now = clock_->now();
 
   // if decay time == 0, clear the old cloud when we get a new one
   // otherwise, clear all the outdated ones
@@ -788,7 +790,7 @@ void PointCloudCommon::processMessage(const sensor_msgs::msg::PointCloud2::Const
 {
   CloudInfoPtr info(new CloudInfo);
   info->message_ = cloud;
-  info->receive_time_ = rclcpp::Time::now();
+  info->receive_time_ = clock_->now();
 
   if (transformCloud(info, true)) {
     std::unique_lock<std::mutex> lock(new_clouds_mutex_);

--- a/rviz_common/src/rviz_default_plugins/point_cloud_common.hpp
+++ b/rviz_common/src/rviz_default_plugins/point_cloud_common.hpp
@@ -46,6 +46,7 @@
 
 // TODO(wjwwood): revist file when pluginlib is available
 //# include <pluginlib/class_loader.h>
+#include "rclcpp/clock.hpp"
 #include "rclcpp/time.hpp"
 
 # include "sensor_msgs/msg/point_cloud.hpp"
@@ -225,6 +226,7 @@ private:
 
   rviz_common::Display * display_;
   rviz_common::DisplayContext * context_;
+  rclcpp::Clock::SharedPtr clock_;
 
   friend class PointCloudSelectionHandler;
 };


### PR DESCRIPTION
The idea is to pass a clock to the VisualizationManager and reuse it in the other parts of RViz.
Fixes #116.