### PR TITLE
Enable RViz application icon to be shown also on Mac

### DIFF
--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -257,7 +257,7 @@ void VisualizationFrame::initialize(const QString & display_config_file)
 
   QDir app_icon_path(QString::fromStdString(package_path_) + "/icons/package.png");
   QIcon app_icon(app_icon_path.absolutePath());
-  setWindowIcon(app_icon);
+  app_->setWindowIcon(app_icon);
 
   if (splash_path_ != "") {
     QPixmap splash_image(splash_path_);


### PR DESCRIPTION
Until now the RViz icon was not shown in the dock on Mac. Instead, the default black executable icon was used. Apparently this was due to the fact that the function `setWindowIcon()` has to be called by the `QApplication` itself in order for it to work on Mac.
This issue is, therefore, solved with the simple change that this PR implements. With it, the RViz logo is correctly shown as application icon in the Mac dock, when Rviz is running, and also on the window's title bar, next to the name "RViz".
