### PR TITLE
Make tf use the rviz ros node 

### DIFF
--- a/rviz_common/src/rviz_common/frame_manager.cpp
+++ b/rviz_common/src/rviz_common/frame_manager.cpp
@@ -59,24 +59,11 @@ FrameManager::FrameManager(
   std::shared_ptr<tf2_ros::TransformListener> tf,
   std::shared_ptr<tf2_ros::Buffer> buffer,
   rclcpp::Clock::SharedPtr clock)
-: sync_time_(0),
-  clock_(clock)
+: tf_(tf), buffer_(buffer), sync_time_(0), clock_(clock)
 {
-  if (!tf) {
-    // TODO(wjwwood): reenable this when possible (ros2 has no singleton node),
-    //                for now just require it to be passed in
-    // tf_.reset(new tf2_ros::TransformListener(ros::NodeHandle(), ros::Duration(10 * 60), true));
-    throw std::runtime_error("given TransformListener is nullprt");
-  } else {
-    tf_ = tf;
-  }
-  buffer_ = buffer;
-
   setSyncMode(SyncOff);
   setPause(false);
 }
-
-FrameManager::~FrameManager() = default;
 
 void FrameManager::update()
 {

--- a/rviz_common/src/rviz_common/frame_manager.hpp
+++ b/rviz_common/src/rviz_common/frame_manager.hpp
@@ -79,7 +79,7 @@ public:
    * \param tf a pointer to tf::TransformListener (should not be used anywhere
    *   else because of thread safety).
    */
-  explicit FrameManager(
+  FrameManager(
     std::shared_ptr<tf2_ros::TransformListener> tf,
     std::shared_ptr<tf2_ros::Buffer> buffer,
     rclcpp::Clock::SharedPtr clock
@@ -91,7 +91,7 @@ public:
    * std::shared_ptr returned by instance(), and it will be deleted when the
    * last reference is removed.
    */
-  ~FrameManager() override;
+  ~FrameManager() override = default;
 
   /// Set the frame to consider "fixed", into which incoming data is transformed.
   /**

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -325,10 +325,11 @@ void VisualizationFrame::initialize(
   //                render_panel and VisualizationManager
   render_panel_->getRenderWindow()->initialize();
 
-  auto buffer = std::make_shared<tf2_ros::Buffer>();
   auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  // TODO(wjwwood): pass the rviz node so tf2 doesn't create it's own...
-  auto tf_listener = std::make_shared<tf2_ros::TransformListener>(*buffer);
+  auto buffer = std::make_shared<tf2_ros::Buffer>();
+  buffer->setUsingDedicatedThread(true);
+  auto tf_listener = std::make_shared<tf2_ros::TransformListener>(
+    *buffer, rviz_ros_node.lock()->get_raw_node(), false);
   manager_ = new VisualizationManager(
     render_panel_, rviz_ros_node, this, tf_listener, buffer, clock);
   manager_->setHelpPath(help_path_);


### PR DESCRIPTION
With #197 merged a running rviz effectively has 2 ros nodes: the main rviz node with name rviz and a second node with name `transform_listener_impl` which is created by `tf`s `TransformListener`.

@wjwwood If we hand the rviz node to tf (as in this pr) rviz repeatedly logs
```Do not call canTransform or lookupTransform with a timeout unless you are using another thread for populating data. Without a dedicated thread it will always timeout.  If you have a seperate thread servicing tf messages, call setUsingDedicatedThread(true) on your Buffer instance.```
We need some help with this.