### PR TITLE
Specified cmake project type CXX (#152)

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(rviz_common)
+project(rviz_common CXX)
 
 # TODO(wjwood): remove when windows build is fixed
 if(DEFINED ENV{RVIZ_BUILD_ON_WINDOWS_OVERRIDE})


### PR DESCRIPTION
* This fixes "error: unrecognized command line option
  ‘-Wno-gnu-zero-variadic-macro-arguments’ [-Werror]" when using
  gcc>=7.2.1