### PR TITLE
hack to fix urdf include dirs again

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -229,6 +229,7 @@ if(BUILD_TESTING)
     find_package(visualization_msgs REQUIRED)
 
     set(TEST_INCLUDE_DIRS
+      ${urdf_INCLUDE_DIRS}
       ${rviz_common_INCLUDE_DIRS}
       ${rviz_rendering_INCLUDE_DIRS}
       ${OGRE_INCLUDE_DIRS}
@@ -237,7 +238,6 @@ if(BUILD_TESTING)
       ${sensor_msgs_INCLUDE_DIRS}
       ${visualization_msgs_INCLUDE_DIRS}
       ${Qt5Widgets_INCLUDE_DIRS}
-      ${urdf_INCLUDE_DIRS}
     )
 
     set(TEST_LINK_LIBRARIES


### PR DESCRIPTION
Similar as #234. This was broken again by #186.

This is only a hack to get the build passing again (when `urdf` is installed on the system and the headers are found in `/usr/include`).

This needs a real fix and the use case should be tested for before future PRs are being merged. @mikaelarguedas already mentioned that in his PR.