### PR TITLE
Default initialize forced_hidden

### DIFF
--- a/rviz_common/src/rviz_common/panel_dock_widget.cpp
+++ b/rviz_common/src/rviz_common/panel_dock_widget.cpp
@@ -41,7 +41,8 @@ namespace rviz_common
 
 PanelDockWidget::PanelDockWidget(const QString & name)
 : QDockWidget(name),
-  collapsed_(false)
+  collapsed_(false),
+  forced_hidden_(false)
 {
   QWidget * title_bar = new QWidget(this);
 


### PR DESCRIPTION
On Windows compiling with VS2015, we can't expand any of the dock widget panels.
This fixes this problem.