### PR TITLE
 Generalize visual testing post build command

### DIFF
--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -139,7 +139,7 @@ if(BUILD_TESTING)
         add_custom_command(TARGET example_test
           POST_BUILD
           COMMAND
-          bash -c "${qt5_install_prefix}/bin/windeployqt.exe ${CMAKE_CURRENT_BINARY_DIR}/Release")
+          cmd /C "${qt5_install_prefix}/bin/windeployqt.exe ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
       endif()
     endif()
   endif()

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -139,7 +139,7 @@ if(BUILD_TESTING)
         add_custom_command(TARGET example_test
           POST_BUILD
           COMMAND
-          cmd /C "${qt5_install_prefix}/bin/windeployqt.exe ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
+          cmd /C "${qt5_install_prefix}/bin/windeployqt.exe $<TARGET_FILE_DIR:example_test>")
       endif()
     endif()
   endif()


### PR DESCRIPTION
The previous command assumed that a `bash` is installed on Windows and that it always builds in Release mode.