### PR TITLE
Fix visibility of xy_orbit_view_controller

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -82,6 +82,7 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/tools/point/point_tool.hpp
   include/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp
   include/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp
+  include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
 )
 
 set(rviz_default_plugins_source_files

--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
@@ -46,6 +46,7 @@
 #endif
 
 #include "rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp"
+#include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre
 {
@@ -59,7 +60,7 @@ namespace view_controllers
 /**
  * \brief Like the orbit view controller, but focal point moves only in the x-y plane.
  */
-class XYOrbitViewController : public OrbitViewController
+class RVIZ_DEFAULT_PLUGINS_PUBLIC XYOrbitViewController : public OrbitViewController
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "./xy_orbit_view_controller.hpp"
+#include "rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
@@ -43,8 +43,7 @@
 #include "rviz_common/render_panel.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"
 
-#include \
-  "../../../../src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp"  // NOLINT
+#include "rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp"
 #include "rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp"
 #include "rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
@@ -43,8 +43,7 @@
 #include "rviz_common/render_panel.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"
 
-#include \
-  "../../../../src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp"  // NOLINT
+#include "rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp"
 #include "rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp"
 
 #include "../../displays/display_test_fixture.hpp"


### PR DESCRIPTION
The new orbit view controller was not yet exposed. 
This becomes visible when running display tests on Windows, which are still disabled on the OSRF jenkins, so only our CI caught the issue.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4618)](http://ci.ros2.org/job/ci_linux/4618/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1519)](http://ci.ros2.org/job/ci_linux-aarch64/1519/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3802)](http://ci.ros2.org/job/ci_osx/3802/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4696)](http://ci.ros2.org/job/ci_windows/4696/)