### PR TITLE
Fixed missing break in switch-case (#152)

### DIFF
--- a/rviz_common/src/rviz_common/config.cpp
+++ b/rviz_common/src/rviz_common/config.cpp
@@ -143,6 +143,7 @@ void Config::copy(const Config & source)  // NOLINT linter wants #include <algor
         for (int i = 0; i < num_children; i++) {
           listAppendNew().copy(source.listChildAt(i));
         }
+        break;
       }
     case Value:
       setValue(source.getValue());


### PR DESCRIPTION
* Fall-through is not intended: listAppendNew sets the type to List
  while the call to setValue after the fall-through resets the type to
  Value.