### PR TITLE
Fix segfault on empty frame

### DIFF
--- a/rviz_common/src/rviz_common/frame_manager.cpp
+++ b/rviz_common/src/rviz_common/frame_manager.cpp
@@ -315,15 +315,21 @@ bool FrameManager::transform(
   if (stripped_fixed_frame[0] == '/') {
     stripped_fixed_frame = stripped_fixed_frame.substr(1);
   }
+
   // convert pose into new frame
   try {
     buffer_->transform(pose_in, pose_out, stripped_fixed_frame);
-  } catch (const tf2::LookupException & exec) {
-    (void) exec;
-    // RVIZ_COMMON_LOG_WARNING_STREAM("tf2 lookup exception when transforming: " << exec.what());
+  } catch (const tf2::LookupException & exception) {
+    (void) exception;
     return false;
-  } catch (const tf2::ConnectivityException & exec) {
-    (void) exec;
+  } catch (const tf2::ConnectivityException & exception) {
+    (void) exception;
+    return false;
+  } catch (const tf2::ExtrapolationException & exception) {
+    (void) exception;
+    return false;
+  } catch (const tf2::InvalidArgumentException & exception) {
+    (void) exception;
     return false;
   }
 

--- a/rviz_common/src/rviz_common/frame_manager.cpp
+++ b/rviz_common/src/rviz_common/frame_manager.cpp
@@ -48,8 +48,9 @@
 #include "tf2_ros/transform_listener.h"
 
 #include "rviz_common/display.hpp"
-#include "rviz_common/properties/property.hpp"
 #include "rviz_common/logging.hpp"
+#include "rviz_common/msg_conversions.hpp"
+#include "rviz_common/properties/property.hpp"
 
 namespace rviz_common
 {
@@ -75,9 +76,7 @@ FrameManager::FrameManager(
   setPause(false);
 }
 
-FrameManager::~FrameManager()
-{
-}
+FrameManager::~FrameManager() = default;
 
 void FrameManager::update()
 {
@@ -244,7 +243,7 @@ bool FrameManager::getTransform(
     return false;
   }
 
-  M_Cache::iterator it = cache_.find(CacheKey(frame, time));
+  auto it = cache_.find(CacheKey(frame, time));
   if (it != cache_.end()) {
     position = it->second.position;
     orientation = it->second.orientation;
@@ -278,15 +277,8 @@ bool FrameManager::transform(
 {
   // TODO(Martin-Idel-SI): Remove when https://github.com/ros2/geometry2/issues/58 closed
   if (frame == fixed_frame_) {
-    position = Ogre::Vector3(
-      pose_msg.position.x,
-      pose_msg.position.y,
-      pose_msg.position.z);
-    orientation = Ogre::Quaternion(
-      pose_msg.orientation.w,
-      pose_msg.orientation.x,
-      pose_msg.orientation.y,
-      pose_msg.orientation.z);
+    position = rviz_common::pointMsgToOgre(pose_msg.position);
+    orientation = rviz_common::quaternionMsgToOgre(pose_msg.orientation);
 
     return true;
   }
@@ -333,16 +325,8 @@ bool FrameManager::transform(
     return false;
   }
 
-  position = Ogre::Vector3(
-    pose_out.pose.position.x,
-    pose_out.pose.position.y,
-    pose_out.pose.position.z);
-  orientation = Ogre::Quaternion(
-    pose_out.pose.orientation.w,
-    pose_out.pose.orientation.x,
-    pose_out.pose.orientation.y,
-    pose_out.pose.orientation.z);
-
+  position = rviz_common::pointMsgToOgre(pose_out.pose.position);
+  orientation = rviz_common::quaternionMsgToOgre(pose_out.pose.orientation);
   return true;
 }
 


### PR DESCRIPTION
- Scenario: Forget to include a frame_id in a message header
- Current behaviour: Segfault
- New behaviour: No segfault, the status error tells the user that no transform exists between an empty frame and the fixed frame and the console prints the error messages from tf2.