### PR TITLE
Fix display tests and enable when possible

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -257,6 +257,7 @@ ament_export_dependencies(
   tf2_geometry_msgs
   tf2_ros
 )
+ament_export_include_directories(include)
 
 install(
   TARGETS rviz_common
@@ -281,8 +282,7 @@ install(
   DESTINATION "share/${PROJECT_NAME}"
 )
 
-# TODO(wjwwood): reenable tests for Windows after resolving building problems
-if(BUILD_TESTING AND NOT WIN32)
+if(BUILD_TESTING)
   # TODO(wjwwood): replace this with ament_lint_auto() and/or add the copyright linter back
   find_package(ament_cmake_cppcheck REQUIRED)
   find_package(ament_cmake_cpplint REQUIRED)
@@ -317,15 +317,6 @@ if(BUILD_TESTING AND NOT WIN32)
     )
   endif()
 
-  # TODO(wjwwood): reenable this test when it can be run on CI
-  # ament_add_gtest(rviz_common_display_test
-  #   test/display_test.cpp
-  #   test/mock_display.cpp
-  #   test/mock_display_group.cpp)
-  # if(TARGET rviz_common_display_test)
-  #   target_link_libraries(rviz_common_display_test rviz_common)
-  # endif()
-
   ament_add_gtest(rviz_common_property_test
     test/property_test.cpp
     test/mock_property_change_receiver.cpp)
@@ -343,6 +334,26 @@ if(BUILD_TESTING AND NOT WIN32)
     test/ros_node_abstraction_test.cpp)
   if(TARGET rviz_common_ros_node_abstraction_test)
     target_link_libraries(rviz_common_ros_node_abstraction_test rviz_common)
+  endif()
+
+  if(DEFINED ENV{DISPLAY})
+    set(DISPLAYPRESENT TRUE)
+  endif()
+
+  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+    message(STATUS "Enabling tests requiring a display")
+
+    ament_add_gtest(rviz_common_display_test
+      test/display_test.cpp
+      test/mock_display.cpp
+      test/mock_display_group.cpp)
+    if(TARGET rviz_common_display_test)
+      target_link_libraries(rviz_common_display_test
+        rviz_common
+        Qt5::Widgets)
+    ament_target_dependencies(rviz_common_display_test
+      rviz_yaml_cpp_vendor)
+    endif()
   endif()
 endif()
 

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -7,6 +7,9 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+option(EnableDisplayTests "EnableDisplayTests")
+set(DisplayTests "False" CACHE STRING "DisplayTestsVariable")
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
   # TODO(wjwwood): try to remove this -- currently needed to pass on CI
@@ -340,7 +343,7 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT TRUE)
   endif()
 
-  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
     message(STATUS "Enabling tests requiring a display")
 
     ament_add_gtest(rviz_common_display_test

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -32,6 +32,7 @@
 #define RVIZ_COMMON__DISPLAY_GROUP_HPP_
 
 #include "rviz_common/display.hpp"
+#include "rviz_common/visibility_control.hpp"
 
 namespace rviz_common
 {
@@ -47,7 +48,7 @@ class DisplayFactory;
  * class stores the Display objects in a separate list.
  * The separation is enforced in addChild().
  */
-class DisplayGroup : public Display
+class RVIZ_COMMON_PUBLIC DisplayGroup : public Display
 {
   Q_OBJECT
 

--- a/rviz_common/include/rviz_common/properties/color_property.hpp
+++ b/rviz_common/include/rviz_common/properties/color_property.hpp
@@ -31,7 +31,14 @@
 #ifndef RVIZ_COMMON__PROPERTIES__COLOR_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__COLOR_PROPERTY_HPP_
 
+#ifdef __APPLE__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgreColourValue.h>
+#ifdef __APPLE__
+# pragma clang diagnostic pop
+#endif
 
 #include <QColor>
 #include <QString>

--- a/rviz_common/include/rviz_common/render_panel.hpp
+++ b/rviz_common/include/rviz_common/render_panel.hpp
@@ -36,7 +36,15 @@
 #include <mutex>
 #include <vector>
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgreVector3.h>
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+
 #include <QWidget>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -34,8 +34,16 @@
 
 #include <string>
 
-#include <OgreSceneManager.h>
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreSceneNode.h>
+#include <OgreSceneManager.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #endif
 

--- a/rviz_common/include/rviz_common/selection/forwards.hpp
+++ b/rviz_common/include/rviz_common/selection/forwards.hpp
@@ -36,8 +36,15 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef __APPLE__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgrePixelFormat.h>
 #include <OgreColourValue.h>
+#ifdef __APPLE__
+# pragma clang diagnostic pop
+#endif
 
 #include "rviz_common/logging.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/selection/selection_handler.hpp
+++ b/rviz_common/include/rviz_common/selection/selection_handler.hpp
@@ -39,7 +39,15 @@
 #include <utility>
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreMovableObject.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "./forwards.hpp"
 #include "rviz_common/interactive_object.hpp"

--- a/rviz_common/include/rviz_common/selection/selection_manager.hpp
+++ b/rviz_common/include/rviz_common/selection/selection_manager.hpp
@@ -45,6 +45,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 
 #include <OgreMaterialManager.h>

--- a/rviz_common/include/rviz_common/selection/selection_manager_iface.hpp
+++ b/rviz_common/include/rviz_common/selection/selection_manager_iface.hpp
@@ -43,6 +43,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 
 #include <OgreMaterialManager.h>

--- a/rviz_common/src/rviz_common/ros_integration/ros_node_storage.cpp
+++ b/rviz_common/src/rviz_common/ros_integration/ros_node_storage.cpp
@@ -49,7 +49,7 @@ std::mutex RosNodeStorage::nodes_by_name_mutex_;
 void
 RosNodeStorage::store_rclcpp_node_by_name(
   const std::string & node_name,
-  const std::shared_ptr<rclcpp::Node> node)
+  std::shared_ptr<rclcpp::Node> node)
 {
   std::lock_guard<std::mutex> lock(nodes_by_name_mutex_);
   nodes_by_name_[node_name] = node;

--- a/rviz_common/src/rviz_common/ros_integration/ros_node_storage.hpp
+++ b/rviz_common/src/rviz_common/ros_integration/ros_node_storage.hpp
@@ -59,7 +59,7 @@ public:
   void
   store_rclcpp_node_by_name(
     const std::string & node_name,
-    const std::shared_ptr<rclcpp::Node> node) override;
+    std::shared_ptr<rclcpp::Node> node) override;
 
   /// Return the rclcpp node shared pointer for the given node name if found, else nullptr.
   /**

--- a/rviz_common/src/rviz_common/ros_integration/ros_node_storage_iface.hpp
+++ b/rviz_common/src/rviz_common/ros_integration/ros_node_storage_iface.hpp
@@ -49,7 +49,7 @@ public:
   virtual void
   store_rclcpp_node_by_name(
     const std::string & node_name,
-    const std::shared_ptr<rclcpp::Node> node) = 0;
+    std::shared_ptr<rclcpp::Node> node) = 0;
 
   virtual std::shared_ptr<rclcpp::Node>
   get_rclcpp_node_by_name(const std::string & node_name) = 0;

--- a/rviz_common/src/rviz_common/yaml_config_reader.hpp
+++ b/rviz_common/src/rviz_common/yaml_config_reader.hpp
@@ -34,6 +34,7 @@
 #include <istream>
 
 #include "rviz_common/config.hpp"
+#include "rviz_common/visibility_control.hpp"
 
 namespace YAML
 {
@@ -43,7 +44,7 @@ class Node;
 namespace rviz_common
 {
 
-class YamlConfigReader
+class RVIZ_COMMON_PUBLIC YamlConfigReader
 {
 public:
   /// Constructor.

--- a/rviz_common/src/rviz_common/yaml_config_writer.hpp
+++ b/rviz_common/src/rviz_common/yaml_config_writer.hpp
@@ -34,6 +34,7 @@
 #include <ostream>
 
 #include "rviz_common/config.hpp"
+#include "rviz_common/visibility_control.hpp"
 
 namespace YAML
 {
@@ -43,7 +44,7 @@ class Emitter;
 namespace rviz_common
 {
 
-class YamlConfigWriter
+class RVIZ_COMMON_PUBLIC YamlConfigWriter
 {
 public:
   /// Constructor.

--- a/rviz_common/test/property_test.cpp
+++ b/rviz_common/test/property_test.cpp
@@ -161,7 +161,7 @@ TEST(VectorProperty, set_value_events) {
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
   p.connect(&p, SIGNAL(changed()), &r, SLOT(changed()));
 
-  p.setVector(Ogre::Vector3(.1, .0001, 1000));
+  p.setVector(Ogre::Vector3(.1f, .0001f, 1000));
   EXPECT_EQ(" aboutToChange, v=0; 0; 0 changed, v=0.1; 0.0001; 1000", r.result().toStdString() );
   r.reset();
 
@@ -239,7 +239,7 @@ TEST(QuaternionProperty, set_value_events) {
   p.connect(&p, SIGNAL(aboutToChange()), &r, SLOT(aboutToChange()));
   p.connect(&p, SIGNAL(changed()), &r, SLOT(changed()));
 
-  p.setQuaternion(Ogre::Quaternion(1, .1, .0001, 1000));
+  p.setQuaternion(Ogre::Quaternion(1, .1f, .0001f, 1000));
   EXPECT_EQ(" aboutToChange, v=0; 0; 0; 1 changed, v=0.1; 0.0001; 1000; 1",
     r.result().toStdString() );
   r.reset();

--- a/rviz_common/test/ros_node_abstraction_test.cpp
+++ b/rviz_common/test/ros_node_abstraction_test.cpp
@@ -46,7 +46,7 @@ class MockRosNodeStorage : public rviz_common::ros_integration::RosNodeStorageIf
 {
 public:
   MOCK_METHOD2(store_rclcpp_node_by_name,
-    void(const std::string & node_name, const rclcpp::Node::SharedPtr node));
+    void(const std::string & node_name, std::shared_ptr<rclcpp::Node> node));
   MOCK_METHOD1(get_rclcpp_node_by_name,
     rclcpp::Node::SharedPtr(const std::string & node_name));
   MOCK_METHOD1(has_rclcpp_node_by_name, bool(const std::string & node_name));

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -240,6 +240,7 @@ if(BUILD_TESTING)
     set(TEST_LINK_LIBRARIES
       rviz_default_plugins_static
       ${rclcpp_LIBRARIES}
+      ${visualization_msgs_LIBRARIES}
       Qt5::Widgets
       rviz_common::rviz_common
     )

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -125,6 +125,7 @@ set_property(TARGET rviz_default_plugins_object PROPERTY POSITION_INDEPENDENT_CO
 target_include_directories(rviz_default_plugins_object PUBLIC
   ${rviz_rendering_INCLUDE_DIRS}
   ${rviz_common_INCLUDE_DIRS}
+  ${laser_geometry_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}
   ${Qt5Widgets_INCLUDE_DIRS}
   ${resource_retriever_INCLUDE_DIRS}

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -292,7 +292,7 @@ if(BUILD_TESTING)
 
     ament_add_gmock(robot_test
         test/rviz_default_plugins/robot/robot_test.cpp
-        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}/../rviz_rendering_tests PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET robot_test)
       target_include_directories(robot_test PUBLIC
         ${TEST_INCLUDE_DIRS})

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -231,6 +231,7 @@ if(BUILD_TESTING)
       ${rviz_rendering_INCLUDE_DIRS}
       ${OGRE_INCLUDE_DIRS}
       ${rclcpp_INCLUDE_DIRS}
+      ${nav_msgs_INCLUDE_DIRS}
       ${sensor_msgs_INCLUDE_DIRS}
       ${visualization_msgs_INCLUDE_DIRS}
       ${Qt5Widgets_INCLUDE_DIRS}
@@ -240,12 +241,13 @@ if(BUILD_TESTING)
     set(TEST_LINK_LIBRARIES
       rviz_default_plugins_static
       ${rclcpp_LIBRARIES}
+      ${nav_msgs_LIBRARIES}
       ${visualization_msgs_LIBRARIES}
       Qt5::Widgets
       rviz_common::rviz_common
     )
 
-    ament_add_gtest(point_cloud2_display_test
+    ament_add_gmock(point_cloud2_display_test
         test/rviz_default_plugins/displays/pointcloud/message_creators.hpp
         test/rviz_default_plugins/displays/pointcloud/message_creators.cpp
         test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp)
@@ -256,7 +258,7 @@ if(BUILD_TESTING)
         ${TEST_LINK_LIBRARIES})
     endif()
 
-    ament_add_gtest(point_cloud_transformers_test
+    ament_add_gmock(point_cloud_transformers_test
         test/rviz_default_plugins/displays/pointcloud/message_creators.hpp
         test/rviz_default_plugins/displays/pointcloud/message_creators.cpp
         test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -20,11 +20,14 @@ find_package(ament_cmake REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(resource_retriever REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(resource_retriever REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
+find_package(tinyxml_vendor REQUIRED)
+find_package(TinyXML REQUIRED)  # provided by tinyxml_vendor
+find_package(urdf REQUIRED)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
@@ -120,9 +123,20 @@ add_library(rviz_default_plugins_object OBJECT
 set_property(TARGET rviz_default_plugins_object PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(rviz_default_plugins_object PUBLIC
-    ${rviz_common_INCLUDE_DIRS}
-    ${OGRE_INCLUDE_DIRS}
-    ${Qt5Widgets_INCLUDE_DIRS}
+  ${rviz_rendering_INCLUDE_DIRS}
+  ${rviz_common_INCLUDE_DIRS}
+  ${OGRE_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+  ${resource_retriever_INCLUDE_DIRS}
+  ${TinyXML_INCLUDE_DIRS}
+  ${urdf_INCLUDE_DIRS}
+  ${visualization_msgs_INCLUDE_DIRS}
+)
+
+target_include_directories(rviz_default_plugins_object
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 add_library(rviz_default_plugins SHARED $<TARGET_OBJECTS:rviz_default_plugins_object>)
@@ -132,6 +146,13 @@ target_include_directories(rviz_default_plugins
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+
+target_include_directories(rviz_default_plugins_static
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
 target_link_libraries(rviz_default_plugins
   laser_geometry::laser_geometry
   resource_retriever::resource_retriever
@@ -206,19 +227,22 @@ if(BUILD_TESTING)
     find_package(visualization_msgs REQUIRED)
 
     set(TEST_INCLUDE_DIRS
-        ${rviz_common_INCLUDE_DIRS}
-        ${rviz_rendering_INCLUDE_DIRS}
-        ${OGRE_INCLUDE_DIRS}
-        ${rclcpp_INCLUDE_DIRS}
-        ${sensor_msgs_INCLUDE_DIRS}
-        ${visualization_msgs_INCLUDE_DIRS}
-        ${Qt5Widgets_INCLUDE_DIRS})
+      ${rviz_common_INCLUDE_DIRS}
+      ${rviz_rendering_INCLUDE_DIRS}
+      ${OGRE_INCLUDE_DIRS}
+      ${rclcpp_INCLUDE_DIRS}
+      ${sensor_msgs_INCLUDE_DIRS}
+      ${visualization_msgs_INCLUDE_DIRS}
+      ${Qt5Widgets_INCLUDE_DIRS}
+      ${urdf_INCLUDE_DIRS}
+    )
 
     set(TEST_LINK_LIBRARIES
-        rviz_default_plugins_static
-        ${rclcpp_LIBRARIES}
-        Qt5::Widgets
-        rviz_common::rviz_common)
+      rviz_default_plugins_static
+      ${rclcpp_LIBRARIES}
+      Qt5::Widgets
+      rviz_common::rviz_common
+    )
 
     ament_add_gtest(point_cloud2_display_test
         test/rviz_default_plugins/displays/pointcloud/message_creators.hpp

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(resource_retriever REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
+find_package(rviz_ogre_vendor REQUIRED)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
@@ -108,10 +109,22 @@ set(rviz_default_plugins_source_files
   src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
 )
 
-add_library(rviz_default_plugins SHARED
+add_library(rviz_default_plugins_object OBJECT
   ${rviz_default_plugins_headers_to_moc}
   ${rviz_default_plugins_source_files}
 )
+
+set_property(TARGET rviz_default_plugins_object PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(rviz_default_plugins_object PUBLIC
+    ${rviz_common_INCLUDE_DIRS}
+    ${OGRE_INCLUDE_DIRS}
+    ${Qt5Widgets_INCLUDE_DIRS}
+)
+
+add_library(rviz_default_plugins SHARED $<TARGET_OBJECTS:rviz_default_plugins_object>)
+add_library(rviz_default_plugins_static STATIC $<TARGET_OBJECTS:rviz_default_plugins_object>)
+
 target_include_directories(rviz_default_plugins
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -139,13 +152,10 @@ pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 
 # prevent pluginlib from using boost
 target_compile_definitions(rviz_default_plugins PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-# Causes the visibility macros to use dllexport rather than dllimport,
-# which is appropriate when building the dll but not consuming it.
-target_compile_definitions(rviz_default_plugins PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 
 ament_export_interfaces(rviz_default_plugins)
 ament_export_dependencies(Qt5)
-ament_export_dependencies(rviz_rendering)
+ament_export_dependencies(rviz_rendering rviz_common)
 ament_export_dependencies(
   # geometry_msgs
   rclcpp
@@ -182,106 +192,144 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_gmock REQUIRED)
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(point_cloud2_display_test
-#      test/rviz_default_plugins/displays/pointcloud/message_creators.hpp
-#      test/rviz_default_plugins/displays/pointcloud/message_creators.cpp
-#      test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
-#      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET point_cloud2_display_test)
-#    target_link_libraries(point_cloud2_display_test rviz_default_plugins)
-#  endif()
+  if(DEFINED ENV{DISPLAY})
+    set(DISPLAYPRESENT TRUE)
+  endif()
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(point_cloud_transformers_test
-#      test/rviz_default_plugins/displays/pointcloud/message_creators.hpp
-#      test/rviz_default_plugins/displays/pointcloud/message_creators.cpp
-#      test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
-#      test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
-#      test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
-#      test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgb8_pc_transformer_test.cpp
-#      test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgbf32_pc_transformer_test.cpp
-#      test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/xyz_pc_transformer_test.cpp
-#      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET point_cloud_transformers_test)
-#    target_link_libraries(point_cloud_transformers_test rviz_default_plugins)
-#  endif()
+  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+    message(STATUS "Enabling tests requiring a display")
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(ros_image_texture_test
-#      test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
-#      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET ros_image_texture_test)
-#    target_link_libraries(ros_image_texture_test rviz_default_plugins)
-#  endif()
+    find_package(sensor_msgs REQUIRED)
+    find_package(visualization_msgs REQUIRED)
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(image_display_test
-#      test/rviz_default_plugins/displays/image/image_display_test.cpp
-#      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET image_display_test)
-#    target_link_libraries(image_display_test rviz_default_plugins)
-#  endif()
+    set(TEST_INCLUDE_DIRS
+        ${rviz_common_INCLUDE_DIRS}
+        ${rviz_rendering_INCLUDE_DIRS}
+        ${OGRE_INCLUDE_DIRS}
+        ${rclcpp_INCLUDE_DIRS}
+        ${sensor_msgs_INCLUDE_DIRS}
+        ${visualization_msgs_INCLUDE_DIRS}
+        ${Qt5Widgets_INCLUDE_DIRS})
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(robot_test
-#      test/rviz_default_plugins/robot/robot_test.cpp
-#      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET robot_test)
-#    target_link_libraries(robot_test rviz_default_plugins)
-#  endif()
+    set(TEST_LINK_LIBRARIES
+        rviz_default_plugins_static
+        ${rclcpp_LIBRARIES}
+        Qt5::Widgets
+        rviz_common::rviz_common)
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(marker_test
-#    test/rviz_default_plugins/displays/marker/markers/arrow_marker_test.cpp
-#    test/rviz_default_plugins/displays/marker/markers/line_marker_test.cpp
-#    test/rviz_default_plugins/displays/marker/markers/mesh_resource_marker_test.cpp
-#    test/rviz_default_plugins/displays/marker/markers/points_marker_test.cpp
-#    test/rviz_default_plugins/displays/marker/markers/shape_marker_test.cpp
-#    test/rviz_default_plugins/displays/marker/markers/text_view_facing_marker_test.cpp
-#    test/rviz_default_plugins/displays/marker/markers/triangle_list_marker_test.cpp
-#    test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
-#    test/rviz_default_plugins/displays/display_test_fixture.cpp
-#    test/rviz_default_plugins/displays/marker/marker_messages.cpp
-#    test/rviz_default_plugins/scene_graph_introspection.cpp
-#    APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;
-#    ${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET marker_test)
-#    target_link_libraries(marker_test rviz_default_plugins)
-#  endif()
+    ament_add_gtest(point_cloud2_display_test
+        test/rviz_default_plugins/displays/pointcloud/message_creators.hpp
+        test/rviz_default_plugins/displays/pointcloud/message_creators.cpp
+        test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp)
+    if(TARGET point_cloud2_display_test)
+      target_include_directories(point_cloud2_display_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(point_cloud2_display_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(marker_display_test
-#    test/rviz_default_plugins/displays/marker/marker_display_test.cpp
-#    test/rviz_default_plugins/displays/display_test_fixture.cpp
-#    test/rviz_default_plugins/displays/marker/marker_messages.cpp
-#    test/rviz_default_plugins/scene_graph_introspection.cpp
-#    APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;
-#    ${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET marker_display_test)
-#    target_link_libraries(marker_display_test rviz_default_plugins)
-#  endif()
+    ament_add_gtest(point_cloud_transformers_test
+        test/rviz_default_plugins/displays/pointcloud/message_creators.hpp
+        test/rviz_default_plugins/displays/pointcloud/message_creators.cpp
+        test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
+        test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
+        test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
+        test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgb8_pc_transformer_test.cpp
+        test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgbf32_pc_transformer_test.cpp
+        test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/xyz_pc_transformer_test.cpp
+        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET point_cloud_transformers_test)
+      target_include_directories(point_cloud_transformers_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(point_cloud_transformers_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
 
-# TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(pose_array_display_test
-#    test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
-#    test/rviz_default_plugins/displays/display_test_fixture.cpp
-#    test/rviz_default_plugins/scene_graph_introspection.cpp
-#    APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;
-#    ${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET pose_array_display_test)
-#    target_link_libraries(pose_array_display_test rviz_default_plugins)
-#  endif()
+    ament_add_gmock(ros_image_texture_test
+        test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp)
+    if(TARGET ros_image_texture_test)
+      target_include_directories(ros_image_texture_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(ros_image_texture_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
 
-  # TODO(greimela): reenable these tests once they can be run on the ci
-#  ament_add_gmock(path_display_test
-#    test/rviz_default_plugins/displays/path/path_display_test.cpp
-#    test/rviz_default_plugins/displays/display_test_fixture.cpp
-#    test/rviz_default_plugins/scene_graph_introspection.cpp
-#    APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-#  if(TARGET path_display_test)
-#    target_link_libraries(path_display_test rviz_default_plugins)
-#  endif()
+    ament_add_gmock(image_display_test
+        test/rviz_default_plugins/displays/image/image_display_test.cpp)
+    if(TARGET image_display_test)
+        target_include_directories(image_display_test PUBLIC
+          ${TEST_INCLUDE_DIRS})
+        target_link_libraries(image_display_test
+          ${TEST_LINK_LIBRARIES})
+    endif()
+
+    ament_add_gmock(robot_test
+        test/rviz_default_plugins/robot/robot_test.cpp
+        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET robot_test)
+      target_include_directories(robot_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(robot_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
+
+    ament_add_gmock(marker_test
+      test/rviz_default_plugins/displays/marker/markers/arrow_marker_test.cpp
+      test/rviz_default_plugins/displays/marker/markers/line_marker_test.cpp
+      test/rviz_default_plugins/displays/marker/markers/mesh_resource_marker_test.cpp
+      test/rviz_default_plugins/displays/marker/markers/points_marker_test.cpp
+      test/rviz_default_plugins/displays/marker/markers/shape_marker_test.cpp
+      test/rviz_default_plugins/displays/marker/markers/text_view_facing_marker_test.cpp
+      test/rviz_default_plugins/displays/marker/markers/triangle_list_marker_test.cpp
+      test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
+      test/rviz_default_plugins/displays/display_test_fixture.cpp
+      test/rviz_default_plugins/displays/marker/marker_messages.cpp
+      test/rviz_default_plugins/scene_graph_introspection.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET marker_test)
+      target_include_directories(marker_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(marker_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
+
+    ament_add_gmock(marker_display_test
+      test/rviz_default_plugins/displays/marker/marker_display_test.cpp
+      test/rviz_default_plugins/displays/display_test_fixture.cpp
+      test/rviz_default_plugins/displays/marker/marker_messages.cpp
+      test/rviz_default_plugins/scene_graph_introspection.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET marker_display_test)
+      target_include_directories(marker_display_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(marker_display_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
+
+    ament_add_gmock(pose_array_display_test
+      test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
+      test/rviz_default_plugins/displays/display_test_fixture.cpp
+      test/rviz_default_plugins/scene_graph_introspection.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET pose_array_display_test)
+      target_include_directories(pose_array_display_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(pose_array_display_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
+
+    ament_add_gmock(path_display_test
+      test/rviz_default_plugins/displays/path/path_display_test.cpp
+      test/rviz_default_plugins/displays/display_test_fixture.cpp
+      test/rviz_default_plugins/scene_graph_introspection.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET path_display_test)
+      target_include_directories(path_display_test PUBLIC
+        ${TEST_INCLUDE_DIRS})
+      target_link_libraries(path_display_test
+        ${TEST_LINK_LIBRARIES})
+    endif()
+  endif()
 endif()
 
 ament_package()

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -7,6 +7,9 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+option(EnableDisplayTests "EnableDisplayTests")
+set(DisplayTests "False" CACHE STRING "DisplayTestsVariable")
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
@@ -196,7 +199,7 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT TRUE)
   endif()
 
-  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
     message(STATUS "Enabling tests requiring a display")
 
     find_package(sensor_msgs REQUIRED)

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -126,6 +126,7 @@ target_include_directories(rviz_default_plugins_object PUBLIC
   ${rviz_rendering_INCLUDE_DIRS}
   ${rviz_common_INCLUDE_DIRS}
   ${laser_geometry_INCLUDE_DIRS}
+  ${nav_msgs_INCLUDE_DIRS}
   ${OGRE_INCLUDE_DIRS}
   ${Qt5Widgets_INCLUDE_DIRS}
   ${resource_retriever_INCLUDE_DIRS}

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -297,7 +297,7 @@ if(BUILD_TESTING)
 
     ament_add_gmock(robot_test
         test/rviz_default_plugins/robot/robot_test.cpp
-        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}/../rviz_rendering_tests PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET robot_test)
       target_include_directories(robot_test PUBLIC
         ${TEST_INCLUDE_DIRS})

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -32,9 +32,9 @@
   <depend>resource_retriever</depend>
   <depend>rviz_common</depend>
   <depend>rviz_rendering</depend>
+  <depend>tinyxml_vendor</depend>
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
-  <depend>tinyxml_vendor</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -29,10 +29,12 @@
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>resource_retriever</depend>
   <depend>rviz_common</depend>
   <depend>rviz_rendering</depend>
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
+  <depend>tinyxml_vendor</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -553,13 +553,5 @@ void CameraDisplay::reset()
 
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::CameraDisplay, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -33,6 +33,11 @@
 #include <memory>
 #include <string>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreRectangle2D.h>
@@ -44,6 +49,9 @@
 #include <OgreViewport.h>
 #include <OgreTechnique.h>
 #include <OgreCamera.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "rviz_rendering/objects/axes.hpp"
 #include "rviz_rendering/render_window.hpp"
@@ -545,5 +553,13 @@ void CameraDisplay::reset()
 
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::CameraDisplay, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -39,10 +39,19 @@
 #include <QObject>  // NOLINT: cpplint cannot handle the include order here
 
 #ifndef Q_MOC_RUN
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 # include <OgreMaterial.h>
 # include <OgrePlatform.h>
 # include <OgreRenderTargetListener.h>
 # include <OgreSharedPtr.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 # include <sensor_msgs/msg/camera_info.hpp>
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
@@ -37,6 +37,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 
 #include <OgreSceneManager.h>
@@ -246,5 +247,13 @@ void GridDisplay::updatePlane()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::GridDisplay, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
@@ -247,13 +247,5 @@ void GridDisplay::updatePlane()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::GridDisplay, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -32,6 +32,11 @@
 #include <string>
 #include <utility>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreCamera.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
@@ -43,6 +48,9 @@
 #include <OgreTechnique.h>
 #include <OgreTextureManager.h>
 #include <OgreViewport.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "sensor_msgs/image_encodings.hpp"
 
@@ -244,5 +252,13 @@ void ImageDisplay::setupRenderPanel()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::ImageDisplay, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -252,13 +252,5 @@ void ImageDisplay::setupRenderPanel()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::ImageDisplay, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.hpp
@@ -37,9 +37,17 @@
 
 # include <QObject>  // NOLINT cpplint cannot handle include order here
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 # include <OgreMaterial.h>
 # include <OgreRenderTargetListener.h>
 # include <OgreSharedPtr.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 # include "rviz_common/ros_topic_display.hpp"
 # include "rviz_common/render_panel.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
@@ -40,7 +40,15 @@
 #include <vector>
 #include <utility>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreTextureManager.h> // NOLINT: cpplint cannot handle include order
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "sensor_msgs/image_encodings.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
@@ -45,7 +45,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # pragma GCC diagnostic ignored "-Wpedantic"
 #endif
-#include <OgreTextureManager.h> // NOLINT: cpplint cannot handle include order
+#include <OgreTextureManager.h>  // NOLINT: cpplint cannot handle include order
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.hpp
@@ -39,9 +39,17 @@
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreTexture.h>
 #include <OgreImage.h>
 #include <OgreSharedPtr.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "sensor_msgs/msg/image.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture_iface.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture_iface.hpp
@@ -30,8 +30,16 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__IMAGE__ROS_IMAGE_TEXTURE_IFACE_HPP_
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__IMAGE__ROS_IMAGE_TEXTURE_IFACE_HPP_
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreTexture.h>
 #include <OgreSharedPtr.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "sensor_msgs/msg/image.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/arrow_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/arrow_marker.cpp
@@ -34,7 +34,11 @@
 #include <memory>
 #include <string>
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
 # pragma warning(push)
 # pragma warning(disable : 4996)
 #endif
@@ -45,7 +49,9 @@
 #include <OgreSceneManager.h>
 #include <OgreVector3.h>
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
 # pragma warning(pop)
 #endif
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_list_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_list_marker.cpp
@@ -33,8 +33,23 @@
 #include <vector>
 #include <string>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreVector3.h>
 #include <OgreSceneNode.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "../marker_display.hpp"
 #include "marker_selection_handler.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_marker_base.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_marker_base.cpp
@@ -34,9 +34,24 @@
 #include <vector>
 #include <string>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneNode.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "../marker_display.hpp"
 #include "marker_selection_handler.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_strip_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_strip_marker.cpp
@@ -32,9 +32,24 @@
 
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneNode.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "../marker_display.hpp"
 #include "marker_selection_handler.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_base.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_base.cpp
@@ -33,7 +33,11 @@
 #include <memory>
 #include <string>
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
 # pragma warning(push)
 # pragma warning(disable : 4996)
 #endif
@@ -44,7 +48,9 @@
 #include <OgreSubEntity.h>
 #include <OgreSharedPtr.h>
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
 # pragma warning(pop)
 #endif
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_factory.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_factory.cpp
@@ -35,14 +35,21 @@
 #include "marker_factory.hpp"
 
 #include <memory>
-#ifdef _WIN32
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
 # pragma warning(push)
 # pragma warning(disable : 4996)
 #endif
 
 #include <OgreSceneNode.h>
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
 # pragma warning(pop)
 #endif
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_selection_handler.cpp
@@ -30,8 +30,23 @@
 
 #include "marker_selection_handler.hpp"
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreQuaternion.h>
 #include <OgreVector3.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "../marker_display.hpp"
 #include "marker_base.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
@@ -32,7 +32,11 @@
 
 #include <string>
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
 # pragma warning(push)
 # pragma warning(disable : 4996)
 #endif
@@ -45,7 +49,9 @@
 #include <OgreTechnique.h>
 #include <OgreTextureManager.h>
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
 # pragma warning(pop)
 #endif
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
@@ -34,7 +34,22 @@
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreMaterial.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "marker_base.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
@@ -32,8 +32,6 @@
 
 #include <vector>
 
-#include <OgreSceneNode.h>
-
 #include "../marker_display.hpp"
 #include "marker_selection_handler.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/shape_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/shape_marker.cpp
@@ -32,9 +32,6 @@
 
 #include <memory>
 
-#include <OgreSceneNode.h>
-#include <OgreMatrix3.h>
-
 #include "marker_selection_handler.hpp"
 #include "../marker_display.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.cpp
@@ -30,8 +30,23 @@
 
 #include "text_view_facing_marker.hpp"
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "marker_selection_handler.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/triangle_list_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/triangle_list_marker.cpp
@@ -32,12 +32,27 @@
 
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreTextureManager.h>
 #include <OgreTechnique.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "marker_selection_handler.hpp"
 #include "../marker_display.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/triangle_list_marker.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/triangle_list_marker.hpp
@@ -33,8 +33,23 @@
 
 #include <string>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreMaterial.h>
 #include <OgreSharedPtr.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "marker_base.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
@@ -34,10 +34,25 @@
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreBillboardSet.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "rviz_common/logging.hpp"
 #include "rviz_common/properties/enum_property.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -31,8 +31,16 @@
 
 #include <memory>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "point_cloud_common.hpp"
 #include "point_cloud_helpers.hpp"
@@ -187,5 +195,13 @@ void PointCloud2Display::reset()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::PointCloud2Display, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -195,13 +195,5 @@ void PointCloud2Display::reset()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::PointCloud2Display, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -34,8 +34,16 @@
 #include <string>
 #include <utility>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreSceneNode.h>
 #include <OgreWireBoundingBox.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 // TODO(wjwwood): revisit file when pluginlib is available
 // #include <pluginlib/class_loader.h>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -84,13 +84,5 @@ void PointCloudDisplay::reset()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::PointCloudDisplay, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -31,6 +31,7 @@
 
 #include <memory>
 #include <utility>
+
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -40,6 +41,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #endif
+
 #include "./point_cloud_common.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -31,9 +31,15 @@
 
 #include <memory>
 #include <utility>
-
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreSceneNode.h>
-
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 #include "./point_cloud_common.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
@@ -76,5 +82,13 @@ void PointCloudDisplay::reset()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::PointCloudDisplay, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_selection_handler.cpp
@@ -33,9 +33,17 @@
 #include <string>
 #include <utility>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 #include <OgreWireBoundingBox.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 // #include <tf/transform_listener.h>
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_transformer.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_transformer.hpp
@@ -35,8 +35,15 @@
 #include <QObject>  // NOLINT
 
 #ifndef Q_MOC_RUN
+#ifdef __APPLE__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgreVector3.h>
 #include <OgreColourValue.h>
+#ifdef __APPLE__
+# pragma clang diagnostic pop
+#endif
 
 #include "sensor_msgs/msg/point_cloud2.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
@@ -26,13 +26,20 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 #include <OgreManualObject.h>
 #include <OgreBillboardSet.h>
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <string>
 
@@ -147,5 +154,13 @@ void PolygonDisplay::enableBlending(const Ogre::ColourValue & color)
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::PolygonDisplay, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
@@ -154,13 +154,5 @@ void PolygonDisplay::enableBlending(const Ogre::ColourValue & color)
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::PolygonDisplay, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
@@ -30,13 +30,19 @@
 
 #include "pose_display_selection_handler.hpp"
 
-#ifdef _WIN32
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
 #pragma warning(push)
 #pragma warning(disable : 4996)
+#endif
 #include <OgreEntity.h>
-#pragma warning(pop)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
 #else
-#include <OgreEntity.h>
+# pragma warning(pop)
 #endif
 
 #include "rviz_rendering/objects/axes.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
@@ -38,7 +38,9 @@
 #pragma warning(push)
 #pragma warning(disable : 4996)
 #endif
+
 #include <OgreEntity.h>
+
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #else

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/flat_arrows_array.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/flat_arrows_array.cpp
@@ -33,8 +33,23 @@
 #include <vector>
 #include <string>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreSceneManager.h>
 #include <OgreTechnique.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 namespace rviz_default_plugins
 {

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/flat_arrows_array.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/flat_arrows_array.hpp
@@ -33,11 +33,26 @@
 
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreSceneNode.h>
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "pose_array_display.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
@@ -33,9 +33,24 @@
 #include <memory>
 #include <string>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
+
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "rviz_common/logging.hpp"
 #include "rviz_common/properties/enum_property.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -319,13 +319,5 @@ void RobotModelDisplay::processMessage(std_msgs::msg::String::ConstSharedPtr msg
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::RobotModelDisplay, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -35,6 +35,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 
 #include <OgreSceneManager.h>
@@ -318,5 +319,13 @@ void RobotModelDisplay::processMessage(std_msgs::msg::String::ConstSharedPtr msg
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::RobotModelDisplay, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
@@ -34,7 +34,14 @@
 #include <memory>
 #include <string>
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgreVector3.h>
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 #include "std_msgs/msg/string.hpp"
 #include "rviz_common/ros_topic_display.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_info.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_info.cpp
@@ -32,7 +32,15 @@
 
 #include <algorithm>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <OgreSceneNode.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/axes.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
@@ -41,11 +41,10 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #endif
-
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
-
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #endif
@@ -599,5 +598,13 @@ void TFDisplay::reset()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::TFDisplay, rviz_common::Display)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
@@ -598,13 +598,5 @@ void TFDisplay::reset()
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-# pragma GCC diagnostic ignored "-Wpedantic"
-#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::TFDisplay, rviz_common::Display)
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.hpp
@@ -37,8 +37,15 @@
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgreQuaternion.h>
 #include <OgreVector3.h>
+#ifdef __APPLE__
+# pragma clang diagnostic pop
+#endif
 
 #include "geometry_msgs/msg/transform_stamped__struct.hpp"
 #include "tf2/exceptions.h"

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp
@@ -37,24 +37,21 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
-#ifdef _WIN32
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
 #pragma warning(push)
 #pragma warning(disable : 4996)
-#include <OgreEntity.h>
-#pragma warning(pop)
-#else
-#include <OgreEntity.h>
 #endif
+
+#include <OgreEntity.h>
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 #include <OgreMaterialManager.h>
-#include <OgreMaterial.h>
-#include <OgreResourceGroupManager.h>
 
 #ifndef _WIN32
 # pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
 #endif
 
 #include "urdf_model/model.h"

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot.hpp
@@ -34,9 +34,16 @@
 #include <string>
 #include <map>
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 #include "urdf/model.h"  // can be replaced later by urdf_model/types.h
 

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_element_base_class.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_element_base_class.cpp
@@ -35,11 +35,6 @@
 #include <vector>
 #include <utility>
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
 #include "robot.hpp"
 
 #include "rviz_common/load_resource.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_element_base_class.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_element_base_class.hpp
@@ -37,9 +37,19 @@
 #include <vector>
 
 #ifndef Q_MOC_RUN
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneNode.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 #endif
 
 #include <QObject>

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.cpp
@@ -34,17 +34,6 @@
 #include <string>
 #include <vector>
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
-#include <OgreSceneNode.h>
-
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-
 #include "./robot_link.hpp"
 #include "robot.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.hpp
@@ -36,10 +36,20 @@
 #include <string>
 
 #ifndef Q_MOC_RUN
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 #include <OgreMaterial.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 #endif
 
 #include <QObject>

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -38,16 +38,13 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
-#ifdef _WIN32
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
 #pragma warning(push)
 #pragma warning(disable : 4996)
-#include <OgreEntity.h>
-#pragma warning(pop)
-#else
-#include <OgreEntity.h>
 #endif
+
+#include <OgreEntity.h>
 #include <OgreMaterial.h>
 #include <OgreMaterialManager.h>
 #include <OgreRibbonTrail.h>
@@ -60,6 +57,8 @@
 
 #ifndef _WIN32
 # pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
 #endif
 
 #include <QFileInfo>

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.hpp
@@ -37,11 +37,21 @@
 #include <vector>
 
 #ifndef Q_MOC_RUN
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #include <OgreVector3.h>
 #include <OgreQuaternion.h>
 #include <OgreAny.h>
 #include <OgreMaterial.h>
 #include <OgreSharedPtr.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 #endif
 
 #include <QObject>

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/tf_link_updater.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/tf_link_updater.cpp
@@ -32,7 +32,14 @@
 
 #include <string>
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
 #include <OgreVector3.h>
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 #include "rviz_common/frame_manager_iface.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/tf_link_updater.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/tf_link_updater.cpp
@@ -33,7 +33,6 @@
 #include <string>
 
 #include <OgreVector3.h>
-#include <OgreQuaternion.h>
 
 #include "rviz_common/frame_manager_iface.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/move/move_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/move/move_tool.cpp
@@ -81,5 +81,13 @@ int MoveTool::processKeyEvent(QKeyEvent * event, rviz_common::RenderPanel * pane
 }  // namespace tools
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::tools::MoveTool, rviz_common::Tool)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/move/move_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/move/move_tool.cpp
@@ -83,7 +83,6 @@ int MoveTool::processKeyEvent(QKeyEvent * event, rviz_common::RenderPanel * pane
 
 #ifndef _WIN32
 # pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
 # pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
@@ -35,6 +35,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 
 #include <OgreCamera.h>
@@ -354,7 +355,15 @@ void OrbitViewController::move(float x, float y, float z)  // NOLINT(build/inclu
 }  // namespace view_controllers
 }  // namespace rviz_default_plugins
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
 #include <pluginlib/class_list_macros.hpp>  // NOLINT(build/include_order)
 PLUGINLIB_EXPORT_CLASS(
   rviz_default_plugins::view_controllers::OrbitViewController,
   rviz_common::ViewController)
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp
@@ -31,7 +31,17 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__VIEW_CONTROLLERS__ORBIT__ORBIT_VIEW_CONTROLLER_HPP_
 #define RVIZ_DEFAULT_PLUGINS__VIEW_CONTROLLERS__ORBIT__ORBIT_VIEW_CONTROLLER_HPP_
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 #include <OgreVector3.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #include <QCursor>
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
@@ -27,6 +27,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef _WIN32
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#endif
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -40,6 +44,9 @@
 #include "test/rviz_rendering/ogre_testing_environment.hpp"
 
 #include "../../../../src/rviz_default_plugins/displays/image/ros_image_texture.hpp"
+#ifdef _WIN32
+# pragma warning(pop)
+#endif
 
 using namespace rviz_default_plugins::displays;  // NOLINT
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
@@ -27,10 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef _WIN32
-# pragma warning(push)
-# pragma warning(disable : 4996)
-#endif
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -44,9 +40,6 @@
 #include "test/rviz_rendering/ogre_testing_environment.hpp"
 
 #include "../../../../src/rviz_default_plugins/displays/image/ros_image_texture.hpp"
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 using namespace rviz_default_plugins::displays;  // NOLINT
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
@@ -132,15 +132,15 @@ void expectAxesAreVisible(Ogre::SceneNode * node)
 }
 
 TEST_F(PoseArrayDisplayFixture, constructor_set_all_the_properties_in_the_right_order) {
-  EXPECT_EQ("Color", display_->childAt(3)->getNameStd());
-  EXPECT_EQ("Alpha", display_->childAt(4)->getNameStd());
-  EXPECT_EQ("Arrow Length", display_->childAt(5)->getNameStd());
-  EXPECT_EQ("Head Radius", display_->childAt(6)->getNameStd());
-  EXPECT_EQ("Head Length", display_->childAt(7)->getNameStd());
-  EXPECT_EQ("Shaft Radius", display_->childAt(8)->getNameStd());
-  EXPECT_EQ("Shaft Length", display_->childAt(9)->getNameStd());
-  EXPECT_EQ("Axes Length", display_->childAt(10)->getNameStd());
-  EXPECT_EQ("Axes Radius", display_->childAt(11)->getNameStd());
+  EXPECT_THAT(display_->childAt(3)->getNameStd(), Eq("Color"));
+  EXPECT_THAT(display_->childAt(4)->getNameStd(), Eq("Alpha"));
+  EXPECT_THAT(display_->childAt(5)->getNameStd(), Eq("Arrow Length"));
+  EXPECT_THAT(display_->childAt(6)->getNameStd(), Eq("Head Radius"));
+  EXPECT_THAT(display_->childAt(7)->getNameStd(), Eq("Head Length"));
+  EXPECT_THAT(display_->childAt(8)->getNameStd(), Eq("Shaft Radius"));
+  EXPECT_THAT(display_->childAt(9)->getNameStd(), Eq("Shaft Length"));
+  EXPECT_THAT(display_->childAt(10)->getNameStd(), Eq("Axes Length"));
+  EXPECT_THAT(display_->childAt(11)->getNameStd(), Eq("Axes Radius"));
 }
 
 TEST_F(PoseArrayDisplayFixture, at_startup_only_flat_arrows_propertie_are_visible) {
@@ -203,12 +203,13 @@ TEST_F(PoseArrayDisplayFixture, setTransform_with_invalid_message_returns_early)
   auto arrows_3d = rviz_default_plugins::findAllArrows(scene_manager_->getRootSceneNode());
   auto axes = rviz_default_plugins::findAllAxes(scene_manager_->getRootSceneNode());
   auto manual_object =
-    rviz_default_plugins::findOneMovableObject(scene_manager_->getRootSceneNode());
+    rviz_default_plugins::findOneManualObject(scene_manager_->getRootSceneNode());
 
   // the default position and orientation of the scene node are (0, 0, 0) and (1, 0, 0, 0)
-  EXPECT_VECTOR3_EQ(Ogre::Vector3(0, 0, 0), display_->getSceneNode()->getPosition());
-  EXPECT_QUATERNION_EQ(Ogre::Quaternion(1, 0, 0, 0), display_->getSceneNode()->getOrientation());
-  EXPECT_FLOAT_EQ(0, manual_object->getBoundingRadius());
+  EXPECT_THAT(display_->getSceneNode()->getPosition(), Vector3Eq(Ogre::Vector3(0, 0, 0)));
+  EXPECT_THAT(
+    display_->getSceneNode()->getOrientation(), QuaternionEq(Ogre::Quaternion(1, 0, 0, 0)));
+  EXPECT_THAT(manual_object->getBoundingRadius(), FloatEq(0));
   EXPECT_THAT(arrows_3d, SizeIs(0));
   EXPECT_THAT(axes, SizeIs(0));
 }
@@ -222,12 +223,13 @@ TEST_F(PoseArrayDisplayFixture, setTransform_with_invalid_transform_returns_earl
   auto arrows_3d = rviz_default_plugins::findAllArrows(scene_manager_->getRootSceneNode());
   auto axes = rviz_default_plugins::findAllAxes(scene_manager_->getRootSceneNode());
   auto manual_object =
-    rviz_default_plugins::findOneMovableObject(scene_manager_->getRootSceneNode());
+    rviz_default_plugins::findOneManualObject(scene_manager_->getRootSceneNode());
 
   // the default position and orientation of the scene node are (0, 0, 0) and (1, 0, 0, 0)
-  EXPECT_VECTOR3_EQ(Ogre::Vector3(0, 0, 0), display_->getSceneNode()->getPosition());
-  EXPECT_QUATERNION_EQ(Ogre::Quaternion(1, 0, 0, 0), display_->getSceneNode()->getOrientation());
-  EXPECT_FLOAT_EQ(0, manual_object->getBoundingRadius());
+  EXPECT_THAT(display_->getSceneNode()->getPosition(), Vector3Eq(Ogre::Vector3(0, 0, 0)));
+  EXPECT_THAT(
+    display_->getSceneNode()->getOrientation(), QuaternionEq(Ogre::Quaternion(1, 0, 0, 0)));
+  EXPECT_THAT(manual_object->getBoundingRadius(), FloatEq(0));
   EXPECT_THAT(arrows_3d, SizeIs(0));
   EXPECT_THAT(axes, SizeIs(0));
 }
@@ -237,8 +239,9 @@ TEST_F(PoseArrayDisplayFixture, setTransform_sets_node_position_and_orientation_
   auto msg = createMessageWithOnePose();
   display_->processMessage(msg);
 
-  EXPECT_VECTOR3_EQ(Ogre::Vector3(0, 1, 0), display_->getSceneNode()->getPosition());
-  EXPECT_QUATERNION_EQ(Ogre::Quaternion(0, 0, 1, 0), display_->getSceneNode()->getOrientation());
+  EXPECT_THAT(display_->getSceneNode()->getPosition(), Vector3Eq(Ogre::Vector3(0, 1, 0)));
+  EXPECT_THAT(
+    display_->getSceneNode()->getOrientation(), QuaternionEq(Ogre::Quaternion(0, 0, 1, 0)));
 }
 
 TEST_F(PoseArrayDisplayFixture, processMessage_sets_manualObject_correctly) {
@@ -247,10 +250,11 @@ TEST_F(PoseArrayDisplayFixture, processMessage_sets_manualObject_correctly) {
   display_->processMessage(msg);
 
   auto manual_object =
-    rviz_default_plugins::findOneMovableObject(scene_manager_->getRootSceneNode());
+    rviz_default_plugins::findOneManualObject(scene_manager_->getRootSceneNode());
   auto manual_objectbounding_radius = 4.17732;
-  EXPECT_FLOAT_EQ(manual_objectbounding_radius, manual_object->getBoundingRadius());
-  EXPECT_VECTOR3_EQ(Ogre::Vector3(0.85f, 2, 3.3f), manual_object->getBoundingBox().getCenter());
+  EXPECT_THAT(manual_object->getBoundingRadius(), FloatEq(manual_objectbounding_radius));
+  EXPECT_THAT(
+    manual_object->getBoundingBox().getCenter(), Vector3Eq(Ogre::Vector3(0.85f, 2, 3.3f)));
 }
 
 TEST_F(PoseArrayDisplayFixture, processMessage_sets_arrows3d_correctly) {
@@ -289,8 +293,8 @@ TEST_F(PoseArrayDisplayFixture, processMessage_sets_axes_correctly) {
 
   expectAxesAreVisible(frames[0]);
   EXPECT_THAT(frames, SizeIs(1));
-  EXPECT_VECTOR3_EQ(Ogre::Vector3(1, 2, 3), frames[0]->getPosition());
-  EXPECT_QUATERNION_EQ(expected_orientation, frames[0]->getOrientation());
+  EXPECT_THAT(frames[0]->getPosition(), Vector3Eq(Ogre::Vector3(1, 2, 3)));
+  EXPECT_THAT(frames[0]->getOrientation(), QuaternionEq(expected_orientation));
 }
 
 TEST_F(PoseArrayDisplayFixture, processMessage_updates_the_display_correctly_after_shape_change) {
@@ -302,9 +306,9 @@ TEST_F(PoseArrayDisplayFixture, processMessage_updates_the_display_correctly_aft
   auto arrows = rviz_default_plugins::findAllArrows(scene_manager_->getRootSceneNode());
   auto frames = rviz_default_plugins::findAllAxes(scene_manager_->getRootSceneNode());
   auto manual_object =
-    rviz_default_plugins::findOneMovableObject(scene_manager_->getRootSceneNode());
+    rviz_default_plugins::findOneManualObject(scene_manager_->getRootSceneNode());
   EXPECT_THAT(arrows, SizeIs(1));
-  EXPECT_EQ(0, manual_object->getBoundingRadius());
+  EXPECT_THAT(manual_object->getBoundingRadius(), FloatEq(0));
   EXPECT_THAT(frames, SizeIs(0));
 
   display_->setShape("Axes");
@@ -312,6 +316,6 @@ TEST_F(PoseArrayDisplayFixture, processMessage_updates_the_display_correctly_aft
   auto post_update_arrows = rviz_default_plugins::findAllArrows(scene_manager_->getRootSceneNode());
   auto post_update_frames = rviz_default_plugins::findAllAxes(scene_manager_->getRootSceneNode());
   EXPECT_THAT(post_update_frames, SizeIs(1));
-  EXPECT_EQ(0, manual_object->getBoundingRadius());
+  EXPECT_THAT(manual_object->getBoundingRadius(), FloatEq(0));
   EXPECT_THAT(post_update_arrows, SizeIs(0));
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
@@ -35,9 +35,24 @@
 #include <memory>
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
+#else
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 #include <OgreRoot.h>
 #include <OgreEntity.h>
 #include <OgreManualObject.h>
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "rviz_common/properties/float_property.hpp"
 
@@ -235,7 +250,7 @@ TEST_F(PoseArrayDisplayFixture, processMessage_sets_manualObject_correctly) {
     rviz_default_plugins::findOneMovableObject(scene_manager_->getRootSceneNode());
   auto manual_objectbounding_radius = 4.17732;
   EXPECT_FLOAT_EQ(manual_objectbounding_radius, manual_object->getBoundingRadius());
-  EXPECT_VECTOR3_EQ(Ogre::Vector3(0.85, 2, 3.3), manual_object->getBoundingBox().getCenter());
+  EXPECT_VECTOR3_EQ(Ogre::Vector3(0.85f, 2, 3.3f), manual_object->getBoundingBox().getCenter());
 }
 
 TEST_F(PoseArrayDisplayFixture, processMessage_sets_arrows3d_correctly) {

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -108,6 +108,8 @@ ament_export_dependencies(rviz_ogre_vendor
   resource_retriever
   ament_index_cpp)
 
+ament_export_include_directories(include)
+
 install(
   TARGETS rviz_rendering
   EXPORT rviz_rendering
@@ -178,62 +180,60 @@ if(BUILD_TESTING)
     target_link_libraries(test_rviz_rendering rviz_rendering)
   endif()
 
-  # TODO(wjwwood): reenable this test when it can be run on CI
-  # ament_add_gtest(point_cloud_test_target
-  #   test/point_cloud_test.cpp
-  #   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-  # if(TARGET point_cloud_test_target)
-  #   target_link_libraries(point_cloud_test_target
-  #     rviz_ogre_vendor::OgreMain
-  #     rviz_rendering
-  #     Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
-  #   )
-  # endif()
+  if(DEFINED ENV{DISPLAY})
+    set(DISPLAYPRESENT TRUE)
+  endif()
 
-  # TODO(wjwwood): reenable this test when it can be run on CI
-  # ament_add_gtest(point_cloud_renderable_test_target test/point_cloud_renderable_test.cpp
-  #   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-  # if(TARGET point_cloud_renderable_test_target)
-  #    target_link_libraries(point_cloud_renderable_test_target
-  #     rviz_ogre_vendor::OgreMain
-  #     rviz_rendering
-  #     Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
-  #   )
-  # endif()
+  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+    message(STATUS "Enabling tests requiring a display")
 
-  # TODO(wjwwood): reenable this test when it can be run on CI
-  # ament_add_gtest(billboard_line_test_target test/billboard_line_test.cpp
-  #   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-  # if(TARGET billboard_line_test_target)
-  #   target_link_libraries(billboard_line_test_target
-  #     rviz_ogre_vendor::OgreMain
-  #     rviz_rendering
-  #     Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
-  #   )
-  # endif()
+    ament_add_gtest(point_cloud_test_target test/point_cloud_test.cpp)
+    if(TARGET point_cloud_test_target)
+      target_link_libraries(point_cloud_test_target
+        rviz_ogre_vendor::OgreMain
+        rviz_rendering
+        Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      )
+    endif()
 
-  # TODO(wjwwood): reenable this test when it can be run on CI
-  # ament_add_gtest(grid_test_target test/grid_test.cpp
-  #   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-  # if(TARGET grid_test_target)
-  #   target_link_libraries(grid_test_target
-  #     rviz_ogre_vendor::OgreMain
-  #     rviz_rendering
-  #     Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
-  #   )
-  # endif()
+    ament_add_gtest(point_cloud_renderable_test_target test/point_cloud_renderable_test.cpp)
+    if(TARGET point_cloud_renderable_test_target)
+      target_link_libraries(point_cloud_renderable_test_target
+        rviz_ogre_vendor::OgreMain
+        rviz_rendering
+        Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      )
+    endif()
 
-  # TODO(wjwwood): reenable this test when it can be run on CI
-  # ament_add_gtest(movable_text_test_target test/movable_text_test.cpp
-  #   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-  # if(TARGET movable_text_test_target)
-  #   target_link_libraries(movable_text_test_target
-  #     rviz_ogre_vendor::OgreMain
-  #     rviz_ogre_vendor::OgreOverlay
-  #     rviz_rendering
-  #     Qt5::Widgets
-  #   )
-  # endif()
+    ament_add_gtest(billboard_line_test_target test/billboard_line_test.cpp)
+    if(TARGET billboard_line_test_target)
+      target_link_libraries(billboard_line_test_target
+        rviz_ogre_vendor::OgreMain
+        rviz_rendering
+        Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      )
+    endif()
+
+    ament_add_gtest(grid_test_target test/grid_test.cpp)
+    if(TARGET grid_test_target)
+      target_link_libraries(grid_test_target
+        rviz_ogre_vendor::OgreMain
+        rviz_rendering
+        Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      )
+    endif()
+    ament_add_gtest(movable_text_test_target test/movable_text_test.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
+      PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET movable_text_test_target)
+      target_link_libraries(movable_text_test_target
+        rviz_ogre_vendor::OgreMain
+        rviz_ogre_vendor::OgreOverlay
+        rviz_rendering
+        Qt5::Widgets
+      )
+    endif()
+  endif()
 endif()
 
 list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -187,7 +187,8 @@ if(BUILD_TESTING)
   if(WIN32 OR APPLE OR DISPLAYPRESENT)
     message(STATUS "Enabling tests requiring a display")
 
-    ament_add_gtest(point_cloud_test_target test/point_cloud_test.cpp)
+    ament_add_gtest(point_cloud_test_target test/point_cloud_test.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET point_cloud_test_target)
       target_link_libraries(point_cloud_test_target
         rviz_ogre_vendor::OgreMain
@@ -196,7 +197,8 @@ if(BUILD_TESTING)
       )
     endif()
 
-    ament_add_gtest(point_cloud_renderable_test_target test/point_cloud_renderable_test.cpp)
+    ament_add_gtest(point_cloud_renderable_test_target test/point_cloud_renderable_test.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET point_cloud_renderable_test_target)
       target_link_libraries(point_cloud_renderable_test_target
         rviz_ogre_vendor::OgreMain

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -7,6 +7,9 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+option(EnableDisplayTests "EnableDisplayTests")
+set(DisplayTests "False" CACHE STRING "DisplayTestsVariable")
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
@@ -184,7 +187,7 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT TRUE)
   endif()
 
-  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "TRUE")
     message(STATUS "Enabling tests requiring a display")
 
     ament_add_gtest(point_cloud_test_target test/point_cloud_test.cpp
@@ -226,6 +229,7 @@ if(BUILD_TESTING)
         Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
       )
     endif()
+
     ament_add_gtest(movable_text_test_target test/movable_text_test.cpp
       APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET movable_text_test_target)

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -207,7 +207,8 @@ if(BUILD_TESTING)
       )
     endif()
 
-    ament_add_gtest(billboard_line_test_target test/billboard_line_test.cpp)
+    ament_add_gtest(billboard_line_test_target test/billboard_line_test.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET billboard_line_test_target)
       target_link_libraries(billboard_line_test_target
         rviz_ogre_vendor::OgreMain
@@ -216,7 +217,8 @@ if(BUILD_TESTING)
       )
     endif()
 
-    ament_add_gtest(grid_test_target test/grid_test.cpp)
+    ament_add_gtest(grid_test_target test/grid_test.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET grid_test_target)
       target_link_libraries(grid_test_target
         rviz_ogre_vendor::OgreMain
@@ -225,8 +227,7 @@ if(BUILD_TESTING)
       )
     endif()
     ament_add_gtest(movable_text_test_target test/movable_text_test.cpp
-      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
-      PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET movable_text_test_target)
       target_link_libraries(movable_text_test_target
         rviz_ogre_vendor::OgreMain

--- a/rviz_rendering/include/rviz_rendering/objects/shape.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/shape.hpp
@@ -36,6 +36,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 
 #include <OgreMaterial.h>

--- a/rviz_rendering/src/rviz_rendering/objects/shape.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/shape.cpp
@@ -36,6 +36,7 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+# pragma GCC diagnostic ignored "-Wpedantic"
 #else
 # pragma warning(push)
 # pragma warning(disable:4996)

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -109,9 +109,11 @@ RenderWindowImpl::RenderWindowImpl(QWindow * parent)
 
 RenderWindowImpl::~RenderWindowImpl()
 {
-  Ogre::Root::getSingletonPtr()->detachRenderTarget(ogre_render_window_);
-  ogre_render_window_->destroy();
-  // enableStereo(false);  // free stereo resources
+  if (ogre_render_window_) {
+    Ogre::Root::getSingletonPtr()->detachRenderTarget(ogre_render_window_);
+    ogre_render_window_->destroy();
+    // enableStereo(false);  // free stereo resources
+  }
 }
 
 void

--- a/rviz_rendering/test/grid_test.cpp
+++ b/rviz_rendering/test/grid_test.cpp
@@ -38,7 +38,7 @@
 #include <OgreRoot.h>
 
 #include "test/rviz_rendering/ogre_testing_environment.hpp"
-#include "rviz_rendering/grid.hpp"
+#include "rviz_rendering/objects/grid.hpp"
 #include "rviz_rendering/objects/billboard_line.hpp"
 
 class GridTestFixture : public ::testing::Test

--- a/rviz_rendering/test/movable_text_test.cpp
+++ b/rviz_rendering/test/movable_text_test.cpp
@@ -68,9 +68,9 @@ float getCharWidth(std::shared_ptr<rviz_rendering::MovableText> movable_text, ch
 
 void assertVector3Equality(Ogre::Vector3 actual, Ogre::Vector3 expected)
 {
-  ASSERT_NEAR(actual.x, expected.x, 0.0001);
-  ASSERT_NEAR(actual.y, expected.y, 0.0001);
-  ASSERT_NEAR(actual.z, expected.z, 0.0001);
+  ASSERT_NEAR(actual.x, expected.x, 0.0001f);
+  ASSERT_NEAR(actual.y, expected.y, 0.0001f);
+  ASSERT_NEAR(actual.z, expected.z, 0.0001f);
 }
 void assertBoundingBoxEquality(Ogre::AxisAlignedBox actual, Ogre::AxisAlignedBox expected)
 {
@@ -111,7 +111,7 @@ TEST_F(MovableTextTestFixture, new_line_creates_a_new_line_making_bounding_box_l
 }
 
 TEST_F(MovableTextTestFixture, larger_char_height_makes_characters_wider) {
-  auto movable_text = std::make_shared<rviz_rendering::MovableText>("A", "Liberation Sans", 2.0);
+  auto movable_text = std::make_shared<rviz_rendering::MovableText>("A", "Liberation Sans", 2.0f);
 
   float char_width = getCharWidth(movable_text, 'A');
   assertBoundingBoxEquality(movable_text->getBoundingBox(),

--- a/rviz_rendering/test/movable_text_test.cpp
+++ b/rviz_rendering/test/movable_text_test.cpp
@@ -33,10 +33,22 @@
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+#else
+# pragma warning(push)
+# pragma warning(disable : 4251)
+#endif
 #include <OgreMovableObject.h>
 #include <OgreFont.h>
 #include <OgreFontManager.h>
 #include <OgreVector3.h>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 #include "test/rviz_rendering/ogre_testing_environment.hpp"
 #include "rviz_rendering/objects/movable_text.hpp"
@@ -164,7 +176,7 @@ TEST_F(MovableTextTestFixture, vertical_alignment_above_puts_y_coordinate_above)
 
   float char_width = getCharWidth(movable_text, 'W');
   assertBoundingBoxEquality(movable_text->getBoundingBox(),
-    Ogre::AxisAlignedBox(Ogre::Vector3(0, 0, 0), Ogre::Vector3(char_width, 4.01, 0)));
+    Ogre::AxisAlignedBox(Ogre::Vector3(0, 0, 0), Ogre::Vector3(char_width, 4.01f, 0)));
 }
 
 TEST_F(MovableTextTestFixture, setSpaceWidth_changes_width_of_space_character) {

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -50,26 +50,37 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_index_cpp REQUIRED)
 
-  # TODO(Martin-Idel-SI): reenable when this test is can run on CI
-  # ament_add_gmock(mesh_loader_test_target
-  #   test/mesh_loader_test.cpp
-  #   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-  # if(TARGET mesh_loader_test_target)
-  #   target_link_libraries(mesh_loader_test_target
-  #     rviz_ogre_vendor::OgreMain
-  #     rviz_rendering::rviz_rendering
-  #     resource_retriever::resource_retriever
-  #   )
-  #   ament_target_dependencies(mesh_loader_test_target
-  #     rviz_assimp_vendor)
-  # endif()
+  if($ENV{DISPLAY})
+    set(DISPLAYPRESENT TRUE)
+  else()
+    set(DISPLAYPRESENT FALSE)
+  endif()
 
-  # TODO(wjwwood): reenable when this test is can run on CI
-  # ament_add_gtest(test_rviz_rendering_tests test/test_rviz_ogre_media_exports.cpp)
-  # if(TARGET test_rviz_rendering_tests)
-  #   target_include_directories(test_rviz_rendering_tests PUBLIC src/rviz_rendering_tests)
-  #   target_link_libraries(test_rviz_rendering_tests ament_index_cpp::ament_index_cpp)
-  # endif()
+  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+    message(STATUS "Enabling tests requiring a display")
+
+    ament_add_gmock(mesh_loader_test_target
+      test/mesh_loader_test.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET mesh_loader_test_target)
+      target_link_libraries(mesh_loader_test_target
+        rviz_ogre_vendor::OgreMain
+        rviz_rendering::rviz_rendering
+        resource_retriever::resource_retriever
+      )
+      ament_target_dependencies(mesh_loader_test_target
+        rviz_assimp_vendor)
+    endif()
+
+    ament_add_gtest(test_rviz_rendering_tests
+      test/test_rviz_ogre_media_exports.cpp)
+    if(TARGET test_rviz_rendering_tests)
+      target_include_directories(test_rviz_rendering_tests
+        PUBLIC src/rviz_rendering_tests)
+      target_link_libraries(test_rviz_rendering_tests
+        ament_index_cpp::ament_index_cpp)
+    endif()
+  endif()
 endif()
 
 ament_package()

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -73,7 +73,8 @@ if(BUILD_TESTING)
     endif()
 
     ament_add_gtest(test_rviz_rendering_tests
-      test/test_rviz_ogre_media_exports.cpp)
+      test/test_rviz_ogre_media_exports.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET test_rviz_rendering_tests)
       target_include_directories(test_rviz_rendering_tests
         PUBLIC src/rviz_rendering_tests)

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -7,6 +7,9 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+option(EnableDisplayTests "EnableDisplayTests")
+set(DisplayTests "False" CACHE STRING "DisplayTestsVariable")
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
@@ -56,7 +59,7 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT FALSE)
   endif()
 
-  if(WIN32 OR APPLE OR DISPLAYPRESENT)
+  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
     message(STATUS "Enabling tests requiring a display")
 
     ament_add_gmock(mesh_loader_test_target


### PR DESCRIPTION
This is a followup for #175 . It aims to fix all display tests and run them when possible.

- In order to not introduce visibility control in `rviz_default_plugins`, we need to build the library both static and shared. Apparently, includes are handled differently in that way, as the static building generates a lot of OGRE and pluginlib warnings on both Windows and Linux.
- To run tests, we try to decide whether OpenGL exists via CMake.