### PR TITLE
Disable Ogre deprecation warning on Windows

### DIFF
--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
@@ -33,7 +33,14 @@
 #include <memory>
 #include <vector>
 
-#include <Ogre.h> // NOLINT
+#ifdef _WIN32
+# pragma warning(push)
+# pragma warning(disable : 4996)
+#  include <Ogre.h>  // NOLINT
+# pragma warning(pop)
+#else
+# include <Ogre.h>  // NOLINT
+#endif
 
 #include "sensor_msgs/image_encodings.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
@@ -36,10 +36,12 @@
 #ifdef _WIN32
 # pragma warning(push)
 # pragma warning(disable : 4996)
-#  include <Ogre.h>  // NOLINT
+#endif
+
+#include <Ogre.h>  // NOLINT
+
+#ifdef _WIN32
 # pragma warning(pop)
-#else
-# include <Ogre.h>  // NOLINT
 #endif
 
 #include "sensor_msgs/image_encodings.hpp"


### PR DESCRIPTION
The Windows build currently shows a deprecation warning in Ogre when building with Visual Studio 2017.