### PR TITLE
Fix failing tests

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -272,7 +272,7 @@ if(BUILD_TESTING)
     ament_add_gmock(grid_cells_display_test
       test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
       test/rviz_default_plugins/displays/display_test_fixture.cpp
-      test/rviz_default_plugins/scene_graph_introspection.cpp
+      test/rviz_default_plugins/scene_graph_introspection_helper.cpp
       APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET grid_cells_display_test)
       target_include_directories(grid_cells_display_test PUBLIC
@@ -327,7 +327,7 @@ if(BUILD_TESTING)
     ament_add_gmock(point_display_test
       test/rviz_default_plugins/displays/point/point_stamped_display_test.cpp
       test/rviz_default_plugins/displays/display_test_fixture.cpp
-      test/rviz_default_plugins/scene_graph_introspection.cpp)
+      test/rviz_default_plugins/scene_graph_introspection_helper.cpp)
     if(TARGET point_display_test)
       target_include_directories(point_display_test PUBLIC
         ${TEST_INCLUDE_DIRS})
@@ -484,7 +484,7 @@ if(BUILD_TESTING)
       test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
       test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
       test/rviz_default_plugins/displays/display_test_fixture.cpp
-      test/rviz_default_plugins/scene_graph_introspection.cpp
+      test/rviz_default_plugins/scene_graph_introspection_helper.cpp
       APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_INSTALL_PREFIX} PATH=${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_yaml_cpp_vendor/bin;${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor/bin)
     if(TARGET fps_view_controller_test)
       target_include_directories(fps_view_controller_test PUBLIC

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
@@ -40,8 +40,9 @@
 
 #include "rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp"
 
+#include "test/rviz_rendering/scene_graph_introspection.hpp"
 #include "../display_test_fixture.hpp"
-#include "../../scene_graph_introspection.hpp"
+#include "../../scene_graph_introspection_helper.hpp"
 
 using namespace ::testing;  // NOLINT
 
@@ -96,7 +97,7 @@ TEST_F(GridCellsDisplayFixture, processMessage_with_invalid_transform_returns_ea
   auto msg = createGridCellsMessageWithTwoCells();
   display_->processMessage(msg);
 
-  auto point_clouds = rviz_default_plugins::findAllPointClouds(scene_manager_->getRootSceneNode());
+  auto point_clouds = rviz_rendering::findAllPointClouds(scene_manager_->getRootSceneNode());
   EXPECT_THAT(point_clouds.size(), Eq(1u));
   EXPECT_THAT(point_clouds[0]->getPoints().size(), Eq(0u));
 }
@@ -107,7 +108,7 @@ TEST_F(GridCellsDisplayFixture, processMessage_with_zero_size_does_not_add_messa
   auto msg = createGridCellsMessageWithTwoCells(0, 1);
   display_->processMessage(msg);
 
-  auto point_clouds = rviz_default_plugins::findAllPointClouds(scene_manager_->getRootSceneNode());
+  auto point_clouds = rviz_rendering::findAllPointClouds(scene_manager_->getRootSceneNode());
   EXPECT_THAT(point_clouds.size(), Eq(1u));
   EXPECT_THAT(point_clouds[0]->getPoints().size(), Eq(0u));
 }
@@ -117,7 +118,7 @@ TEST_F(GridCellsDisplayFixture, processMessage_fills_pointcloud_with_correct_gri
   auto msg = createGridCellsMessageWithTwoCells();
   display_->processMessage(msg);
 
-  auto point_clouds = rviz_default_plugins::findAllPointClouds(scene_manager_->getRootSceneNode());
+  auto point_clouds = rviz_rendering::findAllPointClouds(scene_manager_->getRootSceneNode());
   EXPECT_THAT(point_clouds.size(), Eq(1u));
   EXPECT_THAT(point_clouds[0]->getPoints().size(), Eq(2u));
   EXPECT_THAT(
@@ -136,7 +137,7 @@ TEST_F(GridCellsDisplayFixture, processMessage_clears_cloud_on_new_message) {
   auto broken_msg = createGridCellsMessageWithTwoCells(0, 1);
   display_->processMessage(broken_msg);
 
-  auto point_clouds = rviz_default_plugins::findAllPointClouds(scene_manager_->getRootSceneNode());
+  auto point_clouds = rviz_rendering::findAllPointClouds(scene_manager_->getRootSceneNode());
   EXPECT_THAT(point_clouds.size(), Eq(1u));
   EXPECT_THAT(point_clouds[0]->getPoints().size(), Eq(0u));
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/point/point_stamped_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/point/point_stamped_display_test.cpp
@@ -47,10 +47,11 @@
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/shape.hpp"
-#include "../../scene_graph_introspection.hpp"
 
 #include "rviz_default_plugins/displays/point/point_stamped_display.hpp"
 
+#include "test/rviz_rendering/scene_graph_introspection.hpp"
+#include "../../scene_graph_introspection_helper.hpp"
 #include "../display_test_fixture.hpp"
 
 using namespace ::testing;  // NOLINT
@@ -99,7 +100,7 @@ TEST_F(PointStampedTestFixture, processMessage_adds_nothing_to_scene_if_invalid_
 
   point_stamped_display_->processMessage(createPointMessage(0, 0, 0));
 
-  auto objects = rviz_default_plugins::findAllEntitiesByMeshName(
+  auto objects = rviz_rendering::findAllEntitiesByMeshName(
     scene_manager_->getRootSceneNode(), "rviz_sphere.mesh");
   EXPECT_THAT(objects.size(), Eq(0u));
 }
@@ -115,7 +116,7 @@ TEST_F(PointStampedTestFixture,
   point_stamped_display_->processMessage(createPointMessage(1, 0, 0));
   point_stamped_display_->processMessage(createPointMessage(-1, 0, 0));
 
-  auto objects = rviz_default_plugins::findAllEntitiesByMeshName(
+  auto objects = rviz_rendering::findAllEntitiesByMeshName(
     scene_manager_->getRootSceneNode(), "rviz_sphere.mesh");
   EXPECT_THAT(objects.size(), Eq(2u));
   assertPointsPresent(objects, Ogre::Vector3(1, 0, 0));

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
@@ -46,7 +46,7 @@
 #include "rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp"
 
 #include "../../displays/display_test_fixture.hpp"
-#include "../../scene_graph_introspection.hpp"
+#include "../../scene_graph_introspection_helper.hpp"
 #include "../view_controller_test_fixture.hpp"
 
 using namespace ::testing;  // NOLINT

--- a/rviz_visual_testing_framework/src/internal/display_handler.cpp
+++ b/rviz_visual_testing_framework/src/internal/display_handler.cpp
@@ -152,6 +152,7 @@ void DisplayHandler::selectDisplayAndConfirm(std::shared_ptr<BasePageObject> pag
         return;
       }
 
+      add_by_name_tree->scrollToItem(items.at(0));
       QRect display_element_bounding_box = add_by_name_tree->visualItemRect(items.at(0));
 
       QTest::mouseClick(


### PR DESCRIPTION
This PR fixes a few tests that failed after yesterdays merging. 

- Some files were moved on one branch for tests running on OSX CI
- The amount of displays now needs scrolling in the "add display" dialog. This resulted in failure of all hidden visual tests on Windows and Linux. Tests don't run (yet) on OSRF CI, but fix nevertheless