### PR TITLE
remove ogre-master timeout

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -124,7 +124,6 @@ macro(build_ogre)
   ExternalProject_Add(ogre-master-ca665a6
     URL https://github.com/OGRECave/ogre/archive/v1.10.11.zip
     URL_MD5 6ffd5048fae72805e287bfc0b462b2ea
-    TIMEOUT 600
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}
     CMAKE_ARGS


### PR DESCRIPTION
The 10 minute timeout meant internet connections slower than ~300kb/s couldn't build this project. Timeout is removed. Fixes #230.