### PR TITLE
Add missing dependency on urdf

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(visualization_msgs REQUIRED)
 # find_package(tf2 REQUIRED)
 # find_package(tf2_geometry_msgs REQUIRED)
 # find_package(tf2_ros REQUIRED)
+find_package(urdf REQUIRED)
 
 # These need to be added in the add_library() call so AUTOMOC detects them.
 set(rviz_default_plugins_headers_to_moc
@@ -116,6 +117,7 @@ ament_target_dependencies(rviz_default_plugins
   # geometry_msgs
   rclcpp
   resource_retriever
+  urdf
   visualization_msgs
   # tf2
   # tf2_geometry_msgs

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -28,6 +28,7 @@
   <depend>rclcpp</depend>
   <depend>rviz_common</depend>
   <depend>rviz_rendering</depend>
+  <depend>urdf</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>


### PR DESCRIPTION
Follow-up of #210.

RViz doesn't build on my machine as it finds the system urdfdom headers (that uses boost::shared_ptr, located in `/usr/include/`) instead of the one built in ROS 2.
```
In file included from /home/mikael/work/ros2/current_ws/src/ros2/urdf/urdf/include/urdf/model.h:45:0,
                 from /home/mikael/work/ros2/current_ws/src/ros2/rviz/rviz_default_plugins/src/rviz_default_plugins/robot/robot.hpp:41,
                 from /home/mikael/work/ros2/current_ws/src/ros2/rviz/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp:31:
/home/mikael/work/ros2/current_ws/build_debug_isolated/urdf/include/urdf/urdfdom_compatibility.h:97:41: error: conflicting declaration ‘typedef class std::shared_ptr<urdf::ModelInterface> urdf::ModelInterfaceSharedPtr’
 typedef std::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
                                         ^
In file included from /home/mikael/work/ros2/current_ws/build_debug_isolated/urdf/include/urdf/urdfdom_compatibility.h:93:0,
                 from /home/mikael/work/ros2/current_ws/src/ros2/urdf/urdf/include/urdf/model.h:45,
                 from /home/mikael/work/ros2/current_ws/src/ros2/rviz/rviz_default_plugins/src/rviz_default_plugins/robot/robot.hpp:41,
                 from /home/mikael/work/ros2/current_ws/src/ros2/rviz/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp:31:
/usr/include/urdf_world/types.h:48:43: note: previous declaration as ‘typedef class boost::shared_ptr<urdf::ModelInterface> urdf::ModelInterfaceSharedPtr’
 typedef boost::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
```
Adding the dependency on urdf in the package including urdf headers fixed the issue for me. Though I didnt look into it in details and maybe more is needed (the urdf dependency should be exported? the dependency should come from another package ? ...)
