### PR TITLE
Fix warnings from pluginlib

### DIFF
--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -1,4 +1,4 @@
-<library path="librviz_default_plugins">
+<library path="rviz_default_plugins">
 
   <!-- Displays plugins -->
 


### PR DESCRIPTION
The new pluginlib doesn't want to have a name starting with "lib" as this is Linux specific. It only produces a warning. 