### PR TITLE
Fix select and measure tool behaviour on Mac Retina display

### DIFF
--- a/rviz_common/include/rviz_common/viewport_mouse_event.hpp
+++ b/rviz_common/include/rviz_common/viewport_mouse_event.hpp
@@ -89,6 +89,7 @@ public:
 
   RenderPanel * panel;
   QEvent::Type type;
+  int device_pixel_ratio;
   int x;
   int y;
   int wheel_delta;

--- a/rviz_common/src/rviz_common/viewport_mouse_event.cpp
+++ b/rviz_common/src/rviz_common/viewport_mouse_event.cpp
@@ -32,34 +32,39 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 
+#include "rviz_common/render_panel.hpp"
+#include "rviz_rendering/render_window.hpp"
+
 namespace rviz_common
 {
 
 ViewportMouseEvent::ViewportMouseEvent(RenderPanel * p, QMouseEvent * e, int lx, int ly)
 : panel(p),
   type(e->type()),
-  x(e->x()),
-  y(e->y()),
+  device_pixel_ratio(static_cast<int>(panel->getRenderWindow()->devicePixelRatio())),
+  x(e->x() * device_pixel_ratio),
+  y(e->y() * device_pixel_ratio),
   wheel_delta(0),
   acting_button(e->button()),
   buttons_down(e->buttons()),
   modifiers(e->modifiers()),
-  last_x(lx),
-  last_y(ly)
+  last_x(lx * device_pixel_ratio),
+  last_y(ly * device_pixel_ratio)
 {
 }
 
 ViewportMouseEvent::ViewportMouseEvent(RenderPanel * p, QWheelEvent * e, int lx, int ly)
 : panel(p),
   type(e->type()),
-  x(e->x()),
-  y(e->y()),
+  device_pixel_ratio(static_cast<int>(panel->getRenderWindow()->devicePixelRatio())),
+  x(e->x() * device_pixel_ratio),
+  y(e->y() * device_pixel_ratio),
   wheel_delta(e->delta()),
   acting_button(Qt::NoButton),
   buttons_down(e->buttons()),
   modifiers(e->modifiers()),
-  last_x(lx),
-  last_y(ly)
+  last_x(lx * device_pixel_ratio),
+  last_y(ly * device_pixel_ratio)
 {
 }
 

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -459,8 +459,7 @@ RenderSystem::makeRenderWindow(
   params["macAPICocoaUseNSView"] = "true";
 #endif
   // The parameter 'contentScalingFactor' is declared iOS specific, therefore useless at the moment.
-  (void) pixel_ratio;
-//  params["contentScalingFactor"] = std::to_string(pixel_ratio);
+  params["contentScalingFactor"] = std::to_string(pixel_ratio);
 
   std::ostringstream stream;
   stream << "OgreWindow(" << window_counter++ << ")";

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -458,7 +458,9 @@ RenderSystem::makeRenderWindow(
   params["macAPI"] = "cocoa";
   params["macAPICocoaUseNSView"] = "true";
 #endif
-  params["contentScalingFactor"] = std::to_string(pixel_ratio);
+  // The parameter 'contentScalingFactor' is declared iOS specific, therefore useless at the moment.
+  (void) pixel_ratio;
+//  params["contentScalingFactor"] = std::to_string(pixel_ratio);
 
   std::ostringstream stream;
   stream << "OgreWindow(" << window_counter++ << ")";


### PR DESCRIPTION
Solves #274.

This PR fixes the wrong behaviour shown by the select tool and the measure tool on Mac Retina displays. For such displays the pixel ratio is equal to 2 and not 1 and, until now, this fact was not taken in consideration, resulting in an offset selection with respect to the mouse pointer position.