### PR TITLE
Cleanup point cloud implementation

### DIFF
--- a/rviz_rendering/include/rviz_rendering/point_cloud.hpp
+++ b/rviz_rendering/include/rviz_rendering/point_cloud.hpp
@@ -277,11 +277,6 @@ private:
   void resetBoundingBoxForCurrentPoints();
 
   RVIZ_RENDERING_PUBLIC
-  void insertPointsToPointList(
-    std::vector<Point>::iterator start_iterator,
-    std::vector<Point>::iterator stop_iterator);
-
-  RVIZ_RENDERING_PUBLIC
   RenderableInternals createNewRenderable(uint32_t number_of_points_to_be_added);
 
   RVIZ_RENDERING_PUBLIC

--- a/rviz_rendering/src/rviz_rendering/point_cloud.cpp
+++ b/rviz_rendering/src/rviz_rendering/point_cloud.cpp
@@ -455,7 +455,7 @@ void PointCloud::addPoints(
     return;
   }
   auto num_points = static_cast<uint32_t>(std::distance(start_iterator, stop_iterator));
-  insertPointsToPointList(start_iterator, stop_iterator);
+  points_.insert(points_.cend(), start_iterator, stop_iterator);
 
   RenderableInternals internals = createNewRenderable(num_points);
 
@@ -479,22 +479,6 @@ void PointCloud::addPoints(
 
   if (getParentSceneNode()) {
     getParentSceneNode()->needUpdate();
-  }
-}
-
-void PointCloud::insertPointsToPointList(
-  std::vector<Point>::iterator start_iterator,
-  std::vector<Point>::iterator stop_iterator)
-{
-  assert(start_iterator < stop_iterator);
-
-  auto num_points = static_cast<uint32_t>(std::distance(start_iterator, stop_iterator));
-  if (points_.size() < point_count_ + num_points) {
-    points_.resize(point_count_ + num_points);
-  }
-
-  for (Point * begin = &points_.front() + point_count_; num_points--; ) {
-    *(begin++) = *(start_iterator++);
   }
 }
 


### PR DESCRIPTION
Followup pr to #136 which introduced a insert implementation which is now in turn replaced by the `insert` of `std::vector`