### PR TITLE
Update documentation and package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This branch is currently contained in the main `ros2.repos` file of ROS 2 and can be used for ROS 2.
 The latest release will be available with your ROS 2 download.
 
+ROS 2 does not have a wiki, yet. To learn about rviz and its functionality, please refer to the ROS rviz [wiki page](http://www.ros.org/wiki/rviz). 
+
 # Features in the current master version
 
 ## Features present in rviz for ROS and missing in rviz for ROS 2

--- a/README.md
+++ b/README.md
@@ -1,77 +1,53 @@
 # rviz
 
-This branch is still under construction and is targeted for ROS 2 and/or ROS 1 M-Turtle.
+This branch is currently contained in the main `ros2.repos` file of ROS 2 and can be used for ROS 2.
+The latest release will be available with your ROS 2 download.
 
-# Setup
+# Features in the current master version
 
-Install ros2 (needed for ament at least and ros2's C++ api for the version of rviz in ros 2):
+## Features present in rviz for ROS and missing in rviz for ROS 2
+
+Tools:
+- Interactive Markers
+
+Displays:
+- AxesDisplay
+- DepthCloudDisplay
+- EffortDisplay
+- FluidPressureDisplay
+- IlluminanceDisplay
+- InteractiveMarkerDisplay
+- PoseWithCovarianceStampedDisplay
+- RangeDisplay
+- RelativeHumidityDisplay
+- TemperatureDisplay
+- WrenchDisplay
+
+Other features:
+- Filtering of Topic lists by topic type
+- Message filters
+- Image transport features
+
+If you would like to see those features in rviz, feel free to add a pull request.
+Make sure to read the developer guide below and the migration guide.
+
+## Features new in rviz for ROS 2
+
+None, yet.
+
+# Developer Guide
+
+## Setup: Building from source
+
+The simplest way to build from source is to use the official installation guide, since rviz is part of the official ROS 2 repos file.
 
 https://github.com/ros2/ros2/wiki/Installation
 
-Currently the latest release (beta3) is not sufficient to build rviz so you need to build the ros2 master from source.
+### Building RViz in a separate folder
 
-## Prerequisites
+When developing for rviz, it can be beneficial to build it in a separate folder. 
 
-### Ubuntu
-
-There will be a `setup.bash` file from your ros2 build you can source.
-The current state of this branch requires a from-source build though.
-
-Install the following Ubuntu packages:
-
-```
-apt install libxaw7-dev libgles2-mesa-dev libglu1-mesa-dev qt5-default libyaml-cpp-dev libcurl4-openssl-dev
-```
-
-Source the setup file before continuing:
-
-```
-$ source path/to/ros2/install/setup.bash
-```
-
-### Windows
-
-**Note** Make sure to install all dependencies in either 32 bit or 64 bit version and do not mix.
-
-This setup was tested for Windows 10 x64.
-
-#### Build CURL 7.56.0
-* Download CURL sources from [GitHub](https://github.com/curl/curl/releases/tag/curl-7_56_0)
-* Extract to local folder (e.g. to `C:\ros2\curl-7.56.0`)
-* Create and change to build folder (e.g. `C:\ros2\curl-7.56.0\build`)
-    * Configure CMake: `cmake -G "Visual Studio 15 2017 Win64" ../`
-    * Build the project: `cmake --build . --config Debug`
-    * Install to `C:\Program Files`: `cmake --build . --config Debug --target Install`
-
-#### Get Boost (No build required)
-* Download Boost sources from https://dl.bintray.com/boostorg/release/1.65.1/source/
-* Extract to local folder (e.g. to `C:\ros2\boost_1_65_1`)
-
-#### Build yaml-cpp
-* Download yaml-cpp sources from [GitHub](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.5.3)
-* Extract to local folder (e.g. to `C:\ros2\yaml-cpp-release-0.5.3`)
-* Create and change to build folder (e.g. `C:\ros2\yaml-cpp-release-0.5.3\build`)
-    * Configure CMake: `cmake -G "Visual Studio 15 2017 Win64" ../ -DBoost_INCLUDE_DIR=C:\ros2\boost_1_65_1`
-    * Build the project: `cmake --build . --config Debug`
-    * Install to `C:\Program Files`: `cmake --build . --config Debug --target Install`
-
-#### Setup environment
-* add Qt binary files to PATH (e.g. `C:\Qt\5.9.1\msvc2017_64\bin`)
-* set QT_QPA_PLATFORM_PLUGIN_PATH environment variable (e.g. `C:\Qt\5.9.1\msvc2017_64\plugins\platforms`)
-* Add Curl and yaml-cppto the CMAKE_PREFIX_PATH environment variable
-    * Example: `C:\Program Files\CURL;C:\Program Files\YAML_CPP`
-* Add Curl binary to PATH (e.g. `C:\Program Files\CURL\bin`)
-* Set BOOST_INCLUDEDIR environment variable to Boost include directory (e.g. `C:\ros2\boost_1_65_1`)
-* Add patch.exe to PATH (e.g. from Git Bash, `C:\Program Files\Git\usr\bin`)
-* (For Testing) Add Cppcheck binary to PATH (e.g. `C:\Program Files\Cppcheck`)
-
-Source the setup file before continuing:
-
-```
-$ call path/to/ros2/install/setup.bat
-```
-
-## Building RViz
+**Note:** When building the current ros2 branch from source, the latest ROS 2 release for all dependencies might not be sufficient. Make sure to have a source build of ROS 2 available (see installation procedure above).
 
 Create a new workspace:
 
@@ -84,8 +60,6 @@ Clone these repositories into the source folder:
 
 ```
 $ git clone https://github.com/ros2/rviz.git
-$ git clone https://github.com/ros/pluginlib.git -b ros2
-$ git clone https://github.com/ros2/tinyxml2_vendor.git
 ```
 
 Then build all the packages with this command:
@@ -103,8 +77,6 @@ $ ament build --only rviz_rendering
 
 More instructions and examples to come.
 
-# Developer Guide
-
 In addition to the [ROS 2 Developer Guide](https://github.com/ros2/ros2/wiki/Developer-Guide) we suggest the following.
 
 ## Testing
@@ -117,3 +89,8 @@ Main rationale here is to create code that can be well tested by avoiding highly
 * Use only the interface in the dependent code.
 * Specify dependencies as a constructor argument.
 * Prefer `std::unique_ptr` for storing the dependency instead of a raw pointer.
+
+## Migration Guide
+
+When migrating from rviz to rviz2, please see the more extensive [migration guide](https://github.com/ros2/rviz/migration_guide.md).
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ ROS 2 does not have a wiki, yet. To learn about rviz and its functionality, plea
 ## Features present in rviz for ROS and missing in rviz for ROS 2
 
 Tools:
-- Interactive Markers
+- Interact Tool
+- Initial Pose Tool
 
 Displays:
 - AxesDisplay
@@ -19,6 +20,7 @@ Displays:
 - FluidPressureDisplay
 - IlluminanceDisplay
 - InteractiveMarkerDisplay
+- OculusDisplay
 - PoseWithCovarianceStampedDisplay
 - RangeDisplay
 - RelativeHumidityDisplay
@@ -30,7 +32,7 @@ Other features:
 - Message filters
 - Image transport features
 
-If you would like to see those features in rviz, feel free to add a pull request.
+If you would like to see those features in rviz for ROS 2, feel free to add a pull request.
 Make sure to read the developer guide below and the migration guide.
 
 ## Features new in rviz for ROS 2
@@ -49,7 +51,8 @@ https://github.com/ros2/ros2/wiki/Installation
 
 When developing for rviz, it can be beneficial to build it in a separate folder. 
 
-**Note:** When building the current ros2 branch from source, the latest ROS 2 release for all dependencies might not be sufficient. Make sure to have a source build of ROS 2 available (see installation procedure above).
+**Note:** When building the current ros2 branch from source, the latest ROS 2 release for all dependencies might not be sufficient: it could be necessary to build the ROS 2 master branch.
+Make sure to have a source build of ROS 2 available (see installation procedure above).
 
 Create a new workspace:
 

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -81,10 +81,15 @@ Failures will result in missing symbols while linking.
   This avoids using the API in RosTopicDisplay which is called by the subscribers and needs ROS.
 - The Ogre dependency cannot be mocked.
   To work with it, a special testing setup is provided in `rviz_rendering`.
-  `rviz_default_plugins` provides additional helper methods to traverse the scene graph.
+  In addition, helper methods to traverse the scene graph are provided in `rviz_rendering`.
 - The tests need to be grouped with the other display tests, since the Ogre setup requires an actual display to be run.
   For now, display tests are only run on OSX at the OSRF Jenkins, but they will automatically be run on Linux if a physical display is present.
   To execute display tests on Windows, run `ament test --cmake-args -DEnableDisplayTests=True`.
+
+When writing tests inside `rviz_default_plugins`, test setups can be reused: 
+- For Displays, extend the `display_test_fixture`, which provides a fully set up mock of the Display Context and some convenience features to simulate correct transforms.
+- For Tools, extend the `tool_test_fixture`, which provides a fully set up mock of Display Context as well as convenience methods for mouse interaction.
+- For View Controllers, extend the `view_controller_test_fixture`, which provides a fully set up mock of Display Context as well as convenience methods to simulate mouse interaction
 
 ## End-to-end testing for RViz plugins
 
@@ -118,3 +123,4 @@ Then the function can be used for handler creation and the SelectionHandler work
   If they are needed, please provide a pull request to the RViz repository explaining why this functionality is needed.
 - `CovarianceProperty`: Previously used CovarianceVisual, now contains only a number of properties.
 See `rviz_rendering::CovarianceVisual` for further information and OdometryDisplay in `rviz_default_plugins` for an example usage.
+- The Display Context provides a whole host of new methods needed to write custom panels. The API has changed overall, but the functionality should only be extended.

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -10,7 +10,6 @@ Please refer also to the ROS migration guide at https://github.com/ros2/ros2/wik
 - Most user-facing functionality such as base classes for displays or tools are now located in `rviz_common`.
 - The previous `ogre_helpers` as well as classes to do with rendering are located in `rviz_rendering` or its subfolder `objects`.
 - The default plugins and the robot are located in `rviz_default_plugins`.
-  Their headers are currently not exposed, i.e. cannot be used in custom plugins.
 - The Selection mechanism was moved to a subfolder `interaction` in `rviz_common`.
   The object picking behaviour was moved to a `ViewPicker`, which is also exposed via the display context.
 - If the display extends the `MessageFilterDisplay`, switch to extending `RosTopicDisplay`.

--- a/rviz2/package.xml
+++ b/rviz2/package.xml
@@ -12,7 +12,7 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <!--url type="website">http://ros.org/wiki/rviz2</url-->
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
   <url type="repository">https://github.com/ros2/rviz</url>
   <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -11,7 +11,7 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <!--url type="website">http://ros.org/wiki/rviz_common</url-->
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
   <url type="repository">https://github.com/ros2/rviz</url>
   <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -11,7 +11,7 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <!--url type="website">http://ros.org/wiki/rviz_default_plugins</url-->
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
   <url type="repository">https://github.com/ros2/rviz</url>
   <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -11,7 +11,7 @@
   <author>David Gossow</author>
   <author>Josh Faust</author>
 
-  <!--url type="website">http://ros.org/wiki/rviz_rendering</url-->
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
   <url type="repository">https://github.com/ros2/rviz</url>
   <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 


### PR DESCRIPTION
With this PR the `README` is updated to reflect the current status of RViz.
Moreover, the `package.xml` files of the rviz packages now contain a link to the `README`, in which, in turn, has been inserted a link to the rviz for ros1 wiki page, given that there is none for ros2, yet. 

Further extensions of the documentation will come in  a future PR.