### PR TITLE
Fix segfault on adding image displays after deleting them

### DIFF
--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -109,6 +109,8 @@ RenderWindowImpl::RenderWindowImpl(QWindow * parent)
 
 RenderWindowImpl::~RenderWindowImpl()
 {
+  Ogre::Root::getSingletonPtr()->detachRenderTarget(ogre_render_window_);
+  ogre_render_window_->destroy();
   // enableStereo(false);  // free stereo resources
 }
 


### PR DESCRIPTION
Ogre needs to cleanup all resources before the pointer can be deleted.