### PR TITLE
Update Ogre to 1.10.11

### DIFF
--- a/rviz_common/src/rviz_common/selection/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/selection/selection_manager.cpp
@@ -1026,7 +1026,7 @@ Ogre::Technique * SelectionManager::handleSchemeNotFound(
   }
 
   // find out if the renderable has the picking param set
-  bool has_pick_param = !rend->getUserObjectBindings().getUserAny("pick_handle").isEmpty();
+  bool has_pick_param = rend->getUserObjectBindings().getUserAny("pick_handle").has_value();
 
   // NOTE: it is important to avoid changing the culling mode of the
   // fallback techniques here, because that change then propagates to

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -122,8 +122,8 @@ macro(build_ogre)
 
   include(ExternalProject)
   ExternalProject_Add(ogre-master-ca665a6
-    URL https://github.com/OGRECave/ogre/archive/ca665a69a5ca47608ee0ad304b2596ff866616da.zip
-    URL_MD5 a627f447d0013a9cf0889117ac76bc5f
+    URL https://github.com/OGRECave/ogre/archive/v1.10.11.zip
+    URL_MD5 6ffd5048fae72805e287bfc0b462b2ea
     TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}

--- a/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
+++ b/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
@@ -48,7 +48,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
       NO_CMAKE_SYSTEM_PATH
       NO_CMAKE_FIND_ROOT_PATH
     )
-    if(NOT _ogre_main_static_library_debug_abs AND APPLE)
+    if(NOT _ogre_main_static_library_debug_abs AND NOT WIN32)
       # On macOS it seems the _d is not used, so just use the normal library name.
       set(_ogre_main_static_library_debug_abs ${_ogre_main_static_library_abs})
     endif()
@@ -150,7 +150,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
       NO_CMAKE_SYSTEM_PATH
       NO_CMAKE_FIND_ROOT_PATH
     )
-    if(NOT _ogre_overlay_static_library_debug_abs AND APPLE)
+    if(NOT _ogre_overlay_static_library_debug_abs AND NOT WIN32)
       # On macOS it seems the _d is not used, so just use the normal library name.
       set(_ogre_overlay_static_library_debug_abs ${_ogre_overlay_static_library_abs})
     endif()
@@ -202,7 +202,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
       NO_CMAKE_SYSTEM_PATH
       NO_CMAKE_FIND_ROOT_PATH
     )
-    if(NOT _render_system_gl_static_library_debug_abs AND APPLE)
+    if(NOT _render_system_gl_static_library_debug_abs AND NOT WIN32)
       # On macOS it seems the _d is not used, so just use the normal library name.
       set(_render_system_gl_static_library_debug_abs ${_render_system_gl_static_library_abs})
     endif()
@@ -254,7 +254,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
       NO_CMAKE_SYSTEM_PATH
       NO_CMAKE_FIND_ROOT_PATH
     )
-    if(NOT _ogre_gl_support_static_library_debug_abs AND APPLE)
+    if(NOT _ogre_gl_support_static_library_debug_abs AND NOT WIN32)
       # On macOS it seems the _d is not used, so just use the normal library name.
       set(_ogre_gl_support_static_library_debug_abs ${_ogre_gl_support_static_library_abs})
     endif()

--- a/rviz_rendering/src/rviz_rendering/billboard_line.hpp
+++ b/rviz_rendering/src/rviz_rendering/billboard_line.hpp
@@ -75,7 +75,7 @@ public:
   RVIZ_RENDERING_PUBLIC
   void clear();
   RVIZ_RENDERING_PUBLIC
-  void newLine();
+  void finishLine();
   RVIZ_RENDERING_PUBLIC
   void addPoint(const Ogre::Vector3 & point);
   RVIZ_RENDERING_PUBLIC
@@ -135,11 +135,6 @@ private:
 
   Ogre::ColourValue color_;
   float width_;
-
-  // TODO(Martin-Idel-SI): Replace by using Ogre::BillboardChain::getNumberOfChains once available
-  // Current issue: https://github.com/OGRECave/ogre/issues/603
-  typedef std::vector<uint32_t> V_uint32;
-  V_uint32 num_elements_;
 
   uint32_t num_lines_;
   uint32_t max_points_per_line_;

--- a/rviz_rendering/src/rviz_rendering/grid.cpp
+++ b/rviz_rendering/src/rviz_rendering/grid.cpp
@@ -247,7 +247,7 @@ void Grid::addBillboardLine(const Ogre::Vector3 & p1, const Ogre::Vector3 & p2) 
 {
   billboard_line_->addPoint(p1);
   billboard_line_->addPoint(p2);
-  billboard_line_->newLine();
+  billboard_line_->finishLine();
 }
 
 void Grid::setUserData(const Ogre::Any & data)

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -188,10 +188,10 @@ RenderSystem::loadOgrePlugins()
 {
   std::string plugin_prefix = get_ogre_plugin_directory();
 
-#ifdef NDEBUG
-  ogre_root_->loadPlugin(plugin_prefix + "RenderSystem_GL");
-#else
+#if defined _WIN32 && !NDEBUG
   ogre_root_->loadPlugin(plugin_prefix + "RenderSystem_GL_d");
+#else
+  ogre_root_->loadPlugin(plugin_prefix + "RenderSystem_GL");
 #endif
 // #if __APPLE__
 // #else

--- a/rviz_rendering/test/billboard_line_test.cpp
+++ b/rviz_rendering/test/billboard_line_test.cpp
@@ -74,13 +74,13 @@ std::unique_ptr<rviz_rendering::BillboardLine> oneCellGrid()
 
   grid_cell->addPoint(pts[0]);
   grid_cell->addPoint(pts[1]);
-  grid_cell->newLine();
+  grid_cell->finishLine();
   grid_cell->addPoint(pts[2]);
   grid_cell->addPoint(pts[3]);
-  grid_cell->newLine();
+  grid_cell->finishLine();
   grid_cell->addPoint(pts[0]);
   grid_cell->addPoint(pts[2]);
-  grid_cell->newLine();
+  grid_cell->finishLine();
   grid_cell->addPoint(pts[1]);
   grid_cell->addPoint(pts[3]);
 
@@ -97,7 +97,7 @@ twoLines()
   two_lines->setNumLines(2);
   two_lines->addPoint(pts[0]);
   two_lines->addPoint(pts[1]);
-  two_lines->newLine();
+  two_lines->finishLine();
   two_lines->addPoint(pts[2]);
   two_lines->addPoint(pts[3]);
   return two_lines;
@@ -165,10 +165,7 @@ TEST_F(BillboardLineTestFixture, clear_resets_all_chains) {
   ASSERT_EQ(chains.size(), static_cast<size_t>(1));   // chains are reset, not destroyed
   ASSERT_EQ(chains[0]->getNumberOfChains(), static_cast<size_t>(2));  // reset, not destroyed
 
-  // The following shows a bug in Ogre. The chains are cleared, but still have size.
-  ASSERT_EQ(chains[0]->getNumChainElements(0), static_cast<size_t>(1));
-  ASSERT_EQ(chains[0]->getChainElement(0, 0).position, Ogre::Vector3(1, 1, 0));  // shouldn't be
-  // accessible
+  ASSERT_EQ(chains[0]->getNumChainElements(0), static_cast<size_t>(0));
 }
 
 TEST_F(BillboardLineTestFixture, create_multiple_chains) {
@@ -179,7 +176,7 @@ TEST_F(BillboardLineTestFixture, create_multiple_chains) {
 
   for (unsigned int line = 0; line < 100000; line++) {
     if (line != 0) {
-      grid_cell.newLine();
+      grid_cell.finishLine();
     }
     grid_cell.addPoint(Ogre::Vector3(0, 0, line + 0.1f));
     grid_cell.addPoint(Ogre::Vector3(0, 0, line + 0.3f));
@@ -200,7 +197,7 @@ TEST_F(BillboardLineTestFixture, create_chain_with_extremely_many_elements) {
 
   for (unsigned int line = 0; line < 2; line++) {
     if (line != 0) {
-      grid_cell.newLine();
+      grid_cell.finishLine();
     }
     for (unsigned int point = 0; point < 100000; point++) {
       grid_cell.addPoint(Ogre::Vector3(0, 0, line + point + 0.1f));


### PR DESCRIPTION
Fixes #170 

Update Ogre to Version 1.10.11.
We did some manual testing on Linux, Mac and Windows (VS2015) and it seems everything works as it should.