### PR TITLE
Warn on missing CameraInfo

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -360,7 +360,14 @@ bool CameraDisplay::updateCamera()
     image = texture_->getImage();
   }
 
-  if (!info || !image) {
+  if (!image) {
+    return false;
+  }
+
+  if (!info) {
+    setStatus(StatusLevel::Warn, CAM_INFO_STATUS,
+      "Expecting Camera Info on topic [" + topic_property_->getTopic() + "/camera_info" + "]. "
+      "No CameraInfo received. Topic may not exist.");
     return false;
   }
 


### PR DESCRIPTION
When sending and subscribing to an image topic without subscribing to a camera topic: 
Current behaviour: Every status is okay and the camera display is empty.
New behaviour: A warning is shown to the user that the camera_info topic is empty.