### PR TITLE
Polish selection behaviour

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_handler.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_handler.cpp
@@ -83,6 +83,10 @@ SelectionHandler::~SelectionHandler()
   if (context_->getHandlerManager()) {
     context_->getHandlerManager()->removeHandler(pick_handle_);
   }
+  for (int i = 0; i < properties_.size(); i++) {
+    delete properties_.at(i);
+  }
+  properties_.clear();
 }
 
 void SelectionHandler::registerHandle()

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
@@ -69,6 +69,8 @@ public:
   void reset() override;
   void update(float wall_dt, float ros_dt) override;
 
+  void onDisable() override;
+
 protected:
   /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   void onInitialize() override;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
@@ -93,6 +93,8 @@ public:
   /// Move to public for testing
   bool cloudDataMatchesDimensions(sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud) const;
 
+  void onDisable() override;
+
 protected:
   /** @brief Do initialization. Overridden from RosTopicDisplay. */
   void onInitialize() override;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp
@@ -149,6 +149,8 @@ public:
 
   rviz_common::Display * getDisplay() {return display_;}
 
+  void onDisable();
+
   bool auto_size_;
 
   rviz_common::properties::BoolProperty * selectable_property_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
@@ -77,6 +77,8 @@ public:
 
   void update(float wall_dt, float ros_dt) override;
 
+  void onDisable() override;
+
 protected:
   /** @brief Do initialization. Overridden from RosTopicDisplay. */
   void onInitialize() override;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
@@ -87,6 +87,7 @@ public:
 protected:
   /** @brief Overridden from RosTopicDisplay to get arrow/axes visibility correct. */
   void onEnable() override;
+  void onDisable() override;
 
 private Q_SLOTS:
   void updateShapeVisibility();
@@ -97,6 +98,7 @@ private Q_SLOTS:
 
 private:
   void processMessage(geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;
+  void setupSelectionHandler();
 
   std::unique_ptr<rviz_rendering::Arrow> arrow_;
   std::unique_ptr<rviz_rendering::Axes> axes_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -98,6 +98,12 @@ void LaserScanDisplay::reset()
   point_cloud_common_->reset();
 }
 
+void LaserScanDisplay::onDisable()
+{
+  RosTopicDisplay::onDisable();
+  point_cloud_common_->onDisable();
+}
+
 }  // namespace displays
 }  // namespace rviz_default_plugins
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_marker_base.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/line_marker_base.cpp
@@ -64,6 +64,9 @@ void LineMarkerBase::onNewMessage(
   if (!lines_) {
     lines_ = std::make_shared<rviz_rendering::BillboardLine>(
       context_->getSceneManager(), scene_node_);
+    handler_ = rviz_common::interaction::createSelectionHandler<MarkerSelectionHandler>(
+      this, MarkerID(new_message->ns, new_message->id), context_);
+    handler_->addTrackedObjects(lines_->getSceneNode());
   }
 
   Ogre::Vector3 pos, scale;
@@ -94,10 +97,6 @@ void LineMarkerBase::onNewMessage(
   has_per_point_color_ = new_message->colors.size() == new_message->points.size();
 
   convertNewMessageToBillboardLine(new_message);
-
-  handler_ = rviz_common::interaction::createSelectionHandler<MarkerSelectionHandler>(
-    this, MarkerID(new_message->ns, new_message->id), context_);
-  handler_->addTrackedObjects(lines_->getSceneNode());
 }
 
 void LineMarkerBase::addPoint(

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
@@ -73,6 +73,7 @@ void PointsMarker::onNewMessage(
       this, MarkerID(new_message->ns, new_message->id), context_);
     points_->setPickColor(
       rviz_common::interaction::SelectionManager::handleToColor(handler_->getHandle()));
+    handler_->addTrackedObject(points_);
   }
 
   Ogre::Vector3 pose, scale;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -183,6 +183,12 @@ void PointCloud2Display::reset()
   point_cloud_common_->reset();
 }
 
+void PointCloud2Display::onDisable()
+{
+  RosTopicDisplay::onDisable();
+  point_cloud_common_->onDisable();
+}
+
 }  // namespace displays
 }  // namespace rviz_default_plugins
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -693,6 +693,16 @@ void PointCloudCommon::fillTransformerOptions(
   }
 }
 
+void PointCloudCommon::onDisable()
+{
+  for (auto cloud_info : cloud_infos_) {
+    cloud_info->selection_handler_.reset();
+  }
+  for (auto obsolete_cloud_info : obsolete_cloud_infos_) {
+    obsolete_cloud_info->selection_handler_.reset();
+  }
+}
+
 float PointCloudCommon::getSelectionBoxSize()
 {
   return style_property_->getOptionInt() != rviz_rendering::PointCloud::RM_POINTS ?

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -72,6 +72,12 @@ void PointCloudDisplay::reset()
   point_cloud_common_->reset();
 }
 
+void PointCloudDisplay::onDisable()
+{
+  RosTopicDisplay::onDisable();
+  point_cloud_common_->onDisable();
+}
+
 }  // namespace displays
 }  // namespace rviz_default_plugins
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
@@ -114,11 +114,6 @@ void PoseDisplay::onInitialize()
 
   updateShapeChoice();
   updateColorAndAlpha();
-
-  coll_handler_ = rviz_common::interaction::createSelectionHandler
-    <PoseDisplaySelectionHandler>(this, context_);
-  coll_handler_->addTrackedObjects(arrow_->getSceneNode());
-  coll_handler_->addTrackedObjects(axes_->getSceneNode());
 }
 
 PoseDisplay::~PoseDisplay() = default;
@@ -127,6 +122,21 @@ void PoseDisplay::onEnable()
 {
   RTDClass::onEnable();
   updateShapeVisibility();
+  setupSelectionHandler();
+}
+
+void PoseDisplay::setupSelectionHandler()
+{
+  coll_handler_ = rviz_common::interaction::createSelectionHandler
+    <PoseDisplaySelectionHandler>(this, context_);
+  coll_handler_->addTrackedObjects(arrow_->getSceneNode());
+  coll_handler_->addTrackedObjects(axes_->getSceneNode());
+}
+
+void PoseDisplay::onDisable()
+{
+  RTDClass::onDisable();
+  coll_handler_.reset();
 }
 
 void PoseDisplay::updateColorAndAlpha()

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display_selection_handler.cpp
@@ -105,9 +105,12 @@ rviz_common::interaction::V_AABB PoseDisplaySelectionHandler::getAABBs(
       aabbs.push_back(
         display_->arrow_->getShaft()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
     } else {
-      aabbs.push_back(display_->axes_->getXShape()->getEntity()->getWorldBoundingBox());
-      aabbs.push_back(display_->axes_->getYShape()->getEntity()->getWorldBoundingBox());
-      aabbs.push_back(display_->axes_->getZShape()->getEntity()->getWorldBoundingBox());
+      aabbs.push_back(
+        display_->axes_->getXShape()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
+      aabbs.push_back(
+        display_->axes_->getYShape()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
+      aabbs.push_back(
+        display_->axes_->getZShape()->getEntity()->getWorldBoundingBox(derive_world_bounding_box));
     }
   }
   return aabbs;


### PR DESCRIPTION
This PR polishes the behaviour of selection in multiple ways:

- All markers are now selectable and appear selected (previously line markers were only selected until the message was updated and point messages were not selected)
- Selections are deleted when disabling a display (previously was sometimes the case)

This PR also contains #309 