### PR TITLE
Fix warning in Debug mode

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -311,7 +311,7 @@ void MapDisplay::updateMapDataInMemory(
     std::copy(
       update->data.begin(),
       update->data.begin() + update->width,
-      &current_map_.data[(update->y + y) * current_map_.info.width + update->x]);
+      current_map_.data.begin() + (update->y + y) * current_map_.info.width + update->x);
   }
 }
 


### PR DESCRIPTION
This PR fixes an MS Build warning (in Debug mode) which occured after merging the map display.
(See an instance of this warning here: https://ci.ros2.org/view/nightly/job/nightly_win_deb/915/)

Also referenced in https://github.com/ros2/build_cop/issues/125