### PR TITLE
Disable anti aliasing on Windows

### DIFF
--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -69,8 +69,16 @@ namespace rviz_rendering
 Ogre::GLPlugin * RenderSystem::render_system_gl_plugin_ = nullptr;
 RenderSystem * RenderSystem::instance_ = nullptr;
 int RenderSystem::force_gl_version_ = 0;
-bool RenderSystem::use_anti_aliasing_ = true;
 bool RenderSystem::force_no_stereo_ = false;
+
+// Disable anti aliasing on Windows for now,
+// since it breaks rendering as soon as two render windows are visible
+// TODO(greimela): Investigate why anti aliasing breaks rendering on Windows
+#ifndef _WIN32
+bool RenderSystem::use_anti_aliasing_ = true;
+#else
+bool RenderSystem::use_anti_aliasing_ = false;
+#endif
 
 RenderSystem *
 RenderSystem::get()


### PR DESCRIPTION
This fixes rendering issues on Windows when opening two or more render windows.

This is how the issue looks like:
![rviz_broken](https://user-images.githubusercontent.com/31658255/35870902-24e34cd0-0b63-11e8-93de-3c15a1ac98e8.PNG)
