### PR TITLE
point to the source and bugtracker used in ros2 rather than the upstr…

### DIFF
--- a/rviz2/package.xml
+++ b/rviz2/package.xml
@@ -12,9 +12,9 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <url type="website">http://ros.org/wiki/rviz2</url>
-  <url type="repository">https://github.com/ros-visualization/rviz</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rviz/issues</url>
+  <!--url type="website">http://ros.org/wiki/rviz2</url-->
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -11,9 +11,9 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <url type="website">http://ros.org/wiki/rviz_common</url>
-  <url type="repository">https://github.com/ros-visualization/rviz</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rviz/issues</url>
+  <!--url type="website">http://ros.org/wiki/rviz_common</url-->
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -11,9 +11,9 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <url type="website">http://ros.org/wiki/rviz_default_plugins</url>
-  <url type="repository">https://github.com/ros-visualization/rviz</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rviz/issues</url>
+  <!--url type="website">http://ros.org/wiki/rviz_default_plugins</url-->
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -11,9 +11,9 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <url type="website">http://ros.org/wiki/rviz_rendering</url>
-  <url type="repository">https://github.com/ros-visualization/rviz</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rviz/issues</url>
+  <!--url type="website">http://ros.org/wiki/rviz_rendering</url-->
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
…eam one

Could be considered for ardent patch release as well

Note I didn't update the deprecated rviz package's manifest