### PR TITLE
Disable rendering tests on Mac when building debug.

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -343,7 +343,7 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT TRUE)
   endif()
 
-  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
+  if((APPLE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug") OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
     message(STATUS "Enabling tests requiring a display")
 
     ament_add_gtest(rviz_common_display_test

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -222,7 +222,7 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT TRUE)
   endif()
 
-  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
+  if((APPLE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug") OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
     message(STATUS "Enabling tests requiring a display")
 
     find_package(sensor_msgs REQUIRED)

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -187,7 +187,7 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT TRUE)
   endif()
 
-  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "TRUE")
+  if((APPLE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug") OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "TRUE")
     message(STATUS "Enabling tests requiring a display")
 
     ament_add_gtest(point_cloud_test_target test/point_cloud_test.cpp

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -60,29 +60,31 @@ if(BUILD_TESTING)
   endif()
 
   if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
-    message(STATUS "Enabling tests requiring a display")
+    if (APPLE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+      message(STATUS "Enabling tests requiring a display")
 
-    ament_add_gmock(mesh_loader_test_target
-      test/mesh_loader_test.cpp
-      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-    if(TARGET mesh_loader_test_target)
-      target_link_libraries(mesh_loader_test_target
-        rviz_ogre_vendor::OgreMain
-        rviz_rendering::rviz_rendering
-        resource_retriever::resource_retriever
-      )
-      ament_target_dependencies(mesh_loader_test_target
-        rviz_assimp_vendor)
-    endif()
+      ament_add_gmock(mesh_loader_test_target
+        test/mesh_loader_test.cpp
+        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+      if(TARGET mesh_loader_test_target)
+        target_link_libraries(mesh_loader_test_target
+          rviz_ogre_vendor::OgreMain
+          rviz_rendering::rviz_rendering
+          resource_retriever::resource_retriever
+          )
+        ament_target_dependencies(mesh_loader_test_target
+          rviz_assimp_vendor)
+      endif()
 
-    ament_add_gtest(test_rviz_rendering_tests
-      test/test_rviz_ogre_media_exports.cpp
-      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-    if(TARGET test_rviz_rendering_tests)
-      target_include_directories(test_rviz_rendering_tests
-        PUBLIC src/rviz_rendering_tests)
-      target_link_libraries(test_rviz_rendering_tests
-        ament_index_cpp::ament_index_cpp)
+      ament_add_gtest(test_rviz_rendering_tests
+        test/test_rviz_ogre_media_exports.cpp
+        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+      if(TARGET test_rviz_rendering_tests)
+        target_include_directories(test_rviz_rendering_tests
+          PUBLIC src/rviz_rendering_tests)
+        target_link_libraries(test_rviz_rendering_tests
+          ament_index_cpp::ament_index_cpp)
+      endif()
     endif()
   endif()
 endif()

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -70,7 +70,7 @@ if(BUILD_TESTING)
         rviz_ogre_vendor::OgreMain
         rviz_rendering::rviz_rendering
         resource_retriever::resource_retriever
-        )
+      )
       ament_target_dependencies(mesh_loader_test_target
         rviz_assimp_vendor)
     endif()

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -59,32 +59,30 @@ if(BUILD_TESTING)
     set(DISPLAYPRESENT FALSE)
   endif()
 
-  if(APPLE OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
-    if (APPLE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-      message(STATUS "Enabling tests requiring a display")
+  if((APPLE AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug") OR DISPLAYPRESENT OR EnableDisplayTests STREQUAL "True")
+    message(STATUS "Enabling tests requiring a display")
 
-      ament_add_gmock(mesh_loader_test_target
-        test/mesh_loader_test.cpp
-        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-      if(TARGET mesh_loader_test_target)
-        target_link_libraries(mesh_loader_test_target
-          rviz_ogre_vendor::OgreMain
-          rviz_rendering::rviz_rendering
-          resource_retriever::resource_retriever
-          )
-        ament_target_dependencies(mesh_loader_test_target
-          rviz_assimp_vendor)
-      endif()
+    ament_add_gmock(mesh_loader_test_target
+      test/mesh_loader_test.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET mesh_loader_test_target)
+      target_link_libraries(mesh_loader_test_target
+        rviz_ogre_vendor::OgreMain
+        rviz_rendering::rviz_rendering
+        resource_retriever::resource_retriever
+        )
+      ament_target_dependencies(mesh_loader_test_target
+        rviz_assimp_vendor)
+    endif()
 
-      ament_add_gtest(test_rviz_rendering_tests
-        test/test_rviz_ogre_media_exports.cpp
-        APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
-      if(TARGET test_rviz_rendering_tests)
-        target_include_directories(test_rviz_rendering_tests
-          PUBLIC src/rviz_rendering_tests)
-        target_link_libraries(test_rviz_rendering_tests
-          ament_index_cpp::ament_index_cpp)
-      endif()
+    ament_add_gtest(test_rviz_rendering_tests
+      test/test_rviz_ogre_media_exports.cpp
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
+    if(TARGET test_rviz_rendering_tests)
+      target_include_directories(test_rviz_rendering_tests
+        PUBLIC src/rviz_rendering_tests)
+      target_link_libraries(test_rviz_rendering_tests
+        ament_index_cpp::ament_index_cpp)
     endif()
   endif()
 endif()


### PR DESCRIPTION
Display tests currently fail due to https://github.com/ros2/rviz/issues/246.
In order to make it easier to triage CI failures, disable these tests in that configuration pending resolution of the failure.

Temporarily resolves #245.