### PR TITLE
Use conversions and alpha in other displays

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -147,7 +147,7 @@ void SelectionManager::initialize()
 
   Ogre::TexturePtr tex = Ogre::TextureManager::getSingleton().loadRawData(
     name + "Texture",
-    Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+    "rviz_rendering",
     pixel_stream,
     1,
     1,
@@ -156,8 +156,8 @@ void SelectionManager::initialize()
     0
     );
 
-  Ogre::MaterialPtr material = rviz_rendering::MaterialManager::createMaterialWithNoLighting(name);
-  // material->getTechnique(0)->getPass(0)->setPolygonMode(Ogre::PM_WIREFRAME);
+  Ogre::MaterialPtr material =
+    rviz_rendering::MaterialManager::createMaterialWithShadowsAndNoLighting(name);
   highlight_rectangle_->setMaterial(material);
   Ogre::AxisAlignedBox aabInf;
   aabInf.setInfinite();

--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -51,6 +51,7 @@
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_rendering/custom_parameter_indices.hpp"
+#include "rviz_rendering/material_manager.hpp"
 #include "rviz_rendering/render_window.hpp"
 
 #include "rviz_common/display_context.hpp"
@@ -155,9 +156,7 @@ void SelectionManager::initialize()
     0
     );
 
-  Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().create(
-    name, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-  material->setLightingEnabled(false);
+  Ogre::MaterialPtr material = rviz_rendering::MaterialManager::createMaterialWithNoLighting(name);
   // material->getTechnique(0)->getPass(0)->setPolygonMode(Ogre::PM_WIREFRAME);
   highlight_rectangle_->setMaterial(material);
   Ogre::AxisAlignedBox aabInf;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -543,11 +543,10 @@ void MapDisplay::transformMap()
     RVIZ_COMMON_LOG_ERROR_STREAM("Error transforming map '" << getName().toStdString() <<
       "' from frame '" << frame_ << "' to '" << fixed_frame_.toStdString() << "'.");
 
-    setStatus(rviz_common::properties::StatusProperty::Error, "Transform",
-      "No transform from [" + QString::fromStdString(frame_) + "] to [" + fixed_frame_ + "]");
+    setMissingTransformToFixedFrame(frame_);
     scene_node_->setVisible(false);
   } else {
-    setStatus(rviz_common::properties::StatusProperty::Ok, "Transform", "Transform OK");
+    setTransformOk();
   }
 
   scene_node_->setPosition(position);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/arrow_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/arrow_marker.cpp
@@ -53,6 +53,7 @@
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/shape.hpp"
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/msg_conversions.hpp"
 
 #include "rviz_default_plugins/displays/marker/marker_common.hpp"
 #include "rviz_default_plugins/displays/marker/markers/marker_selection_handler.hpp"
@@ -136,10 +137,8 @@ void ArrowMarker::setArrowFromPoints(const MarkerConstSharedPtr & message)
   last_arrow_set_from_points_ = true;
 
   // compute translation & rotation from the two points
-  Ogre::Vector3 point1(
-    message->points[0].x, message->points[0].y, message->points[0].z);
-  Ogre::Vector3 point2(
-    message->points[1].x, message->points[1].y, message->points[1].z);
+  Ogre::Vector3 point1 = rviz_common::pointMsgToOgre(message->points[0]);
+  Ogre::Vector3 point2 = rviz_common::pointMsgToOgre(message->points[1]);
 
   Ogre::Vector3 direction = point2 - point1;
   float distance = direction.length();
@@ -180,7 +179,7 @@ void ArrowMarker::setArrow(const MarkerConstSharedPtr & message)
     owner_->setMarkerStatus(
       getID(), rviz_common::properties::StatusProperty::Warn, "Scale of 0 in one of x/y/z");
   }
-  arrow_->setScale(Ogre::Vector3(message->scale.x, message->scale.y, message->scale.z));
+  arrow_->setScale(rviz_common::vector3MsgToOgre(message->scale));
 
   Ogre::Quaternion orient = Ogre::Vector3::NEGATIVE_UNIT_Z.getRotationTo(Ogre::Vector3(1, 0, 0));
   arrow_->setOrientation(orient);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_selection_handler.cpp
@@ -33,6 +33,7 @@
 #include <OgreQuaternion.h>
 #include <OgreVector3.h>
 
+#include "rviz_common/msg_conversions.hpp"
 #include "rviz_default_plugins/displays/marker/marker_display.hpp"
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 #include "rviz_common/properties/property.hpp"
@@ -60,17 +61,12 @@ MarkerSelectionHandler::~MarkerSelectionHandler()
 
 Ogre::Vector3 MarkerSelectionHandler::getPosition()
 {
-  return Ogre::Vector3(marker_->getMessage()->pose.position.x,
-           marker_->getMessage()->pose.position.y,
-           marker_->getMessage()->pose.position.z);
+  return rviz_common::pointMsgToOgre(marker_->getMessage()->pose.position);
 }
 
 Ogre::Quaternion MarkerSelectionHandler::getOrientation()
 {
-  return Ogre::Quaternion(marker_->getMessage()->pose.orientation.w,
-           marker_->getMessage()->pose.orientation.x,
-           marker_->getMessage()->pose.orientation.y,
-           marker_->getMessage()->pose.orientation.z);
+  return rviz_common::quaternionMsgToOgre(marker_->getMessage()->pose.orientation);
 }
 
 void MarkerSelectionHandler::createProperties(

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
@@ -51,6 +51,7 @@
 #include <OgreTextureManager.h>
 
 #include "rviz_rendering/mesh_loader.hpp"
+#include "rviz_rendering/material_manager.hpp"
 #include "rviz_common/display_context.hpp"
 
 #include "rviz_default_plugins/displays/marker/marker_common.hpp"
@@ -192,9 +193,7 @@ void MeshResourceMarker::createMeshWithMaterials(
 Ogre::MaterialPtr MeshResourceMarker::createDefaultMaterial(const std::string & material_name) const
 {
   Ogre::MaterialPtr default_material =
-    Ogre::MaterialManager::getSingleton().create(material_name, "rviz_rendering");
-  default_material->setReceiveShadows(false);
-  default_material->getTechnique(0)->setLightingEnabled(true);
+    rviz_rendering::MaterialManager::createMaterialWithLighting(material_name);
   default_material->getTechnique(0)->setAmbient(0.5, 0.5, 0.5);
   return default_material;
 }
@@ -239,13 +238,7 @@ MeshResourceMarker::updateMaterialColor(const MarkerBase::MarkerConstSharedPtr &
   Ogre::SceneBlendType blending;
   bool depth_write;
 
-  if (a < 0.9998) {
-    blending = Ogre::SBT_TRANSPARENT_ALPHA;
-    depth_write = false;
-  } else {
-    blending = Ogre::SBT_REPLACE;
-    depth_write = true;
-  }
+  rviz_rendering::MaterialManager::enableAlphaBlending(blending, depth_write, a);
 
   if (new_message->mesh_use_embedded_materials && r == 0 && g == 0 && b == 0 && a == 0) {
     blending = Ogre::SBT_REPLACE;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
@@ -37,6 +37,7 @@
 #include "rviz_rendering/objects/axes.hpp"
 
 #include "rviz_common/logging.hpp"
+#include "rviz_common/msg_conversions.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/covariance_property.hpp"
 #include "rviz_common/properties/enum_property.hpp"
@@ -303,25 +304,12 @@ bool OdometryDisplay::messageIsSimilarToPrevious(nav_msgs::msg::Odometry::ConstS
     return false;
   }
 
-  Ogre::Vector3 last_position(
-    last_used_message_->pose.pose.position.x,
-    last_used_message_->pose.pose.position.y,
-    last_used_message_->pose.pose.position.z);
-  Ogre::Vector3 current_position(
-    message->pose.pose.position.x,
-    message->pose.pose.position.y,
-    message->pose.pose.position.z);
+  auto last_position = rviz_common::pointMsgToOgre(last_used_message_->pose.pose.position);
+  auto current_position = rviz_common::pointMsgToOgre(message->pose.pose.position);
 
-  auto last_orientation = Ogre::Quaternion(
-    last_used_message_->pose.pose.orientation.w,
-    last_used_message_->pose.pose.orientation.x,
-    last_used_message_->pose.pose.orientation.y,
-    last_used_message_->pose.pose.orientation.z);
-  auto current_orientation = Ogre::Quaternion(
-    message->pose.pose.orientation.w,
-    message->pose.pose.orientation.x,
-    message->pose.pose.orientation.y,
-    message->pose.pose.orientation.z);
+  auto last_orientation =
+    rviz_common::quaternionMsgToOgre(last_used_message_->pose.pose.orientation);
+  auto current_orientation = rviz_common::quaternionMsgToOgre(message->pose.pose.orientation);
 
   bool position_difference_is_within_tolerance =
     (last_position - current_position).length() < position_tolerance_property_->getFloat();
@@ -377,8 +365,8 @@ std::unique_ptr<rviz_rendering::CovarianceVisual> OdometryDisplay::createAndSetC
   covariance_visual->setPosition(position);
   covariance_visual->setOrientation(orientation);
   auto quaternion = message->pose.pose.orientation;
-  covariance_visual->setCovariance(Ogre::Quaternion(
-      quaternion.w, quaternion.x, quaternion.y, quaternion.z), message->pose.covariance);
+  covariance_visual->setCovariance(
+    rviz_common::quaternionMsgToOgre(quaternion), message->pose.covariance);
   covariance_visual->updateUserData(covariance_property_->getUserData());
 
   return covariance_visual;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/point/point_stamped_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/point/point_stamped_display.cpp
@@ -42,6 +42,7 @@
 #include "rviz_rendering/objects/shape.hpp"
 
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/msg_conversions.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/properties/int_property.hpp"
@@ -151,7 +152,7 @@ void PointStampedDisplay::createNewSphereVisual(
   float radius = radius_property_->getFloat();
   Ogre::ColourValue color = color_property_->getOgreColor();
   visual->setColor(color.r, color.g, color.b, alpha);
-  visual->setPosition(Ogre::Vector3(msg->point.x, msg->point.y, msg->point.z));
+  visual->setPosition(rviz_common::pointMsgToOgre(msg->point));
   visual->setScale(Ogre::Vector3(radius, radius, radius));
 
   visuals_.push_back(visual);

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/point/point_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/point/point_tool.cpp
@@ -37,6 +37,7 @@
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/interaction/view_picker_iface.hpp"
 #include "rviz_common/load_resource.hpp"
+#include "rviz_common/msg_conversions.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/render_panel.hpp"
@@ -118,13 +119,12 @@ void PointTool::setStatusForPosition(const Ogre::Vector3 & position)
 
 void PointTool::publishPosition(const Ogre::Vector3 & position) const
 {
-  geometry_msgs::msg::PointStamped ps;
-  ps.point.x = position.x;
-  ps.point.y = position.y;
-  ps.point.z = position.z;
-  ps.header.frame_id = context_->getFixedFrame().toStdString();
-  ps.header.stamp = rclcpp::Clock().now();
-  publisher_->publish(ps);
+  auto point = rviz_common::pointOgreToMsg(position);
+  geometry_msgs::msg::PointStamped point_stamped;
+  point_stamped.point = point;
+  point_stamped.header.frame_id = context_->getFixedFrame().toStdString();
+  point_stamped.header.stamp = rclcpp::Clock().now();
+  publisher_->publish(point_stamped);
 }
 
 }  // namespace tools

--- a/rviz_rendering/include/rviz_rendering/material_manager.hpp
+++ b/rviz_rendering/include/rviz_rendering/material_manager.hpp
@@ -58,6 +58,8 @@ public:
 
   static Ogre::MaterialPtr createMaterialWithShadowsAndLighting(std::string name);
 
+  static Ogre::MaterialPtr createMaterialWithShadowsAndNoLighting(std::string name);
+
   static void enableAlphaBlending(Ogre::MaterialPtr material, float alpha);
 
   static void enableAlphaBlending(Ogre::SceneBlendType & blending, bool & depth_write, float alpha);

--- a/rviz_rendering/src/rviz_rendering/material_manager.cpp
+++ b/rviz_rendering/src/rviz_rendering/material_manager.cpp
@@ -89,6 +89,14 @@ Ogre::MaterialPtr MaterialManager::createMaterialWithShadowsAndLighting(std::str
   return material;
 }
 
+Ogre::MaterialPtr MaterialManager::createMaterialWithShadowsAndNoLighting(std::string name)
+{
+  Ogre::MaterialPtr material = Ogre::MaterialManager::getSingleton().create(name, "rviz_rendering");
+  material->getTechnique(0)->setLightingEnabled(false);
+
+  return material;
+}
+
 void MaterialManager::enableAlphaBlending(Ogre::MaterialPtr material, float alpha)
 {
   if (alpha < unit_alpha_threshold) {

--- a/rviz_rendering/src/rviz_rendering/objects/line.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/line.cpp
@@ -29,13 +29,15 @@
 
 #include "rviz_rendering/objects/line.hpp"
 
-#include <sstream>
+#include <string>
 
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
+
+#include "rviz_rendering/material_manager.hpp"
 
 namespace rviz_rendering
 {
@@ -50,16 +52,12 @@ Line::Line(Ogre::SceneManager * manager, Ogre::SceneNode * parent_node)
   scene_node_ = parent_node->createChildSceneNode();
 
   static int count = 0;
-  std::stringstream ss;
-  ss << "LineMaterial" << count++;
+  std::string line_material_name = "LineMaterial" + std::to_string(count++);
 
   // NOTE: The second parameter to the create method is the resource group the material will be
   // added to. If the group you name does not exist (in your resources.cfg file) the library will
   // assert() and your program will crash
-  manual_object_material_ = Ogre::MaterialManager::getSingleton().create(
-    ss.str(), "rviz_rendering");
-  manual_object_material_->setReceiveShadows(false);
-  manual_object_material_->getTechnique(0)->setLightingEnabled(true);
+  manual_object_material_ = MaterialManager::createMaterialWithLighting(line_material_name);
   manual_object_material_->getTechnique(0)->getPass(0)->setDiffuse(0, 0, 0, 0);
   manual_object_material_->getTechnique(0)->getPass(0)->setAmbient(1, 1, 1);
 
@@ -114,13 +112,7 @@ void Line::setColor(const Ogre::ColourValue & c)
   manual_object_material_->getTechnique(0)->setAmbient(c * 0.5);
   manual_object_material_->getTechnique(0)->setDiffuse(c);
 
-  if (c.a < 0.9998) {
-    manual_object_material_->getTechnique(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
-    manual_object_material_->getTechnique(0)->setDepthWriteEnabled(false);
-  } else {
-    manual_object_material_->getTechnique(0)->setSceneBlending(Ogre::SBT_REPLACE);
-    manual_object_material_->getTechnique(0)->setDepthWriteEnabled(true);
-  }
+  MaterialManager::enableAlphaBlending(manual_object_material_, c.a);
 }
 
 void Line::setColor(float r, float g, float b, float a)


### PR DESCRIPTION
This is a cleanup PR: We harmonise transform behaviour, use message conversions and our alpha blending everywhere, where we couldn't use it till now (due to merge conflicts, etc.)