### PR TITLE
Fix pose selection when disabling display

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
@@ -87,6 +87,7 @@ public:
 protected:
   /** @brief Overridden from RosTopicDisplay to get arrow/axes visibility correct. */
   void onEnable() override;
+  void onDisable() override;
 
 private Q_SLOTS:
   void updateShapeVisibility();
@@ -97,6 +98,7 @@ private Q_SLOTS:
 
 private:
   void processMessage(geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;
+  void setupSelectionHandler();
 
   std::unique_ptr<rviz_rendering::Arrow> arrow_;
   std::unique_ptr<rviz_rendering::Axes> axes_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
@@ -114,11 +114,6 @@ void PoseDisplay::onInitialize()
 
   updateShapeChoice();
   updateColorAndAlpha();
-
-  coll_handler_ = rviz_common::interaction::createSelectionHandler
-    <PoseDisplaySelectionHandler>(this, context_);
-  coll_handler_->addTrackedObjects(arrow_->getSceneNode());
-  coll_handler_->addTrackedObjects(axes_->getSceneNode());
 }
 
 PoseDisplay::~PoseDisplay() = default;
@@ -127,6 +122,21 @@ void PoseDisplay::onEnable()
 {
   RTDClass::onEnable();
   updateShapeVisibility();
+  setupSelectionHandler();
+}
+
+void PoseDisplay::setupSelectionHandler()
+{
+  coll_handler_ = rviz_common::interaction::createSelectionHandler
+    <PoseDisplaySelectionHandler>(this, context_);
+  coll_handler_->addTrackedObjects(arrow_->getSceneNode());
+  coll_handler_->addTrackedObjects(axes_->getSceneNode());
+}
+
+void PoseDisplay::onDisable()
+{
+  RTDClass::onDisable();
+  coll_handler_.reset();
 }
 
 void PoseDisplay::updateColorAndAlpha()

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
@@ -105,9 +105,12 @@ rviz_common::interaction::V_AABB PoseDisplaySelectionHandler::getAABBs(
       aabbs.push_back(
         display_->arrow_->getShaft()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
     } else {
-      aabbs.push_back(display_->axes_->getXShape()->getEntity()->getWorldBoundingBox());
-      aabbs.push_back(display_->axes_->getYShape()->getEntity()->getWorldBoundingBox());
-      aabbs.push_back(display_->axes_->getZShape()->getEntity()->getWorldBoundingBox());
+      aabbs.push_back(
+        display_->axes_->getXShape()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
+      aabbs.push_back(
+        display_->axes_->getYShape()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
+      aabbs.push_back(
+        display_->axes_->getZShape()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
     }
   }
   return aabbs;


### PR DESCRIPTION
When disabling a pose display, the selection remained active (wire box present without arrow or axes). 
In addition, selection wireboxes acted weirdly for axes. 
Both issues are fixed with this PR.