### PR TITLE
Fix Qt5 include file not found

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(rviz_common REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
+include_directories(${Qt5Widgets_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME}_app
   src/main.cpp


### PR DESCRIPTION
Fix linux build issue: 

> rviz2/root/ros2_ws/rviz2_ws/src/rviz2/src/main.cpp:31:24: fatal error: QApplication: No such file or directory

CXX_INCLUDES does not include `-I/usr/include/x86_64-linux-gnu/qt5/QtWidgets/ `, so that c++ could not find the `#include <QApplication>` when execute **_build/rviz2/CMakeFiles/rviz2_app.dir/build.make_** as below:

`/usr/bin/c++   $(CXX_DEFINES) $(CXX_INCLUDES) $(CXX_FLAGS) -o CMakeFiles/rviz2_app.dir/src/main.cpp.o -c /root/ros2_ws/rviz2_ws/src/rviz2/src/main.cpp`