### PR TITLE
Fix build error for ignored qualifiers warning/error on GCC8

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/triangle_list_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/triangle_list_marker.cpp
@@ -208,9 +208,9 @@ bool TriangleListMarker::fillManualObjectAndDetermineAlpha(
     std::vector<Ogre::Vector3> corners(3);
     for (size_t c = 0; c < 3; c++) {
       corners[c] = Ogre::Vector3(
-        static_cast<const Ogre::Real>(points[i + c].x),
-        static_cast<const Ogre::Real>(points[i + c].y),
-        static_cast<const Ogre::Real>(points[i + c].z));
+        static_cast<Ogre::Real>(points[i + c].x),
+        static_cast<Ogre::Real>(points[i + c].y),
+        static_cast<Ogre::Real>(points[i + c].z));
     }
     Ogre::Vector3 normal = (corners[1] - corners[0]).crossProduct(corners[2] - corners[0]);
     normal.normalise();


### PR DESCRIPTION
Building rviz using GCC8 results in few errors, including `std::filesystem`-related one discussed in https://github.com/ros/pluginlib/pull/116.

This PR fixes another one - new GCC detects additional ignored qualifiers (`const` in this case) and `-Werror` makes it fail on them.