### PR TITLE
Enable displays panel using pluginlib workaround

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -78,15 +78,15 @@ set(rviz_common_headers_to_moc
   # src/rviz_common/add_display_dialog.hpp
   # src/rviz_common/help_panel.hpp
   include/rviz_common/properties/enum_property.hpp
-  # src/rviz_common/properties/property_tree_widget.hpp
-  # src/rviz_common/properties/splitter_handle.hpp
+  include/rviz_common/properties/property_tree_widget.hpp
+  include/rviz_common/properties/splitter_handle.hpp
   # src/rviz_common/selection_panel.hpp
   include/rviz_common/frame_position_tracking_view_controller.hpp
   include/rviz_common/properties/quaternion_property.hpp
   include/rviz_common/visualizer_app.hpp
   include/rviz_common/display.hpp
   include/rviz_common/display_context.hpp
-  # src/rviz_common/displays_panel.hpp
+  src/rviz_common/displays_panel.hpp
   src/rviz_common/failed_panel.hpp
   include/rviz_common/frame_manager.hpp
   src/rviz_common/loading_dialog.hpp
@@ -104,9 +104,9 @@ set(rviz_common_headers_to_moc
   include/rviz_common/properties/int_property.hpp
   include/rviz_common/properties/line_edit_with_button.hpp
   include/rviz_common/properties/property.hpp
-  # src/rviz_common/properties/property_tree_delegate.hpp
+  include/rviz_common/properties/property_tree_delegate.hpp
   include/rviz_common/properties/property_tree_model.hpp
-  # src/rviz_common/properties/property_tree_with_help.hpp
+  include/rviz_common/properties/property_tree_with_help.hpp
   include/rviz_common/properties/status_list.hpp
   include/rviz_common/properties/status_property.hpp
   include/rviz_common/properties/string_property.hpp
@@ -172,7 +172,7 @@ set(rviz_common_source_files
   # src/rviz_common/display_factory.cpp
   src/rviz_common/display_group.cpp
   src/rviz_common/display.cpp
-  # src/rviz_common/displays_panel.cpp
+  src/rviz_common/displays_panel.cpp
   src/rviz_common/failed_display.cpp
   src/rviz_common/failed_panel.cpp
   # src/rviz_common/failed_tool.cpp
@@ -199,13 +199,13 @@ set(rviz_common_source_files
   src/rviz_common/properties/int_property.cpp
   src/rviz_common/properties/line_edit_with_button.cpp
   src/rviz_common/properties/parse_color.cpp
-  # src/rviz_common/properties/property_tree_delegate.cpp
+  src/rviz_common/properties/property_tree_delegate.cpp
   src/rviz_common/properties/property_tree_model.cpp
-  # src/rviz_common/properties/property_tree_widget.cpp
-  # src/rviz_common/properties/property_tree_with_help.cpp
+  src/rviz_common/properties/property_tree_widget.cpp
+  src/rviz_common/properties/property_tree_with_help.cpp
   src/rviz_common/properties/property.cpp
   src/rviz_common/properties/quaternion_property.cpp
-  # src/rviz_common/properties/splitter_handle.cpp
+  src/rviz_common/properties/splitter_handle.cpp
   src/rviz_common/properties/status_list.cpp
   src/rviz_common/properties/status_property.cpp
   src/rviz_common/properties/string_property.cpp

--- a/rviz_common/src/rviz_common/displays_panel.cpp
+++ b/rviz_common/src/rviz_common/displays_panel.cpp
@@ -34,11 +34,10 @@
 #include <QInputDialog>
 #include <QApplication>
 
-#include <boost/bind.hpp>
-
-#include "./display_factory.hpp"
+// TODO(greimela): Enable button again after adding displays is possible
+// #include "./display_factory.hpp"
+// #include "./add_display_dialog.hpp"
 #include "rviz_common/display.hpp"
-#include "./add_display_dialog.hpp"
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/properties/property_tree_widget.hpp"
 #include "rviz_common/properties/property_tree_with_help.hpp"
@@ -52,12 +51,14 @@ namespace rviz_common
 DisplaysPanel::DisplaysPanel(QWidget * parent)
 : Panel(parent)
 {
-  tree_with_help_ = new PropertyTreeWithHelp;
+  tree_with_help_ = new properties::PropertyTreeWithHelp;
   property_grid_ = tree_with_help_->getTree();
 
   QPushButton * add_button = new QPushButton("Add");
   add_button->setShortcut(QKeySequence(QString("Ctrl+N")));
   add_button->setToolTip("Add a new display, Ctrl+N");
+  // TODO(greimela): Enable button again after adding displays is possible
+  add_button->setEnabled(false);
   duplicate_button_ = new QPushButton("Duplicate");
   duplicate_button_->setShortcut(QKeySequence(QString("Ctrl+D")));
   duplicate_button_->setToolTip("Duplicate a display, Ctrl+D");
@@ -85,11 +86,12 @@ DisplaysPanel::DisplaysPanel(QWidget * parent)
 
   setLayout(layout);
 
-  connect(add_button, SIGNAL(clicked(bool)), this, SLOT(onNewDisplay()));
-  connect(duplicate_button_, SIGNAL(clicked(bool)), this, SLOT(onDuplicateDisplay()));
-  connect(remove_button_, SIGNAL(clicked(bool)), this, SLOT(onDeleteDisplay()));
-  connect(rename_button_, SIGNAL(clicked(bool)), this, SLOT(onRenameDisplay()));
-  connect(property_grid_, SIGNAL(selectionHasChanged()), this, SLOT(onSelectionChanged()));
+  // TODO(greimela): Enable buttons again after adding displays is possible
+//  connect(add_button, SIGNAL(clicked(bool)), this, SLOT(onNewDisplay()));
+//  connect(duplicate_button_, SIGNAL(clicked(bool)), this, SLOT(onDuplicateDisplay()));
+//  connect(remove_button_, SIGNAL(clicked(bool)), this, SLOT(onDeleteDisplay()));
+//  connect(rename_button_, SIGNAL(clicked(bool)), this, SLOT(onRenameDisplay()));
+//  connect(property_grid_, SIGNAL(selectionHasChanged()), this, SLOT(onSelectionChanged()));
 }
 
 DisplaysPanel::~DisplaysPanel()
@@ -98,38 +100,39 @@ DisplaysPanel::~DisplaysPanel()
 
 void DisplaysPanel::onInitialize()
 {
-  property_grid_->setModel(vis_manager_->getDisplayTreeModel() );
+  property_grid_->setModel(vis_manager_->getDisplayTreeModel());
 }
 
+// TODO(greimela): Enable again after adding displays is possible
 void DisplaysPanel::onNewDisplay()
 {
-  QString lookup_name;
-  QString display_name;
-  QString topic;
-  QString datatype;
-
-  QStringList empty;
-
-  QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  AddDisplayDialog * dialog = new AddDisplayDialog(vis_manager_->getDisplayFactory(),
-      "Display",
-      empty, empty,
-      &lookup_name,
-      &display_name,
-      &topic,
-      &datatype);
-  QApplication::restoreOverrideCursor();
-
-  vis_manager_->stopUpdate();
-  if (dialog->exec() == QDialog::Accepted) {
-    Display * disp = vis_manager_->createDisplay(lookup_name, display_name, true);
-    if (!topic.isEmpty() && !datatype.isEmpty() ) {
-      disp->setTopic(topic, datatype);
-    }
-  }
-  vis_manager_->startUpdate();
-  activateWindow();  // Force keyboard focus back on main window.
-  delete dialog;
+//  QString lookup_name;
+//  QString display_name;
+//  QString topic;
+//  QString datatype;
+//
+//  QStringList empty;
+//
+//  QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+//  AddDisplayDialog * dialog = new AddDisplayDialog(vis_manager_->getDisplayFactory(),
+//      "Display",
+//      empty, empty,
+//      &lookup_name,
+//      &display_name,
+//      &topic,
+//      &datatype);
+//  QApplication::restoreOverrideCursor();
+//
+//  vis_manager_->stopUpdate();
+//  if (dialog->exec() == QDialog::Accepted) {
+//    Display * disp = vis_manager_->createDisplay(lookup_name, display_name, true);
+//    if (!topic.isEmpty() && !datatype.isEmpty() ) {
+//      disp->setTopic(topic, datatype);
+//    }
+//  }
+//  vis_manager_->startUpdate();
+//  activateWindow();  // Force keyboard focus back on main window.
+//  delete dialog;
 }
 
 void DisplaysPanel::onDuplicateDisplay()
@@ -205,15 +208,12 @@ void DisplaysPanel::onRenameDisplay()
   Display * display_to_rename = displays[0];
 
   if (!display_to_rename) {
-    rviz
-    {
-      return;
-    }
-
-    QString old_name = display_to_rename->getName();
+    return;
   }
-  QString new_name = QInputDialog::getText(this, "Rename Display", "New Name?", QLineEdit::Normal,
-      old_name);
+
+  QString old_name = display_to_rename->getName();
+  QString new_name = QInputDialog::getText(
+    this, "Rename Display", "New Name?", QLineEdit::Normal, old_name);
 
   if (new_name.isEmpty() || new_name == old_name) {
     return;

--- a/rviz_common/src/rviz_common/displays_panel.hpp
+++ b/rviz_common/src/rviz_common/displays_panel.hpp
@@ -30,8 +30,6 @@
 #ifndef RVIZ_COMMON__DISPLAYS_PANEL_HPP_
 #define RVIZ_COMMON__DISPLAYS_PANEL_HPP_
 
-#include <boost/thread/mutex.hpp>
-
 #include <vector>
 #include <map>
 #include <set>
@@ -43,11 +41,13 @@ class QPushButton;
 
 namespace rviz_common
 {
-
-class PropertyTreeWidget;
-class PropertyTreeWithHelp;
 class VisualizationManager;
 class Display;
+namespace properties
+{
+class PropertyTreeWidget;
+class PropertyTreeWithHelp;
+}
 
 /**
  * \class DisplaysPanel
@@ -82,12 +82,12 @@ protected Q_SLOTS:
   void onSelectionChanged();
 
 protected:
-  PropertyTreeWidget * property_grid_;
+  properties::PropertyTreeWidget * property_grid_;
 
   QPushButton * duplicate_button_;
   QPushButton * remove_button_;
   QPushButton * rename_button_;
-  PropertyTreeWithHelp * tree_with_help_;
+  properties::PropertyTreeWithHelp * tree_with_help_;
 };
 
 }  // namespace rviz_common

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -78,6 +78,7 @@
 // TODO(wjwwood): readd this once we have a solution for the pluginlib stuff
 // #include "./panel_factory.hpp"
 
+#include "./displays_panel.hpp"
 #include "./env_config.hpp"
 #include "./failed_panel.hpp"
 #include "./load_resource.hpp"
@@ -374,6 +375,9 @@ void VisualizationFrame::initialize(const QString & display_config_file)
   } else {
     loadDisplayConfig(QString::fromStdString(default_display_config_file_));
   }
+
+  // TODO(greimela): Remove as soon as displays are loaded from config
+  addPanelByName("Displays", "rviz/DisplaysPanel");
 
   // Periodically process events for the splash screen.
   if (app_) {app_->processEvents();}
@@ -1246,7 +1250,6 @@ void VisualizationFrame::exitFullScreen()
   setFullScreen(false);
 }
 
-#if 0
 QDockWidget * VisualizationFrame::addPanelByName(
   const QString & name,
   const QString & class_id,
@@ -1254,10 +1257,15 @@ QDockWidget * VisualizationFrame::addPanelByName(
   bool floating)
 {
   QString error;
-  Panel * panel = panel_factory_->make(class_id, &error);
-  if (!panel) {
+
+  // TODO(greimela): Temporary workaround until pluginlib is migrated
+  Panel * panel;
+  if (class_id == "rviz/DisplaysPanel") {
+    panel = new DisplaysPanel(nullptr);
+  } else {
     panel = new FailedPanel(class_id, error);
   }
+
   panel->setName(name);
   connect(panel, SIGNAL(configChanged()), this, SLOT(setDisplayConfigModified()));
 
@@ -1271,11 +1279,11 @@ QDockWidget * VisualizationFrame::addPanelByName(
 
   record.panel->initialize(manager_);
 
-  record.dock->setIcon(panel_factory_->getIcon(class_id));
+  // TODO(greimela): Temporary workaround until pluginlib is migrated
+//  record.dock->setIcon(panel_factory_->getIcon(class_id));
 
   return record.dock;
 }
-#endif
 
 PanelDockWidget * VisualizationFrame::addPane(
   const QString & name, QWidget * panel,

--- a/rviz_common/src/rviz_common/visualization_frame.hpp
+++ b/rviz_common/src/rviz_common/visualization_frame.hpp
@@ -410,8 +410,6 @@ protected:
   void
   updateRecentConfigMenu();
 
-// TODO(wjwwood): reenable when plugin loading is fixed
-#if 0
   /// Add a panel by a given name and class name.
   QDockWidget *
   addPanelByName(
@@ -419,7 +417,6 @@ protected:
     const QString & class_lookup_name,
     Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
     bool floating = true);
-#endif
 
   /// Loads custom panels from the given Config object.
   void


### PR DESCRIPTION
For now the buttons to add and remove displays are disabled, since all displays are currently created programmatically.
We will also provide a follow-up PR containing some refactoring.

Belongs to #57.