### PR TITLE
work around libassimp-dev bug

### DIFF
--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -11,6 +11,7 @@ find_package(assimp REQUIRED QUIET)
 # workaround bug in Assimp 4.1.0 https://github.com/assimp/assimp/issues/1914
 # Affecting Ubuntu package: libassimp-dev 4.1.0~dfsg-3, Brew: assimp 4.1.0
 string(REPLACE "/lib/lib/" "/lib/" ASSIMP_LIBRARY_DIRS "${ASSIMP_LIBRARY_DIRS}")
+string(REPLACE "/lib/include" "/include" ASSIMP_INCLUDE_DIRS "${ASSIMP_INCLUDE_DIRS}")
 
 set(rviz_assimp_vendor_LIBRARIES)
 foreach(library IN LISTS ASSIMP_LIBRARIES)

--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -8,6 +8,9 @@ endif()
 
 find_package(assimp REQUIRED QUIET)
 
+# workaround bug in Ubuntu package libassimp-dev 4.1.0~dfsg-3
+string(REPLACE "/lib/lib/" "/lib/" ASSIMP_LIBRARY_DIRS "${ASSIMP_LIBRARY_DIRS}")
+
 set(rviz_assimp_vendor_LIBRARIES)
 foreach(library IN LISTS ASSIMP_LIBRARIES)
   message(STATUS "library: ${library}")

--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -11,7 +11,7 @@ find_package(assimp REQUIRED QUIET)
 # workaround bug in Assimp 4.1.0 https://github.com/assimp/assimp/issues/1914
 # Affecting Ubuntu package: libassimp-dev 4.1.0~dfsg-3, Brew: assimp 4.1.0
 string(REPLACE "/lib/lib/" "/lib/" ASSIMP_LIBRARY_DIRS "${ASSIMP_LIBRARY_DIRS}")
-string(REPLACE "/lib/include" "/include" ASSIMP_INCLUDE_DIRS "${ASSIMP_INCLUDE_DIRS}")
+string(REGEX REPLACE "/lib/include$" "/include" ASSIMP_INCLUDE_DIRS "${ASSIMP_INCLUDE_DIRS}")
 
 set(rviz_assimp_vendor_LIBRARIES)
 foreach(library IN LISTS ASSIMP_LIBRARIES)

--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -8,7 +8,8 @@ endif()
 
 find_package(assimp REQUIRED QUIET)
 
-# workaround bug in Ubuntu package libassimp-dev 4.1.0~dfsg-3
+# workaround bug in Assimp 4.1.0 https://github.com/assimp/assimp/issues/1914
+# Affecting Ubuntu package: libassimp-dev 4.1.0~dfsg-3, Brew: assimp 4.1.0
 string(REPLACE "/lib/lib/" "/lib/" ASSIMP_LIBRARY_DIRS "${ASSIMP_LIBRARY_DIRS}")
 
 set(rviz_assimp_vendor_LIBRARIES)


### PR DESCRIPTION
The CMake config file provided by the current Debian package sets the variable `ASSIMP_LIBRARY_DIRS` to the value `/usr/lib/lib/x86_64-linux-gnu`. The duplicate `lib` comes from the way the value is being parameterized when building the Debian package. Anyway the correct value is `/usr/lib/x86_64-linux-gnu`.

While investigating this problem I noticed that the code trying to find the library (see https://github.com/ros2/rviz/commit/826bd0b8f2487051f4768cd48e6e2d4f1993ce28#diff-5e9bf0e7ab4d201db275acc2fcd12886R28) doesn't check the result of the `find_library` call. That should happen independent of this workaround. @wjwwood Can you follow up on this when you have a chance?

@j-rivero Can you try to get this fixed upstream when you have a chance?