### PR TITLE
Fix rviz crash when removing a display

### DIFF
--- a/rviz_common/include/rviz_common/properties/display_group_visibility_property.hpp
+++ b/rviz_common/include/rviz_common/properties/display_group_visibility_property.hpp
@@ -86,9 +86,8 @@ public:
   virtual void update();
 
 public Q_SLOTS:
-  void onDisplayAdded(rviz_common::Display * display);
-
-  void onDisplayRemoved(rviz_common::Display * display);
+  void onDisplayAdded(Display * display);
+  void onDisplayRemoved(Display * display);
 
 private:
   // sort the properties in the same way as in the
@@ -96,7 +95,7 @@ private:
   void sortDisplayList();
 
   DisplayGroup * display_group_;
-  std::map<rviz_common::Display *, DisplayVisibilityProperty *> disp_vis_props_;
+  std::map<Display *, DisplayVisibilityProperty *> disp_vis_props_;
   Display * parent_display_;
 };
 

--- a/rviz_common/src/rviz_common/properties/display_group_visibility_property.cpp
+++ b/rviz_common/src/rviz_common/properties/display_group_visibility_property.cpp
@@ -64,10 +64,12 @@ DisplayGroupVisibilityProperty::DisplayGroupVisibilityProperty(
   display_group_(display_group),
   parent_display_(parent_display)
 {
-  connect(display_group, SIGNAL(displayAdded(rviz::Display *)), this,
-    SLOT(onDisplayAdded(rviz::Display *)));
-  connect(display_group, SIGNAL(displayRemoved(rviz::Display *)), this,
-    SLOT(onDisplayRemoved(rviz::Display *)));
+  connect(
+    display_group, SIGNAL(displayAdded(Display *)),
+    this, SLOT(onDisplayAdded(Display *)));
+  connect(
+    display_group, SIGNAL(displayRemoved(Display *)),
+    this, SLOT(onDisplayRemoved(Display *)));
 
   for (int i = 0; i < display_group->numDisplays(); i++) {
     rviz_common::Display * display = display_group->getDisplayAt(i);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -98,7 +98,7 @@ CameraDisplay::CameraDisplay()
   image_position_property_ = new rviz_common::properties::EnumProperty(
     "Image Rendering", BOTH,
     "Render the image behind all other geometry or overlay it on top, or both.",
-    this, SLOT(forceRender()));
+    this);
   image_position_property_->addOption(BACKGROUND);
   image_position_property_->addOption(OVERLAY);
   image_position_property_->addOption(BOTH);
@@ -113,7 +113,7 @@ CameraDisplay::CameraDisplay()
   zoom_property_ = new rviz_common::properties::FloatProperty(
     "Zoom Factor", 1.0f,
     "Set a zoom factor below 1 to see a larger part of the world, above 1 to magnify the image.",
-    this, SLOT(forceRender()));
+    this);
   zoom_property_->setMin(0.00001f);
   zoom_property_->setMax(100000.0f);
 }


### PR DESCRIPTION
The crash occurred when adding a camera display and then deleting any display that was created before adding the camera display.

Cleaning up the signals and slots fixes this.