### PR TITLE
Harmonise failed transform behaviour

### DIFF
--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -166,7 +166,7 @@ public:
    * This is thread-safe.
    *
    * Every Display has a StatusList to indicate how it is doing.  The
-   * StatusList has StatusPropertychildren indicating the status of
+   * StatusList has StatusProperty children indicating the status of
    * various subcomponents of the Display.  Each child of the status
    * has a level, a name, and descriptive text.  The top-level
    * StatusList has a level which is set to the worst of all the
@@ -192,6 +192,21 @@ public:
     properties::StatusProperty::Level level,
     const std::string & name,
     const std::string & text);
+
+  /// Convenience: Show and log missing transform
+  /**
+   * Convenience function which
+   * @param frame frame with missing transform to fixed_frame
+   * @param additional_info additional info included in the error_message which then reads "Could
+   * not transform <additional_info> from [<fixed_frame>] to [<frame>].
+   */
+  void
+  setMissingTransformToFixedFrame(
+    const std::string & frame, const std::string & additional_info = "");
+
+  /// Convenience: Set Transform ok
+  void
+  setTransformOk();
 
   /// Delete the status entry with the given name.
   /**

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -380,8 +380,13 @@ bool CameraDisplay::updateCamera()
 
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
-  context_->getFrameManager()->getTransform(
-    image->header.frame_id, image->header.stamp, position, orientation);
+  if (!context_->getFrameManager()->getTransform(
+      image->header.frame_id, image->header.stamp, position, orientation))
+  {
+    setMissingTransformToFixedFrame(image->header.frame_id);
+    return false;
+  }
+  setTransformOk();
 
   // convert vision (Z-forward) frame to ogre frame (Z-out)
   orientation = orientation * Ogre::Quaternion(Ogre::Degree(180), Ogre::Vector3::UNIT_X);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
@@ -145,15 +145,9 @@ void GridDisplay::update(float dt, float ros_dt)
   if (context_->getFrameManager()->getTransform(frame, position, orientation)) {
     scene_node_->setPosition(position);
     scene_node_->setOrientation(orientation);
-    setStatus(StatusProperty::Ok, "Transform", "Transform OK");
+    setTransformOk();
   } else {
-    std::string error;
-    if (context_->getFrameManager()->transformHasProblems(frame, error)) {
-      setStatus(StatusProperty::Error, "Transform", QString::fromStdString(error));
-    } else {
-      setStatus(StatusProperty::Error, "Transform",
-        "Could not transform from [" + qframe + "] to [" + fixed_frame_ + "]");
-    }
+    setMissingTransformToFixedFrame(qframe.toStdString());
   }
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
@@ -416,12 +416,10 @@ void PathDisplay::processMessage(nav_msgs::msg::Path::ConstSharedPtr msg)
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->getTransform(msg->header, position, orientation)) {
-    rviz_common::UniformStringStream ss;
-    ss << "Error transforming from frame '" << msg->header.frame_id << "' to frame '" <<
-      qPrintable(fixed_frame_) << "'";
-    setStatusStd(rviz_common::properties::StatusProperty::Error, "Message", ss.str());
+    setMissingTransformToFixedFrame(msg->header.frame_id);
     return;
   }
+  setTransformOk();
 
   Ogre::Matrix4 transform(orientation);
   transform.setTrans(position);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -57,7 +57,6 @@ PointCloud2Display::PointCloud2Display()
 void PointCloud2Display::onInitialize()
 {
   RTDClass::onInitialize();
-  topic_property_->setValue("pointcloud2");
   point_cloud_common_->initialize(context_, scene_node_);
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -576,13 +576,10 @@ bool PointCloudCommon::transformCloud(const CloudInfoPtr & cloud_info, bool upda
         cloud_info->position_,
         cloud_info->orientation_))
     {
-      std::stringstream ss;
-      ss << "Failed to transform from frame [" << cloud_info->message_->header.frame_id << "] to "
-        "frame [" << context_->getFrameManager()->getFixedFrame() << "]";
-      display_->setStatusStd(
-        rviz_common::properties::StatusProperty::Error, message_status_name_, ss.str());
+      display_->setMissingTransformToFixedFrame(cloud_info->message_->header.frame_id);
       return false;
     }
+    display_->setTransformOk();
   }
   // Remove outdated error message
   display_->deleteStatusStd(message_status_name_);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -53,7 +53,6 @@ PointCloudDisplay::PointCloudDisplay()
 void PointCloudDisplay::onInitialize()
 {
   RTDClass::onInitialize();
-  topic_property_->setValue("pointcloud");
   point_cloud_common_->initialize(context_, scene_node_);
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
@@ -106,9 +106,10 @@ void PolygonDisplay::processMessage(geometry_msgs::msg::PolygonStamped::ConstSha
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->getTransform(msg->header, position, orientation)) {
-    RVIZ_COMMON_LOG_DEBUG_STREAM("Error transforming from frame '" <<
-      msg->header.frame_id.c_str() << "' to frame '" << qPrintable(fixed_frame_) << "'");
+    setMissingTransformToFixedFrame(msg->header.frame_id);
+    return;
   }
+  setTransformOk();
 
   scene_node_->setPosition(position);
   scene_node_->setOrientation(orientation);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
@@ -199,11 +199,10 @@ void PoseDisplay::processMessage(geometry_msgs::msg::PoseStamped::ConstSharedPtr
   if (!context_->getFrameManager()->transform(message->header, message->pose, position,
     orientation))
   {
-    RVIZ_COMMON_LOG_ERROR_STREAM("Error transforming pose '" << qPrintable(getName()) <<
-      "' from frame '" << message->header.frame_id.c_str() << "' to frame '" <<
-      qPrintable(fixed_frame_));
+    setMissingTransformToFixedFrame(message->header.frame_id, "pose " + getNameStd());
     return;
   }
+  setTransformOk();
 
   pose_valid_ = true;
   updateShapeVisibility();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
@@ -217,11 +217,11 @@ bool PoseArrayDisplay::setTransform(std_msgs::msg::Header const & header)
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if (!context_->getFrameManager()->getTransform(header, position, orientation)) {
-    RVIZ_COMMON_LOG_ERROR_STREAM(
-      "Error transforming pose '" << qPrintable(getName()) << "' from frame '" <<
-        header.frame_id.c_str() << "' to frame '" << qPrintable(fixed_frame_) << "'");
+    setMissingTransformToFixedFrame(header.frame_id, "pose " + getNameStd());
     return false;
   }
+  setTransformOk();
+
   scene_node_->setPosition(position);
   scene_node_->setOrientation(orientation);
   return true;

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
@@ -46,7 +46,7 @@ TEST_F(VisualTestFixture, test_camera_display_with_published_image) {
   auto points = {nodes::createPoint(0, 0, 10)};
   std::vector<PublisherWithFrame> publishers = {
     PublisherWithFrame(std::make_shared<nodes::CameraInfoPublisher>(), "image"),
-    PublisherWithFrame(std::make_shared<nodes::ImagePublisher>(), "image"),
+    PublisherWithFrame(std::make_shared<nodes::ImagePublisher>(), "image_frame"),
     PublisherWithFrame(std::make_shared<nodes::PointCloudPublisher>(points), "pointcloud_frame")
   };
   auto cam_publisher = std::make_unique<VisualTestPublisher>(publishers);
@@ -59,6 +59,7 @@ TEST_F(VisualTestFixture, test_camera_display_with_published_image) {
   camera_display->collapse();
 
   auto pointcloud_display = addDisplay<PointCloudDisplayPageObject>();
+  pointcloud_display->setTopic("/pointcloud");
   pointcloud_display->setStyle("Spheres");
   pointcloud_display->setSizeMeters(11);
   pointcloud_display->setColor(0, 0, 255);


### PR DESCRIPTION
The current behaviour on missing transform is pretty uneven. Some displays show something, some set a status error (or both). This PR aims to straighten out this behaviour across displays. The wanted behaviour would be:

- Don't show anything when transform is missing
- Show a Status error telling the user what's going on
- With debug logging enabled, also print to the console

Two displays exhibit different behaviour as before:
- TF display shows a warning status
- Grid display shows the grid nevertheless. This is also necessary to not have an empty window when loading rviz without any transform.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4603)](http://ci.ros2.org/job/ci_linux/4603/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1505)](http://ci.ros2.org/job/ci_linux-aarch64/1505/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3787)](http://ci.ros2.org/job/ci_osx/3787/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4681)](http://ci.ros2.org/job/ci_windows/4681/)