### PR TITLE
Make status non editable

### DIFF
--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -242,6 +242,7 @@ void Display::setStatusInternal(int level, const QString & name, const QString &
 
   if (!status_) {
     status_ = new rviz_common::properties::StatusList("Status");
+    status_->setReadOnly(true);
     addChild(status_, 0);
   }
   StatusProperty::Level old_level = status_->getLevel();

--- a/rviz_common/src/rviz_common/properties/status_list.cpp
+++ b/rviz_common/src/rviz_common/properties/status_list.cpp
@@ -57,6 +57,7 @@ void StatusList::setStatus(Level level, const QString & name, const QString & te
   StatusProperty * child;
   if (child_iter == status_children_.end()) {
     child = new StatusProperty(name, text, level, this);
+    child->setReadOnly(true);
     status_children_.insert(name, child);
   } else {
     child = child_iter.value();

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -226,6 +226,7 @@ VisualizationManager::VisualizationManager(
   updateBackgroundColor();
 
   global_status_ = new StatusList("Global Status", root_display_group_);
+  global_status_->setReadOnly(true);
 
   rviz_rendering::MaterialManager::createDefaultColorMaterials();
 


### PR DESCRIPTION
Currently, any status property can be edited. There is no reason for that, so this PR makes them not editable.