### PR TITLE
print message to stdout instead of stderr

### DIFF
--- a/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
+++ b/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
@@ -54,8 +54,8 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
     endif()
 
     add_library(rviz_ogre_vendor::OgreMain UNKNOWN IMPORTED)
-    message("rviz_ogre_vendor::OgreMain for IMPORTED_LOCATION_RELEASE: ${_ogre_main_static_library_abs}")
-    message("rviz_ogre_vendor::OgreMain for IMPORTED_LOCATION_DEBUG: ${_ogre_main_static_library_debug_abs}")
+    message(STATUS "rviz_ogre_vendor::OgreMain for IMPORTED_LOCATION_RELEASE: ${_ogre_main_static_library_abs}")
+    message(STATUS "rviz_ogre_vendor::OgreMain for IMPORTED_LOCATION_DEBUG: ${_ogre_main_static_library_debug_abs}")
     set_target_properties(rviz_ogre_vendor::OgreMain
       PROPERTIES
         IMPORTED_LOCATION_RELEASE ${_ogre_main_static_library_abs}
@@ -156,8 +156,8 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
     endif()
 
     add_library(rviz_ogre_vendor::OgreOverlay UNKNOWN IMPORTED)
-    message("rviz_ogre_vendor::OgreOverlay for IMPORTED_LOCATION_RELEASE: ${_ogre_overlay_static_library_abs}")
-    message("rviz_ogre_vendor::OgreOverlay for IMPORTED_LOCATION_DEBUG: ${_ogre_overlay_static_library_debug_abs}")
+    message(STATUS "rviz_ogre_vendor::OgreOverlay for IMPORTED_LOCATION_RELEASE: ${_ogre_overlay_static_library_abs}")
+    message(STATUS "rviz_ogre_vendor::OgreOverlay for IMPORTED_LOCATION_DEBUG: ${_ogre_overlay_static_library_debug_abs}")
     set_target_properties(rviz_ogre_vendor::OgreOverlay
       PROPERTIES
         IMPORTED_LOCATION_RELEASE ${_ogre_overlay_static_library_abs}
@@ -208,8 +208,8 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
     endif()
 
     add_library(rviz_ogre_vendor::RenderSystem_GL UNKNOWN IMPORTED)
-    message("rviz_ogre_vendor::RenderSystem_GL for IMPORTED_LOCATION_RELEASE: ${_render_system_gl_static_library_abs}")
-    message("rviz_ogre_vendor::RenderSystem_GL for IMPORTED_LOCATION_DEBUG: ${_render_system_gl_static_library_debug_abs}")
+    message(STATUS "rviz_ogre_vendor::RenderSystem_GL for IMPORTED_LOCATION_RELEASE: ${_render_system_gl_static_library_abs}")
+    message(STATUS "rviz_ogre_vendor::RenderSystem_GL for IMPORTED_LOCATION_DEBUG: ${_render_system_gl_static_library_debug_abs}")
     set_target_properties(rviz_ogre_vendor::RenderSystem_GL
       PROPERTIES
         IMPORTED_LOCATION_RELEASE ${_render_system_gl_static_library_abs}
@@ -260,8 +260,8 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
     endif()
 
     add_library(rviz_ogre_vendor::OgreGLSupport UNKNOWN IMPORTED)
-    message("rviz_ogre_vendor::OgreGLSupport for IMPORTED_LOCATION_RELEASE: ${_ogre_gl_support_static_library_abs}")
-    message("rviz_ogre_vendor::OgreGLSupport for IMPORTED_LOCATION_DEBUG: ${_ogre_gl_support_static_library_debug_abs}")
+    message(STATUS "rviz_ogre_vendor::OgreGLSupport for IMPORTED_LOCATION_RELEASE: ${_ogre_gl_support_static_library_abs}")
+    message(STATUS "rviz_ogre_vendor::OgreGLSupport for IMPORTED_LOCATION_DEBUG: ${_ogre_gl_support_static_library_debug_abs}")
     set_target_properties(rviz_ogre_vendor::OgreGLSupport
       PROPERTIES
         IMPORTED_LOCATION_RELEASE ${_ogre_gl_support_static_library_abs}


### PR DESCRIPTION
To avoid `stderr` output.