### PR TITLE
Change the default position of the camera in RenderPanel.

### DIFF
--- a/rviz_common/include/rviz_common/render_panel.hpp
+++ b/rviz_common/include/rviz_common/render_panel.hpp
@@ -36,6 +36,7 @@
 #include <mutex>
 #include <vector>
 
+#include <OgreVector3.h>
 #include <QWidget>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/visibility_control.hpp"
@@ -95,6 +96,7 @@ public:
    */
   QSize
   sizeHint() const override;
+  static const Ogre::Vector3 default_camera_pose_;
 
 // TODO(wjwwood): reenable these and pass down to rviz_rendering::RenderWindow
 #if 0

--- a/rviz_common/src/rviz_common/render_panel.cpp
+++ b/rviz_common/src/rviz_common/render_panel.cpp
@@ -31,7 +31,7 @@
 #include "rviz_common/render_panel.hpp"
 
 #include <memory>
-#include <sstream>
+#include <string>
 
 #include <OgreCamera.h>
 #include <OgreSceneManager.h>
@@ -104,12 +104,12 @@ void RenderPanel::initialize(DisplayContext * context, bool use_main_scene)
   if (use_main_scene) {
     rviz_rendering::RenderWindowOgreAdapter::setSceneManager(
       render_window_, context_->getSceneManager());
-    std::stringstream ss;
+    std::string camera_name;
     static int count = 0;
-    ss << "RenderPanelCamera" << count++;
-    auto default_camera_ = context_->getSceneManager()->createCamera(ss.str());
+    camera_name = "RenderPanelCamera" + std::to_string(count++);
+    auto default_camera_ = context_->getSceneManager()->createCamera(camera_name);
     default_camera_->setNearClipDistance(0.01f);
-    default_camera_->setPosition(Ogre::Vector3(0, 10, 15));
+    default_camera_->setPosition(default_camera_pose_);
     default_camera_->lookAt(Ogre::Vector3(0, 0, 0));
 
     rviz_rendering::RenderWindowOgreAdapter::setOgreCamera(render_window_, default_camera_);
@@ -287,6 +287,8 @@ RenderPanel::sizeHint() const
 {
   return QSize(320, 240);
 }
+
+const Ogre::Vector3 RenderPanel::default_camera_pose_ = Ogre::Vector3(999999, 999999, 999999);
 
 #if 0
 void RenderPanel::showContextMenu(std::shared_ptr<QMenu> menu)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -328,7 +328,7 @@ void CameraDisplay::clear()
     "Topic may not exist.");
 
   rviz_rendering::RenderWindowOgreAdapter::getOgreCamera(
-    render_panel_->getRenderWindow())->setPosition(Ogre::Vector3(999999, 999999, 999999));
+    render_panel_->getRenderWindow())->setPosition(rviz_common::RenderPanel::default_camera_pose_);
 }
 
 void CameraDisplay::update(float wall_dt, float ros_dt)


### PR DESCRIPTION
- Current behaviour: when adding a new camera display, the grid is displayed in the associated widget, but if you detach the widget or close and then reopen the displays panel, the grid is gone, because the position of the camera of the associated render panel is reset to the value`Ogre::Vector3(999999, 999999, 999999)`. 

- New behaviour: with these changes the position of the camera is set to that value from the beginning, so that when the camera display is added, the grid is not displayed.