### PR TITLE
Fix build with yaml-cpp installed system-wise

### DIFF
--- a/rviz_yaml_cpp_vendor/rviz_yaml_cpp_vendor-extras.cmake.in
+++ b/rviz_yaml_cpp_vendor/rviz_yaml_cpp_vendor-extras.cmake.in
@@ -1,6 +1,8 @@
-find_package(yaml-cpp QUIET)
+## mjbogusz: find_package() and if() disabled until ament can handle complex paths resolving to /usr/include
+## always use locally built yaml-cpp for now
+# find_package(yaml-cpp QUIET)
 
-if(NOT yaml-cpp_FOUND)
+# if(NOT yaml-cpp_FOUND)
   # add the local Modules directory to the modules path
   if(WIN32)
     set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_yaml_cpp_vendor/CMake")
@@ -8,7 +10,7 @@ if(NOT yaml-cpp_FOUND)
     set(yaml-cpp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_yaml_cpp_vendor/lib/cmake/yaml-cpp")
   endif()
   message(STATUS "Setting yaml-cpp_DIR to: '${yaml-cpp_DIR}'")
-endif()
+# endif()
 
 find_package(yaml-cpp CONFIG REQUIRED QUIET)
 


### PR DESCRIPTION
EDIT: Reduced the scope of the PR. Now it only fixes using system-wise installed yaml-cpp's `INCLUDE_DIR` which resulted in passing `-isystem /usr/include` to compiler.

Below is the comment for original scope of this PR.

---

This fixes issues mentioned in #152:
* Passing `-isystem /usr/include` to compiler (resulting in `fatal error: stdlib.h: No such file or directory`) if `yaml-cpp` is installed system-wise
* Not using system-wise installed `yaml-cpp` (thus requiring to additionally download and compile)
* Checking for variadic macro compiler flag (`unrecognized command line option ‘-Wno-gnu-zero-variadic-macro-arguments’`)

I can split this PR into two (yaml-cpp and variadic macros) if that's the preferred workflow.