### PR TITLE
Hide warning when disabling map display

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -138,6 +138,8 @@ protected:
   void subscribe() override;
   void unsubscribe() override;
 
+  void onEnable() override;
+
   /** @brief Copy update's data into current_map_ and call showMap(). */
   void incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -240,7 +240,9 @@ void MapDisplay::updateDrawUnder() const
 
 void MapDisplay::clear()
 {
-  setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
+  if (isEnabled()) {
+    setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
+  }
 
   if (!loaded_) {
     return;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -131,7 +131,6 @@ MapDisplay::~MapDisplay()
 {
   unsubscribe();
   clear();
-  swatches_.clear();
 }
 
 Ogre::TexturePtr makePaletteTexture(std::vector<unsigned char> palette_bytes)
@@ -248,10 +247,10 @@ void MapDisplay::clear()
     return;
   }
 
-  for (const auto & swatch : swatches_) {
-    swatch->setVisible(false);
-    swatch->resetTexture();
-  }
+  swatches_.clear();
+  height_ = 0;
+  width_ = 0;
+  resolution_ = 0.0f;
 
   loaded_ = false;
 }
@@ -574,6 +573,12 @@ void MapDisplay::update(float wall_dt, float ros_dt)
   (void) ros_dt;
 
   transformMap();
+}
+
+void MapDisplay::onEnable()
+{
+  RosTopicDisplay::onEnable();
+  setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
 }
 
 }  // namespace displays

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/map/map_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/map/map_display_test.cpp
@@ -188,7 +188,7 @@ TEST_F(MapTestFixture, showMap_does_not_display_anything_if_transform_fails) {
   EXPECT_FALSE(manual_objects[0]->isVisible());
 }
 
-TEST_F(MapTestFixture, reset_makes_map_invisible) {
+TEST_F(MapTestFixture, reset_deletes_map) {
   mockValidTransform();
   Ogre::Vector3 position(1, 0, 0);
   Ogre::Quaternion orientation(0.5f, 0.5f, 0, 0);
@@ -200,8 +200,7 @@ TEST_F(MapTestFixture, reset_makes_map_invisible) {
   auto manual_objects = rviz_rendering::findAllOgreObjectByType<Ogre::ManualObject>(
     scene_manager_->getRootSceneNode(), "ManualObject");
 
-  ASSERT_THAT(manual_objects, SizeIs(1));
-  EXPECT_FALSE(manual_objects[0]->isVisible());
+  ASSERT_THAT(manual_objects, SizeIs(0));
 }
 
 TEST_F(MapTestFixture, createSwatches_creates_more_swatches_if_map_is_too_big) {


### PR DESCRIPTION
These changes hide the `Map is empty` warning when the map display is disabled.

Additionally, we cleaned up the `clear()` behavior for a more consistent behavior.
The map is now actually cleared instead of just being set invisible.