### PR TITLE
Fix bugs causing RViz to crash on macOS

### DIFF
--- a/rviz_common/include/rviz_common/render_panel.hpp
+++ b/rviz_common/include/rviz_common/render_panel.hpp
@@ -97,6 +97,11 @@ public:
    */
   QSize
   sizeHint() const override;
+
+  // This method has to be overridden in order to avoid an Ogre assertion to fail on macOS
+  // (The assertion can be found in OgreOSXCocoaWindow.mm, line 410)
+  void resizeEvent(QResizeEvent * event) override;
+
   static const Ogre::Vector3 default_camera_pose_;
 
 // TODO(wjwwood): reenable these and pass down to rviz_rendering::RenderWindow

--- a/rviz_common/src/rviz_common/render_panel.cpp
+++ b/rviz_common/src/rviz_common/render_panel.cpp
@@ -288,6 +288,12 @@ RenderPanel::sizeHint() const
   return QSize(320, 240);
 }
 
+void RenderPanel::resizeEvent(QResizeEvent * event)
+{
+  QWidget::resizeEvent(event);
+  render_window_->windowMovedOrResized();
+}
+
 const Ogre::Vector3 RenderPanel::default_camera_pose_ = Ogre::Vector3(999999, 999999, 999999);
 
 #if 0

--- a/rviz_rendering/include/rviz_rendering/render_window.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_window.hpp
@@ -98,6 +98,9 @@ public:
   void
   setupSceneAfterInit(setupSceneCallback setup_scene_callback);
 
+  void
+  windowMovedOrResized();
+
 public slots:
   virtual
   void

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -100,7 +100,7 @@ RenderWindowImpl::~RenderWindowImpl()
 {
   if (ogre_render_window_) {
     Ogre::Root::getSingletonPtr()->detachRenderTarget(ogre_render_window_);
-    ogre_render_window_->destroy();
+    Ogre::Root::getSingletonPtr()->destroyRenderTarget(ogre_render_window_);
     // enableStereo(false);  // free stereo resources
   }
 }

--- a/rviz_rendering/src/rviz_rendering/render_window.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window.cpp
@@ -117,6 +117,12 @@ RenderWindow::setupSceneAfterInit(setupSceneCallback setup_scene_callback)
   impl_->setupSceneAfterInit(setup_scene_callback);
 }
 
+void RenderWindow::windowMovedOrResized()
+{
+  // It seems that the 'width' and 'height' parameters of the resize() method don't play a role here
+  impl_->resize(0, 0);
+}
+
 void
 RenderWindow::renderLater()
 {


### PR DESCRIPTION
This PR fixes two bugs which caused RViz to crash on macOS, both related to displays with an own Ogre render window.

**First bug**
The first problem appeared only when building in Debug mode: as assert in `OgreOSXCocoaWindow.mm` (line 410) failed when the RViz windows was resized while having a second Ogre render window embedded in it (for example the one of an Image or Camera Display).
The commit [9b7471c6](https://github.com/ros2/rviz/commit/b7471c6d739af737c8f142ade47fac07775366d5) fixes this.

**Second bug**
A second crash of RViz used to happen after adding a display with own render window (again, like a Image or Camera display), removing it and then trying to resize the application window. In this case, it was a segfault occurring, therefore, also when building in Release mode. This second issue is fixed by the commit [3a9e36c](https://github.com/ros2/rviz/commit/3a9e36ca3218c3c38f9fc2438a68a37e00b2d94b)
