### PR TITLE
Change logic to get property indices

### DIFF
--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/page_objects/base_page_object.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/page_objects/base_page_object.hpp
@@ -57,10 +57,16 @@ public:
   void collapse();
 
 protected:
-  void setString(QString property_name, QString value_to_set, int property_row_index);
-  void setComboBox(QString property_name, QString value_to_set, int property_row_index);
+  int findPropertyRowIndexByName(
+    const QString & property_name, QModelIndex relative_display_index);
+
+  void setString(const QString & property_name, const QString & value_to_set);
+  void setComboBox(const QString & property_name, const QString & value_to_set);
   void setBool(
-    QString property_name, bool value_to_set, int property_row_index, int sub_property_index = -1);
+    const QString & main_property_name,
+    bool value_to_set,
+    int sub_property_index = -1,
+    const QString & sub_property_name = "");
 
   int display_id_;
   int display_category_;
@@ -68,10 +74,7 @@ protected:
   std::shared_ptr<Executor> executor_;
 
 private:
-  bool checkPropertyName(
-    QString expected_property_name, int property_row_index, QModelIndex display_index);
-  void failIfPropertyIsAbsent(
-    QString property_name, int property_row_index, QModelIndex parent_index);
+  void failForAbsentProperty(const QString & property_name);
   void clickOnTreeItem(QModelIndex item_index) const;
   void doubleClickOnTreeItem(QModelIndex item_index) const;
   QModelIndex getRelativeIndexAndExpandDisplay();
@@ -80,7 +83,7 @@ private:
   QModelIndex getPropertyToChangeIndex(
     int property_row_index, const QModelIndex & parent_index) const;
   QModelIndex getMainPropertyIndex(
-    QString property_name, int property_row_index, QModelIndex display_index);
+    const QString & property_name, int property_row_index, QModelIndex display_index);
   QModelIndex getSubPropertyIndex(
     QString property_name,
     int main_property_index,

--- a/rviz_visual_testing_framework/src/page_objects/camera_display_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/camera_display_page_object.cpp
@@ -49,58 +49,42 @@ CameraDisplayPageObject::CameraDisplayPageObject(
 void CameraDisplayPageObject::setDisplayVisibilityInRenderWindow(
   QString display_name, int relative_row_index, bool display_visibility)
 {
-  int property_row_index = 1;
-
-  setBool(display_name, display_visibility, property_row_index, relative_row_index);
+  setBool("Visibility", display_visibility, relative_row_index, display_name);
 }
 
 void CameraDisplayPageObject::setTopic(QString topic)
 {
-  int property_row_index = 2;
-
-  setComboBox("Topic", topic, property_row_index);
+  setComboBox("Topic", topic);
 }
 
 void CameraDisplayPageObject::setUnreliable(bool unreliable)
 {
-  int property_row_index = 3;
-
-  setBool("Unreliable", unreliable, property_row_index);
+  setBool("Unreliable", unreliable);
 }
 
 void CameraDisplayPageObject::setQueueSize(QString queue_size)
 {
-  int property_row_index = 4;
-
-  setString("Queue Size", queue_size, property_row_index);
+  setString("Queue Size", queue_size);
 }
 
 void CameraDisplayPageObject::setImageRendering(QString image_rendering)
 {
-  int property_row_index = 5;
-
-  setComboBox("Image Rendering", image_rendering, property_row_index);
+  setComboBox("Image Rendering", image_rendering);
 }
 
 void CameraDisplayPageObject::setOverlayAlpha(QString overlay_alpha)
 {
-  int property_row_index = 6;
-
-  setString("Overlay Alpha", overlay_alpha, property_row_index);
+  setString("Overlay Alpha", overlay_alpha);
 }
 
 void CameraDisplayPageObject::setZoomFacor(QString zoom_factor)
 {
-  int property_row_index = 7;
-
-  setString("Zoom Factor", zoom_factor, property_row_index);
+  setString("Zoom Factor", zoom_factor);
 }
 
 void CameraDisplayPageObject::setVisibility(bool visibility)
 {
-  int property_row_index = 1;
-
-  setBool("Visibility", visibility, property_row_index);
+  setBool("Visibility", visibility);
 }
 
 void CameraDisplayPageObject::setRenderWindow()

--- a/rviz_visual_testing_framework/src/page_objects/grid_display_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/grid_display_page_object.cpp
@@ -44,68 +44,50 @@ GridDisplayPageObject::GridDisplayPageObject(
 
 void GridDisplayPageObject::setReferenceFrame(QString reference_frame)
 {
-  int property_row_index = 1;
-
-  setComboBox("Reference Frame", reference_frame, property_row_index);
+  setComboBox("Reference Frame", reference_frame);
 }
 
 void GridDisplayPageObject::setPlaneCellCount(QString plane_cell_count)
 {
-  int property_row_index = 2;
-
-  setString("Plane Cell Count", plane_cell_count, property_row_index);
+  setString("Plane Cell Count", plane_cell_count);
 }
 
 void GridDisplayPageObject::setNormalCellCount(QString normal_cell_count)
 {
-  int property_row_index = 3;
-
-  setString("Normal Cell Count", normal_cell_count, property_row_index);
+  setString("Normal Cell count", normal_cell_count);
 }
 
 void GridDisplayPageObject::setCellSize(QString cell_size)
 {
-  int property_row_index = 4;
-
-  setString("Cell Size", cell_size, property_row_index);
+  setString("Cell Size", cell_size);
 }
 
 void GridDisplayPageObject::setLineStyle(QString line_style)
 {
-  int property_row_index = 5;
-
-  setComboBox("Line Style", line_style, property_row_index);
+  setComboBox("Line Style", line_style);
 }
 
 void GridDisplayPageObject::setColor(int red, int green, int blue)
 {
-  int property_row_index = 6;
-
   QString color_code = QString::fromStdString(
     std::to_string(red) + "; " + std::to_string(green) + "; " + std::to_string(blue));
 
-  setString("Color", color_code, property_row_index);
+  setString("Color", color_code);
 }
 
 void GridDisplayPageObject::setAlpha(QString alpha)
 {
-  int property_row_index = 7;
-
-  setString("Alpha", alpha, property_row_index);
+  setString("Alpha", alpha);
 }
 
 void GridDisplayPageObject::setPlane(QString plane)
 {
-  int property_row_index = 8;
-
-  setComboBox("Plane", plane, property_row_index);
+  setComboBox("Plane", plane);
 }
 
 void GridDisplayPageObject::setOffset(float x, float y, float z)
 {
-  int property_row_index = 9;
-
   QString offset_triple = format(x) + "; " + format(y) + "; " + format(z);
 
-  setString("Offset", offset_triple, property_row_index);
+  setString("Offset", offset_triple);
 }

--- a/rviz_visual_testing_framework/src/page_objects/image_display_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/image_display_page_object.cpp
@@ -54,21 +54,15 @@ void ImageDisplayPageObject::setRenderWindow()
 
 void ImageDisplayPageObject::setTopic(QString topic)
 {
-  int property_row_index = 1;
-
-  setComboBox("Topic", topic, property_row_index);
+  setComboBox("Topic", topic);
 }
 
 void ImageDisplayPageObject::setUnreliable(bool unreliable)
 {
-  int property_row_index = 2;
-
-  setBool("Unreliable", unreliable, property_row_index);
+  setBool("Unreliable", unreliable);
 }
 
 void ImageDisplayPageObject::setQueueSize(QString queue_size)
 {
-  int property_row_index = 3;
-
-  setString("Queue Size", queue_size, property_row_index);
+  setString("Queue Size", queue_size);
 }

--- a/rviz_visual_testing_framework/src/page_objects/point_cloud_display_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/point_cloud_display_page_object.cpp
@@ -44,82 +44,60 @@ PointCloudDisplayPageObject::PointCloudDisplayPageObject(
 
 void PointCloudDisplayPageObject::setSizeMeters(QString meters_size)
 {
-  int property_row_index = 6;
-
-  setString("Size (m)", meters_size, property_row_index);
+  setString("Size (m)", meters_size);
 }
 
 void PointCloudDisplayPageObject::setSizePixels(QString pixels_size)
 {
-  int property_row_index = 7;
-
-  setString("Size (Pixels)", pixels_size, property_row_index);
+  setString("Size (Pixels)", pixels_size);
 }
 
 void PointCloudDisplayPageObject::setStyle(QString points_style)
 {
-  int property_row_index = 5;
-
-  setComboBox("Style", points_style, property_row_index);
+  setComboBox("Style", points_style);
 }
 
 void PointCloudDisplayPageObject::setAlpha(QString alpha)
 {
-  int property_row_index = 8;
-
-  setString("Alpha", alpha, property_row_index);
+  setString("Alpha", alpha);
 }
 
 void PointCloudDisplayPageObject::setDecayTime(QString decay_time)
 {
-  int property_row_index = 9;
-
-  setString("Decay Time", decay_time, property_row_index);
+  setString("Decay Time", decay_time);
 }
 
 void PointCloudDisplayPageObject::setQueueSize(QString queue_size)
 {
-  int property_row_index = 3;
-
-  setString("Queue Size", queue_size, property_row_index);
+  setString("Queue Size", queue_size);
 }
 
 void PointCloudDisplayPageObject::setSelectable(bool selectable)
 {
-  int property_row_index = 4;
-
-  setBool("Selectable", selectable, property_row_index);
+  setBool("Selectable", selectable);
 }
 
 void PointCloudDisplayPageObject::setUnreliable(bool unreliable)
 {
-  int property_row_index = 2;
-
-  setBool("Unreliable", unreliable, property_row_index);
+  setBool("Unreliable", unreliable);
 }
 
 void PointCloudDisplayPageObject::setPositionTransformer(QString position_transformer)
 {
-  int property_row_index = 10;
-
-  setComboBox(
-    "Position Transformer", position_transformer, property_row_index);
+  setComboBox("Position Transformer", position_transformer);
 }
 
 void PointCloudDisplayPageObject::setColorTransformer(QString color_transformer)
 {
-  int property_row_index = 11;
-  setComboBox("Color Transformer", color_transformer, property_row_index);
+  setComboBox("Color Transformer", color_transformer);
 }
 
 void PointCloudDisplayPageObject::setColor(int red, int green, int blue)
 {
   setColorTransformer("FlatColorPCTransformer");
 
-  int property_row_index = 15;
-
   QString color_code = QString::fromStdString(
     std::to_string(red) + "; " + std::to_string(green) + "; " + std::to_string(blue));
 
-  setString("Color", color_code, property_row_index);
+  setString("Color", color_code);
 }

--- a/rviz_visual_testing_framework/src/page_objects/polygon_display_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/polygon_display_page_object.cpp
@@ -41,31 +41,23 @@ PolygonDisplayPageObject::PolygonDisplayPageObject(
 
 void PolygonDisplayPageObject::setTopic(QString topic)
 {
-  int property_row_index = 1;
-
-  setString("Topic", topic, property_row_index);
+  setString("Topic", topic);
 }
 
 void PolygonDisplayPageObject::setUnreliable(bool unreliable)
 {
-  int property_row_index = 2;
-
-  setBool("Unreliable", unreliable, property_row_index);
+  setBool("Unreliable", unreliable);
 }
 
 void PolygonDisplayPageObject::setColor(int red, int green, int blue)
 {
-  int property_row_index = 3;
-
   QString color_code = QString::fromStdString(
     std::to_string(red) + "; " + std::to_string(green) + "; " + std::to_string(blue));
 
-  setString("Color", color_code, property_row_index);
+  setString("Color", color_code);
 }
 
 void PolygonDisplayPageObject::setAlpha(QString alpha)
 {
-  int property_row_index = 4;
-
-  setString("Alpha", alpha, property_row_index);
+  setString("Alpha", alpha);
 }


### PR DESCRIPTION
Previously the index of the various display properties in the property tree was explicitly coded in the page objects. On top of being harder to maintain, this approach could also result in unstable tests.
With these changes, the property position in the tree is dynamically found using its name. 