### PR TITLE
Restore program options for RViz

### DIFF
--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -178,7 +178,7 @@ bool VisualizerApp::init(int argc, char ** argv)
 
   QCommandLineOption ogre_log_option(
     QStringList() << "l" << "ogre-log",
-    "Enable the Ogre.log file (output in cwd) and console output.");
+      "Enable the Ogre.log file (output in cwd) and console output.");
   parser.addOption(ogre_log_option);
 
   // TODO(botteroa-si): enable when possible
@@ -277,9 +277,9 @@ bool VisualizerApp::init(int argc, char ** argv)
   //
   // nh_.reset(new ros::NodeHandle);
   //
-   if (enable_ogre_log) {
-     rviz_rendering::OgreLogging::useLogFileAndStandardOut();
-   }
+  if (enable_ogre_log) {
+    rviz_rendering::OgreLogging::useLogFileAndStandardOut();
+  }
   //
   // if (force_gl_version) {
   //   RenderSystem::forceGlVersion(force_gl_version);

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -150,12 +150,6 @@ bool VisualizerApp::init(int argc, char ** argv)
 #endif
 #endif
 
-  // TODO(wjwwood): anonymous is not working right now, reenable later
-  // node_name_ = rviz_common::ros_integration::init(argc, argv, "rviz", true /* anonymous_name */);
-  node_name_ = ros_client_abstraction_->init(argc, argv, "rviz", false /* anonymous_name */);
-
-  startContinueChecker();
-
   rviz_common::install_rviz_rendering_log_handlers();
 
   QCommandLineParser parser;
@@ -222,6 +216,7 @@ bool VisualizerApp::init(int argc, char ** argv)
 
   try {
     parser.process(*app_);
+
     enable_ogre_log = parser.isSet(ogre_log_option);
 //    disable_stereo = parser.isSet(no_stereo_option);
 //    disable_anti_aliasing = parser.isSet(disable_anti_aliasing_option);
@@ -292,6 +287,12 @@ bool VisualizerApp::init(int argc, char ** argv)
   // if (disable_stereo) {
   //   RenderSystem::forceNoStereo();
   // }
+
+  startContinueChecker();
+
+  // TODO(wjwwood): anonymous is not working right now, reenable later
+  // node_name_ = rviz_common::ros_integration::init(argc, argv, "rviz", true /* anonymous_name */);
+  node_name_ = ros_client_abstraction_->init(argc, argv, "rviz", false /* anonymous_name */);
 
   frame_ = new VisualizationFrame(node_name_);
   frame_->setApp(this->app_);

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -209,21 +209,20 @@ bool VisualizerApp::init(int argc, char ** argv)
 //  bool disable_anti_aliasing = false;
 //  bool disable_stereo = false;
 
-  try {
-    parser.process(*app_);
+  parser.process(*app_);
 
-    enable_ogre_log = parser.isSet(ogre_log_option);
+  enable_ogre_log = parser.isSet(ogre_log_option);
 //    disable_stereo = parser.isSet(no_stereo_option);
 //    disable_anti_aliasing = parser.isSet(disable_anti_aliasing_option);
 
-    if (parser.isSet(display_config_option)) {
-      display_config = parser.value(display_config_option);
-    }
-    if (parser.isSet(fixed_frame_option)) {
-      fixed_frame = parser.value(fixed_frame_option);
-    }
+  if (parser.isSet(display_config_option)) {
+    display_config = parser.value(display_config_option);
+  }
+  if (parser.isSet(fixed_frame_option)) {
+    fixed_frame = parser.value(fixed_frame_option);
+  }
 
-    // TODO(botteroa-si): enable when possible
+  // TODO(botteroa-si): enable when possible
 //    if (parser.isSet(splash_screen_option)) {
 //      splash_path = parser.value(splash_screen_option);
 //    }
@@ -249,10 +248,6 @@ bool VisualizerApp::init(int argc, char ** argv)
 //       ros::console::notifyLoggerLevelsChanged();
 //     }
 //   }
-  } catch (std::exception & e) {
-    RVIZ_COMMON_LOG_ERROR_STREAM("Error parsing command line:" << e.what());
-    return false;
-  }
 
   //
   // if (!ros::master::check() ) {

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -43,9 +43,10 @@
 #include <QCommandLineOption>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 
-#include "rviz_common/logging.hpp"
-
 #include "rviz_common/interaction/selection_manager.hpp"
+#include "rviz_common/logging.hpp"
+#include "rviz_rendering/ogre_logging.hpp"
+
 #include "./visualization_frame.hpp"
 #include "./visualization_manager.hpp"
 
@@ -175,6 +176,11 @@ bool VisualizerApp::init(int argc, char ** argv)
     QStringList() << "v" << "verbose", "Enable debug visualizations");
   parser.addOption(verbose_option);
 
+  QCommandLineOption ogre_log_option(
+    QStringList() << "l" << "ogre-log",
+    "Enable the Ogre.log file (output in cwd) and console output.");
+  parser.addOption(ogre_log_option);
+
   // TODO(botteroa-si): enable when possible
 //  QCommandLineOption splash_screen_option(
 //    QStringList() << "s" << "splash-screen",
@@ -185,11 +191,6 @@ bool VisualizerApp::init(int argc, char ** argv)
 //  QCommandLineOption help_file_option(
 //    "help-file", "A custom html file to show as the help screen", "help_path");
 //  parser.addOption(help_file_option);
-//
-//  QCommandLineOption ogre_log_option(
-//    QStringList() << "l" << "ogre-log",
-//    "Enable the Ogre.log file (output in cwd) and console output.");
-//  parser.addOption(ogre_log_option);
 //
 //  QCommandLineOption open_gl_option(
 //    "opengl",
@@ -211,9 +212,9 @@ bool VisualizerApp::init(int argc, char ** argv)
 //   ("in-mc-wrapper", "Signal that this is running inside a master-chooser wrapper")
 
   QString display_config, fixed_frame, splash_path, help_path;
-  bool verbose = false;
+  bool verbose;
+  bool enable_ogre_log;
   // TODO(botteroa-si): enable when possible
-//  bool enable_ogre_log = false;
 //  bool in_mc_wrapper = false;
 //  int force_gl_version = 0;
 //  bool disable_anti_aliasing = false;
@@ -221,7 +222,7 @@ bool VisualizerApp::init(int argc, char ** argv)
 
   try {
     parser.process(*app_);
-//    enable_ogre_log = parser.isSet(ogre_log_option);
+    enable_ogre_log = parser.isSet(ogre_log_option);
 //    disable_stereo = parser.isSet(no_stereo_option);
 //    disable_anti_aliasing = parser.isSet(disable_anti_aliasing_option);
     verbose = parser.isSet(verbose_option);
@@ -276,9 +277,9 @@ bool VisualizerApp::init(int argc, char ** argv)
   //
   // nh_.reset(new ros::NodeHandle);
   //
-  // if (enable_ogre_log) {
-  //   OgreLogging::useRosLog();
-  // }
+   if (enable_ogre_log) {
+     rviz_rendering::OgreLogging::useLogFileAndStandardOut();
+   }
   //
   // if (force_gl_version) {
   //   RenderSystem::forceGlVersion(force_gl_version);

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -166,10 +166,6 @@ bool VisualizerApp::init(int argc, char ** argv)
     QStringList() << "f" << "fixed-frame", "Set the fixed frame", "fixed_frame");
   parser.addOption(fixed_frame_option);
 
-  QCommandLineOption verbose_option(
-    QStringList() << "v" << "verbose", "Enable debug visualizations");
-  parser.addOption(verbose_option);
-
   QCommandLineOption ogre_log_option(
     QStringList() << "l" << "ogre-log",
       "Enable the Ogre.log file (output in cwd) and console output.");
@@ -206,7 +202,6 @@ bool VisualizerApp::init(int argc, char ** argv)
 //   ("in-mc-wrapper", "Signal that this is running inside a master-chooser wrapper")
 
   QString display_config, fixed_frame, splash_path, help_path;
-  bool verbose;
   bool enable_ogre_log;
   // TODO(botteroa-si): enable when possible
 //  bool in_mc_wrapper = false;
@@ -220,7 +215,6 @@ bool VisualizerApp::init(int argc, char ** argv)
     enable_ogre_log = parser.isSet(ogre_log_option);
 //    disable_stereo = parser.isSet(no_stereo_option);
 //    disable_anti_aliasing = parser.isSet(disable_anti_aliasing_option);
-    verbose = parser.isSet(verbose_option);
 
     if (parser.isSet(display_config_option)) {
       display_config = parser.value(display_config_option);
@@ -259,7 +253,7 @@ bool VisualizerApp::init(int argc, char ** argv)
     RVIZ_COMMON_LOG_ERROR_STREAM("Error parsing command line:" << e.what());
     return false;
   }
-  
+
   //
   // if (!ros::master::check() ) {
   // TODO(wjwwood): figure out how to support the "wait for master" functionality
@@ -309,14 +303,10 @@ bool VisualizerApp::init(int argc, char ** argv)
   }
   frame_->initialize(display_config);
 
-<<<<<<< d49b17db4cf9ab1fe890fb74be239201d246e98c
-=======
   if (!fixed_frame.isEmpty()) {
     frame_->getManager()->setFixedFrame(fixed_frame);
   }
-  frame_->getManager()->getSelectionManager()->setDebugMode(verbose);
 
->>>>>>> Restore working program options
   frame_->show();
 
   // TODO(wjwwood): reenable the ROS service to reload the shaders via the ros_integration API

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -39,6 +39,8 @@
 // #include <OgreMaterialManager.h>
 
 #include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
+#include <QCommandLineParser>  // NOLINT: cpplint is unable to handle the include order here
+#include <QCommandLineOption>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/logging.hpp"
@@ -155,100 +157,113 @@ bool VisualizerApp::init(int argc, char ** argv)
 
   rviz_common::install_rviz_rendering_log_handlers();
 
-  // TODO(wjwwood): restore the program options without using Boost
-  // po::options_description options;
-  // options.add_options()
-  //   ("help,h", "Produce this help message")
-  //   ("splash-screen,s", po::value<std::string>(), "A custom splash-screen image to display")
-  //   ("help-file", po::value<std::string>(), "A custom html file to show as the help screen")
-  //   ("display-config,d", po::value<std::string>(), "A display config file (.rviz) to load")
-  //   ("fixed-frame,f", po::value<std::string>(), "Set the fixed frame")
-  //   ("ogre-log,l", "Enable the Ogre.log file (output in cwd) and console output.")
-  //   ("in-mc-wrapper", "Signal that this is running inside a master-chooser wrapper")
-  //   ("opengl", po::value<int>(),
-  //   "Force OpenGL version (use '--opengl 210' for OpenGL 2.1 compatibility mode)")
-  //   ("disable-anti-aliasing", "Prevent rviz from trying to use anti-aliasing when rendering.")
-  //   ("no-stereo", "Disable the use of stereo rendering.")
-  //   ("log-level-debug", "Sets the ROS logger level to debug.");
-  // po::variables_map vm;
-  // std::string display_config, fixed_frame, splash_path, help_path;
-  // bool enable_ogre_log = false;
-  // bool in_mc_wrapper = false;
-  // int force_gl_version = 0;
-  // bool disable_anti_aliasing = false;
-  // bool disable_stereo = false;
-  // try {
-  //   po::store(po::parse_command_line(argc, argv, options), vm);
-  //   po::notify(vm);
-  //
-  //   if (vm.count("help")) {
-  //     std::cout << "rviz command line options:\n" << options;
-  //     return false;
-  //   }
-  //
-  //   if (vm.count("in-mc-wrapper")) {
-  //     in_mc_wrapper = true;
-  //   }
-  //
-  //   if (vm.count("display-config")) {
-  //     display_config = vm["display-config"].as<std::string>();
-  //     if (display_config.substr(display_config.size() - 4, 4) == ".vcg") {
-  //       std::cerr << "ERROR: the config file '" << display_config <<
-  //         "' is a .vcg file, which is the old rviz config format." << std::endl;
-  //       std::cerr <<
-  //         "       New config files have a .rviz extension and use YAML formatting.  "
-  //         "The format changed"
-  //                 <<
-  //         std::endl;
-  //       std::cerr <<
-  //         "       between Fuerte and Groovy.  "
-  //         "There is not (yet) an automated conversion program."
-  //                 <<
-  //         std::endl;
-  //       return false;
-  //     }
-  //   }
-  //
-  //   if (vm.count("splash-screen")) {
-  //     splash_path = vm["splash-screen"].as<std::string>();
-  //   }
-  //
-  //   if (vm.count("help-file")) {
-  //     help_path = vm["help-file"].as<std::string>();
-  //   }
-  //
-  //   if (vm.count("fixed-frame")) {
-  //     fixed_frame = vm["fixed-frame"].as<std::string>();
-  //   }
-  //
-  //   if (vm.count("ogre-log")) {
-  //     enable_ogre_log = true;
-  //   }
-  //
-  //   if (vm.count("no-stereo")) {
-  //     disable_stereo = true;
-  //   }
-  //
-  //   if (vm.count("opengl")) {
-  //     //std::cout << vm["opengl"].as<std::string>() << std::endl;
-  //     force_gl_version = vm["opengl"].as<int>();
-  //   }
-  //
-  //   if (vm.count("disable-anti-aliasing")) {
-  //     disable_anti_aliasing = true;
-  //   }
-  //
-  //   if (vm.count("log-level-debug")) {
-  //     if (
-  //       ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug))
-  //     {
-  //       ros::console::notifyLoggerLevelsChanged();
-  //     }
-  //   }
-  // } catch (std::exception & e) {
-  //   ROS_ERROR("Error parsing command line: %s", e.what());
-  //   return false;
-  // }
+  QCommandLineParser parser;
+  parser.setApplicationDescription("3D visualization tool for ROS2");
+  parser.addHelpOption();
+
+  QCommandLineOption display_config_option(
+    QStringList() << "d" << "display-config",
+      "A display config file (.rviz) to load",
+      "display_config");
+  parser.addOption(display_config_option);
+
+  QCommandLineOption fixed_frame_option(
+    QStringList() << "f" << "fixed-frame", "Set the fixed frame", "fixed_frame");
+  parser.addOption(fixed_frame_option);
+
+  QCommandLineOption verbose_option(
+    QStringList() << "v" << "verbose", "Enable debug visualizations");
+  parser.addOption(verbose_option);
+
+  // TODO(botteroa-si): enable when possible
+//  QCommandLineOption splash_screen_option(
+//    QStringList() << "s" << "splash-screen",
+//    "A custom splash-screen image to display",
+//    "splash_path");
+//  parser.addOption(splash_screen_option);
+//
+//  QCommandLineOption help_file_option(
+//    "help-file", "A custom html file to show as the help screen", "help_path");
+//  parser.addOption(help_file_option);
+//
+//  QCommandLineOption ogre_log_option(
+//    QStringList() << "l" << "ogre-log",
+//    "Enable the Ogre.log file (output in cwd) and console output.");
+//  parser.addOption(ogre_log_option);
+//
+//  QCommandLineOption open_gl_option(
+//    "opengl",
+//    "Force OpenGL version (use '--opengl 210' for OpenGL 2.1 compatibility mode)",
+//    "version");
+//  parser.addOption(open_gl_option);
+//
+//  QCommandLineOption disable_anti_aliasing_option(
+//    "disable-anti-aliasing", "Prevent rviz from trying to use anti-aliasing when rendering.");
+//  parser.addOption(disable_anti_aliasing_option);
+//
+//  QCommandLineOption no_stereo_option("no-stereo", "Disable the use of stereo rendering.");
+//  parser.addOption(no_stereo_option);
+//
+//  QCommandLineOption log_level_debug_option(
+//    "log-level-debug", "Sets the ROS logger level to debug.");
+//  parser.addOption(log_level_debug_option);
+
+//   ("in-mc-wrapper", "Signal that this is running inside a master-chooser wrapper")
+
+  QString display_config, fixed_frame, splash_path, help_path;
+  bool verbose = false;
+  // TODO(botteroa-si): enable when possible
+//  bool enable_ogre_log = false;
+//  bool in_mc_wrapper = false;
+//  int force_gl_version = 0;
+//  bool disable_anti_aliasing = false;
+//  bool disable_stereo = false;
+
+  try {
+    parser.process(*app_);
+//    enable_ogre_log = parser.isSet(ogre_log_option);
+//    disable_stereo = parser.isSet(no_stereo_option);
+//    disable_anti_aliasing = parser.isSet(disable_anti_aliasing_option);
+    verbose = parser.isSet(verbose_option);
+
+    if (parser.isSet(display_config_option)) {
+      display_config = parser.value(display_config_option);
+    }
+    if (parser.isSet(fixed_frame_option)) {
+      fixed_frame = parser.value(fixed_frame_option);
+    }
+
+    // TODO(botteroa-si): enable when possible
+//    if (parser.isSet(splash_screen_option)) {
+//      splash_path = parser.value(splash_screen_option);
+//    }
+//    if (parser.isSet(help_file_option)) {
+//      help_path = parser.value(help_file_option);
+//    }
+//    if (parser.isSet(splash_screen_option)) {
+//      splash_path = parser.value(splash_screen_option);
+//    }
+//    if (parser.isSet(open_gl_option)) {
+//      force_gl_version = parser.value(open_gl_option).toInt();
+//    }
+
+//   if (vm.count("in-mc-wrapper")) {
+//     in_mc_wrapper = true;
+//   }
+//
+//
+//   if (vm.count("log-level-debug")) {
+//     if (
+//       ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug))
+//     {
+//       ros::console::notifyLoggerLevelsChanged();
+//     }
+//   }
+  } catch (std::exception & e) {
+    RVIZ_COMMON_LOG_ERROR_STREAM("Error parsing command line:" << e.what());
+    return false;
+  }
+  
   //
   // if (!ros::master::check() ) {
   // TODO(wjwwood): figure out how to support the "wait for master" functionality
@@ -280,24 +295,26 @@ bool VisualizerApp::init(int argc, char ** argv)
   frame_ = new VisualizationFrame(node_name_);
   frame_->setApp(this->app_);
 
-  // if (help_path != "") {
-  //   frame_->setHelpPath(QString::fromStdString(help_path));
-  // }
+  if (!help_path.isEmpty()) {
+    frame_->setHelpPath(help_path);
+  }
 
   // TODO(wjwwood): figure out how to preserve the "choost new master" feature
   // frame_->setShowChooseNewMaster(in_mc_wrapper);
 
-  // if (vm.count("splash-screen") ) {
-  //   frame_->setSplashPath(QString::fromStdString(splash_path));
-  // }
+  if (!splash_path.isEmpty()) {
+    frame_->setSplashPath(splash_path);
+  }
+  frame_->initialize(display_config);
 
-  // frame_->initialize(QString::fromStdString(display_config));
-  frame_->initialize();
+<<<<<<< d49b17db4cf9ab1fe890fb74be239201d246e98c
+=======
+  if (!fixed_frame.isEmpty()) {
+    frame_->getManager()->setFixedFrame(fixed_frame);
+  }
+  frame_->getManager()->getSelectionManager()->setDebugMode(verbose);
 
-  // if (!fixed_frame.empty() ) {
-  //   frame_->getManager()->setFixedFrame(QString::fromStdString(fixed_frame));
-  // }
-
+>>>>>>> Restore working program options
   frame_->show();
 
   // TODO(wjwwood): reenable the ROS service to reload the shaders via the ros_integration API

--- a/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
+++ b/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
@@ -59,6 +59,16 @@ public:
   void
   useLogFile(const std::string & filename = "Ogre.log");
 
+  /// Configure Ogre to write output to stdout and to the given log file name.
+  /**
+   * If file name is a relative path, it will be relative to
+   * the directory which is current when the program is run.  Default
+   * is "Ogre.log".
+   */
+  static
+  void
+  useLogFileAndStandardOut(const std::string & filename = "Ogre.log");
+
   /// Disable Ogre logging entirely, this is the default.
   static
   void

--- a/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
+++ b/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
@@ -33,6 +33,8 @@
 
 #include <string>
 
+#include "rviz_rendering/visibility_control.hpp"
+
 namespace rviz_rendering
 {
 
@@ -66,6 +68,7 @@ public:
    * is "Ogre.log".
    */
   static
+  RVIZ_RENDERING_PUBLIC
   void
   useLogFileAndStandardOut(const std::string & filename = "Ogre.log");
 

--- a/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "ogre_logging.hpp"
+#include "rviz_rendering/ogre_logging.hpp"
 
 #include <string>
 
@@ -95,14 +95,19 @@ public:
 namespace rviz_rendering
 {
 
-// OgreLogging::Preference OgreLogging::preference_ = OgreLogging::NoLogging;
-OgreLogging::Preference OgreLogging::preference_ = OgreLogging::StandardOut;
+OgreLogging::Preference OgreLogging::preference_ = OgreLogging::NoLogging;
 // TODO(wjwwood): refactor this to not have static members.
 std::string OgreLogging::filename_;  // NOLINT: cpplint doesn't allow static strings
 
 void OgreLogging::useLogFile(const std::string & filename)
 {
   preference_ = FileLogging;
+  filename_ = filename;
+}
+
+void OgreLogging::useLogFileAndStandardOut(const std::string & filename)
+{
+  preference_ = StandardOut;
   filename_ = filename;
 }
 
@@ -125,8 +130,7 @@ void OgreLogging::configureLogging()
 
   // Printing to standard out is what Ogre does if you don't do any LogManager calls.
   if (preference_ == StandardOut) {
-    // ll.min_lml = Ogre::LML_NORMAL;
-    ll.min_lml = Ogre::LML_TRIVIAL;
+    ll.min_lml = Ogre::LML_NORMAL;
   }
   // cppcheck-suppress memleak
 }

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -58,10 +58,10 @@
 #include "ament_index_cpp/get_resource.hpp"
 #include "ament_index_cpp/get_resources.hpp"
 #include "rviz_rendering/logging.hpp"
+#include "rviz_rendering/ogre_logging.hpp"
 #include "rviz_rendering/resource_config.hpp"
 
 #include "string_helper.hpp"
-#include "ogre_logging.hpp"
 
 namespace rviz_rendering
 {

--- a/rviz_visual_testing_framework/src/visual_test_fixture.cpp
+++ b/rviz_visual_testing_framework/src/visual_test_fixture.cpp
@@ -39,7 +39,10 @@ void VisualTestFixture::SetUpTestCase()
 {
   QLocale::setDefault(QLocale::English);
   int argc = 1;
-  char * argv[] = {const_cast<char *>("rviz2"), nullptr};
+
+  auto first_argument = new char[6];
+  snprintf(first_argument, sizeof(first_argument), "rviz2");
+  char * argv[] = {first_argument, nullptr};
 
   visualizer_app_ = new rviz_common::VisualizerApp(
     std::make_unique<rviz_common::ros_integration::RosClientAbstraction>());
@@ -57,6 +60,7 @@ void VisualTestFixture::SetUpTestCase()
         QString::fromStdString(std::string(_SRC_DIR_PATH) +
         "/visual_tests_test_image_config.rviz")));
   }
+  delete[] first_argument;
 }
 
 void VisualTestFixture::TearDown()

--- a/rviz_visual_testing_framework/src/visual_test_fixture.cpp
+++ b/rviz_visual_testing_framework/src/visual_test_fixture.cpp
@@ -38,10 +38,11 @@
 void VisualTestFixture::SetUpTestCase()
 {
   QLocale::setDefault(QLocale::English);
-  int argc = 1;
 
-  auto first_argument = new char[6];
-  snprintf(first_argument, sizeof(first_argument), "rviz2");
+  int argc = 1;
+  std::string application_name = "rviz2";
+  auto first_argument = new char[application_name.length() + 1];
+  strcpy(first_argument, application_name.c_str());  // NOLINT (cpplint doesn't like strcpy())
   char * argv[] = {first_argument, nullptr};
 
   visualizer_app_ = new rviz_common::VisualizerApp(

--- a/rviz_visual_testing_framework/src/visual_test_fixture.cpp
+++ b/rviz_visual_testing_framework/src/visual_test_fixture.cpp
@@ -40,9 +40,7 @@ void VisualTestFixture::SetUpTestCase()
   QLocale::setDefault(QLocale::English);
 
   int argc = 1;
-  std::string application_name = "rviz2";
-  auto first_argument = new char[application_name.length() + 1];
-  strcpy(first_argument, application_name.c_str());  // NOLINT (cpplint doesn't like strcpy())
+  char first_argument[6] = "rviz2";
   char * argv[] = {first_argument, nullptr};
 
   visualizer_app_ = new rviz_common::VisualizerApp(
@@ -61,7 +59,6 @@ void VisualTestFixture::SetUpTestCase()
         QString::fromStdString(std::string(_SRC_DIR_PATH) +
         "/visual_tests_test_image_config.rviz")));
   }
-  delete[] first_argument;
 }
 
 void VisualTestFixture::TearDown()

--- a/rviz_visual_testing_framework/src/visual_test_fixture.cpp
+++ b/rviz_visual_testing_framework/src/visual_test_fixture.cpp
@@ -38,13 +38,17 @@
 void VisualTestFixture::SetUpTestCase()
 {
   QLocale::setDefault(QLocale::English);
-  int argc = 0;
+  int argc = 1;
+  char * argv[] = {const_cast<char *>("rviz2"), nullptr};
+
   visualizer_app_ = new rviz_common::VisualizerApp(
     std::make_unique<rviz_common::ros_integration::RosClientAbstraction>());
-  qapp_ = new QApplication(argc, nullptr);
+  qapp_ = new QApplication(argc, argv);
+
 
   visualizer_app_->setApp(qapp_);
-  visualizer_app_->init(0, nullptr);
+
+  visualizer_app_->init(argc, argv);
   if (VisualTest::generateReferenceImages()) {
     visualizer_app_->loadConfig(QDir::toNativeSeparators(
         QString::fromStdString(std::string(_SRC_DIR_PATH) + "/visual_tests_default_config.rviz")));


### PR DESCRIPTION
closes #223 

This pull request restores the program options that can currently be used.
In particular, the Ogre output is now hidden by default and can be enabled via the corresponding option.
