### PR TITLE
Improve plugin development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,24 @@ These features have already been ported from `ros-visualization/rviz` to `ros2/r
 The basic documentation can still be found on the rviz [wiki page](http://www.ros.org/wiki/rviz). 
 For some displays, the [documentation is updated](docs/FEATURES.md).
 
-| Displays               | Tools         | View Controller       | Panels          |
-| ---------------------- | ------------- | --------------------- | --------------- |
-| Camera                 | Move Camera   | Orbit                 | Displays        |
-| Grid                   | Focus Camera  | XY Orbit              | Help            |
-| Grid Cells             | Measure       | First Person          | Selections      |
-| Image                  | Select        | Third Person Follower | Tool Properties |
-| Laser Scan             | 2D Nav Goal   | Top Down Orthographic | Views           |
-| Map                    | Publish Point |                       |                 |
-| Marker                 |
-| Marker Array           |
-| Odometry               |
-| Point Cloud (1 and 2)  |
-| Point                  |
-| Polygon                |
-| Pose                   |
-| Pose Array             |
-| Robot Model            |
-| TF                     |
+| Displays              | Tools         | View Controller       | Panels          |
+| --------------------- | ------------- | --------------------- | --------------- |
+| Camera                | Move Camera   | Orbit                 | Displays        |
+| Grid                  | Focus Camera  | XY Orbit              | Help            |
+| Grid Cells            | Measure       | First Person          | Selections      |
+| Image                 | Select        | Third Person Follower | Tool Properties |
+| Laser Scan            | 2D Nav Goal   | Top Down Orthographic | Views           |
+| Map                   | Publish Point |                       |                 |
+| Marker                |
+| Marker Array          |
+| Odometry              |
+| Point Cloud (1 and 2) |
+| Point                 |
+| Polygon               |
+| Pose                  |
+| Pose Array            |
+| Robot Model           |
+| TF                    |
 
 ### Not yet ported
 These features have not been ported to `ros2/rviz` yet.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# rviz
+# RViz
 
 This branch is currently contained in the main `ros2.repos` file of ROS 2 and can be used for ROS 2.
 The latest release will be available with your ROS 2 download.
 
-ROS 2 does not have a wiki yet. To learn about rviz and its functionality, please refer to the ROS rviz [wiki page](http://www.ros.org/wiki/rviz). 
+ROS 2 does not have a wiki yet. To learn about RViz and its functionality, please refer to the ROS RViz [wiki page](http://www.ros.org/wiki/rviz). 
 
 ## Features
 
 ### Already ported
 These features have already been ported from `ros-visualization/rviz` to `ros2/rviz`.
-The basic documentation can still be found on the rviz [wiki page](http://www.ros.org/wiki/rviz). 
+The basic documentation can still be found on the RViz [wiki page](http://www.ros.org/wiki/rviz). 
 For some displays, the [documentation is updated](docs/FEATURES.md).
 
 | Displays              | Tools         | View Controller       | Panels          |
@@ -54,7 +54,7 @@ Other features:
 - Message filters
 - Image transport features
 
-In case you wished to see those features in rviz for ROS 2, feel free to add a pull request.
+In case you wished to see those features in RViz for ROS 2, feel free to add a pull request.
 Make sure to read the developer guide below and the migration guide.
 
 ### New features
@@ -66,13 +66,13 @@ None, yet.
 ### Build
 #### Building RViz together with ROS 2
 
-The simplest way to build from source is to use the official installation guide, since rviz is part of the official ROS 2 repos file.
+The simplest way to build from source is to use the official installation guide, since RViz is part of the official ROS 2 repos file.
 
 https://github.com/ros2/ros2/wiki/Installation
 
 #### Building RViz in a separate workspace
 
-When developing for rviz, it can be beneficial to build it in a separate workspace. 
+When developing for RViz, it can be beneficial to build it in a separate workspace. 
 
 **Note:** When building the current ros2 branch from source, the latest ROS 2 release for all dependencies might not be sufficient: it could be necessary to build the ROS 2 master branch.
 Make sure to have a source build of ROS 2 available (see installation procedure above).
@@ -93,15 +93,9 @@ $ git clone https://github.com/ros2/rviz.git
 Then build all the packages with this command:
 
 ```
-$ ament build
+$ colcon build --merge-install
 ```
-
-Or specific packages with command, for example just `rviz_ogre_vendor` and then `rviz_rendering`:
-
-```
-$ ament build --only rviz_ogre_vendor
-$ ament build --only rviz_rendering
-```
+The `--merge-install` flag is optional but ensures a cleaner environment which is helpful for development.
 
 More instructions and examples to come.
 
@@ -120,7 +114,7 @@ Main rationale here is to create code that can be well tested by avoiding highly
 
 ### Migration
 
-When migrating from rviz to rviz2, please see the more extensive [migration guide](docs/migration_guide.md).
+When migrating from `ros-visualization/rviz` to `ros2/rviz`, please see the more extensive [migration guide](docs/migration_guide.md).
 
 ### Plugin Development
 

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -2,48 +2,24 @@
 
 This is intended as a guide for people wishing to develop custom plugins.
 
-## Overview of RViz API
-
-### rviz_rendering
-
-The `rviz_rendering` package is supposed to contain all functionality referring to rendering:
-
-* Visuals and objects to be added to the scene graph such as arrows, shapes or text objects in the subfolder `objects` (many of those objects were ported from the folder `ogre_helpers`)
-* The render window, including functions exposing some of its internals (RenderWindowOgreAdapter). 
-  If possible, refrain from using the RenderWindowOgreAdapter, as it might be deprecated and deleted in the future
-* Convenience functions to work with materials (`material_manager.hpp`) or other ogre related functionality (e.g. ray tracing in `viewport_projection_finder.hpp`)
-* Convenience classes for testing, allowing to set up a working ogre environment and helpers for scene graph introspection
-
-### rviz_common
-
-The `rviz_common` package contains the bulk of rviz useful for doing plugin development:
-
-* Main application and rendering queues (not exposed)
-* Main entry points for plugin development - base classes for panels, view controllers, displays and tools
-* Convenience classes to work with properties in the various views (such as the display panel) located in `rviz_common/properties`
-* Main classes for selectable types, the SelectionHandlers (located in `rviz_common/interaction`)
-* Access points to ROS 2. 
-  Currently, rviz uses only one node, which can be accessed via `ros_integration`. 
-  In the future, further changes may be necessary to fully abstract ROS 2 access into `ros_integration`
-
-### rviz_default_plugins
-
-The `rviz_default_plugins` contains all plugins (view controllers, tools, displays and in the future, panels) shipped with rviz (most of them ported from the `default_plugins` folder of rviz). 
-
-* When developing simple plugins it is not necessary to use anything in this package.
-* When developing more complex plugins similar to existing plugins it might be beneficial to use or even derive from classes contained in this package to simplify your development.
-
-### rviz_visual_testing_framework
-
-The `rviz_visual_testing_framework` contains the backbone to writing visual tests for plugins. 
-It will only ever be necessary to use this package as a test dependency if you want to write automated screenshot tests.
-Please see the documentation in the package for further help.
-
-### rviz2
-
-This package contains the main program startup and entry point for nodes (not exposed).
 
 ## Plugin Development
+
+### Extension Points
+
+Plugins can extend RViz at different extension points:
+
+| plugin type | base type |
+| ----------- | --------- |
+| Display     | `rviz_common::Display` |
+| Panel       | `rviz_common::Panel`   |
+| Tool        | `rviz_common::Tool`    |
+| View Controller | `rviz_common::ViewController` |
+
+Every plugin must be of the corresponding base type in order to be recognized by RViz.
+Refer to the documentation of the relevant base class for a detailed API description.
+
+### Plugin Basics
 
 * In order to write your own plugin, set up a regular ROS 2 workspace (see the [official documentation]("https://github.com/ros2/ros2/wiki/Colcon-Tutorial") for further help).
 * You will need to link your program against `rviz_common` and probably also against `rviz_rendering` and `rviz_default_plugins`. 
@@ -61,14 +37,14 @@ target_compile_definitions(rviz_default_plugins PUBLIC "PLUGINLIB__DISABLE_BOOST
 target_compile_definitions(rviz_default_plugins PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 ```
 * You need to write a `plugin_description.xml` file which contains the information necessary for the pluginlib to load your plugin at runtime. 
-  See `rviz_default_plugins/plugins_description.xml` for an example (the syntax is the same as for the old rviz)
+  See `rviz_default_plugins/plugins_description.xml` for an example (the syntax is the same as for the old RViz)
 * Export the plugin description file via
 ```
 pluginlib_export_plugin_description_file(<your library> plugins_description.xml)
 ```
 This should make sure that your plugins are found at runtime
 
-### Writing a custom display
+### Writing a display plugin
 
 * In order to write a display plugin, derive from either `rviz_common::Display` or `rviz_common::RosTopicDisplay<MessageType>`.
 
@@ -100,20 +76,61 @@ register_rviz_ogre_media_exports(DIRECTORIES "test_folder/scripts")
 ```
 *Note:* If you want to export folder hierarchies, each folder needs to be exported separately. Folders within exported folders are not automatically available.
 
-### Writing a custom panel
+### Writing a panel plugin
 
 To write a custom panel, derive from `rviz_common::Panel`.
 
-### Writing a custom tool
+### Writing a tool plugin
 
 * When writing a tool, derive from `rviz_common::Tool`
 * Hotkeys for activating and deactivating tools can be set by setting the member variable `shortcut_key_` to the char of your choice
 * Adding properties to the "Tool Properties" panel is possible by passing the return value of the function `getPropertyContainer()` as parent to the property in question (see `rviz_default_plugins::tools::MeasureTool` for an example)
 * Custom cursors, icons, etc. for use in your plugins are available through `rviz_common/load_resource`
 
-### Writing a custom view controller
+### Writing a view controller plugin
 
 * In order to write a custom view controller which should be independent of tf frames, derive from `rviz_common::ViewController` 
 * If your view controller should be able to track tf frames in a scene, derive from `rviz_common::FramePositionTrackingViewController`, which already contains convenience functionality for tracking target frames
 * If your custom view controller orbits a focal point, it might also be beneficial to derive from `rviz_default_plugins::OrbitViewController`
 
+
+## Overview of RViz API
+
+### rviz_rendering
+
+The `rviz_rendering` package is supposed to contain all functionality referring to rendering:
+
+* Visuals and objects to be added to the scene graph such as arrows, shapes or text objects in the subfolder `objects` (many of those objects were ported from the folder `ogre_helpers`)
+* The render window, including functions exposing some of its internals (RenderWindowOgreAdapter). 
+  If possible, refrain from using the RenderWindowOgreAdapter, as it might be deprecated and deleted in the future
+* Convenience functions to work with materials (`material_manager.hpp`) or other ogre related functionality (e.g. ray tracing in `viewport_projection_finder.hpp`)
+* Convenience classes for testing, allowing to set up a working ogre environment and helpers for scene graph introspection
+
+### rviz_common
+
+The `rviz_common` package contains the bulk of RViz useful for doing plugin development:
+
+* Main application and rendering queues (not exposed)
+* Main entry points for plugin development - base classes for panels, view controllers, displays and tools
+* Convenience classes to work with properties in the various views (such as the display panel) located in `rviz_common/properties`
+* Main classes for selectable types, the SelectionHandlers (located in `rviz_common/interaction`)
+* Access points to ROS 2. 
+  Currently, RViz uses only one node, which can be accessed via `ros_integration`. 
+  In the future, further changes may be necessary to fully abstract ROS 2 access into `ros_integration`
+
+### rviz_default_plugins
+
+The `rviz_default_plugins` contains all plugins (view controllers, tools, displays and in the future, panels) shipped with RViz (most of them ported from the `default_plugins` folder of RViz). 
+
+* When developing simple plugins it is not necessary to use anything in this package.
+* When developing more complex plugins similar to existing plugins it might be beneficial to use or even derive from classes contained in this package to simplify your development.
+
+### rviz_visual_testing_framework
+
+The `rviz_visual_testing_framework` contains the backbone to writing visual tests for plugins. 
+It will only ever be necessary to use this package as a test dependency if you want to write automated screenshot tests.
+Please see the documentation in the package for further help.
+
+### rviz2
+
+This package contains the main program startup and entry point for nodes (not exposed).

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -9,11 +9,11 @@ This is intended as a guide for people wishing to develop custom plugins.
 
 Plugins can extend RViz at different extension points:
 
-| plugin type | base type |
-| ----------- | --------- |
-| Display     | `rviz_common::Display` |
-| Panel       | `rviz_common::Panel`   |
-| Tool        | `rviz_common::Tool`    |
+| plugin type     | base type                     |
+| --------------- | ----------------------------- |
+| Display         | `rviz_common::Display`        |
+| Panel           | `rviz_common::Panel`          |
+| Tool            | `rviz_common::Tool`           |
 | View Controller | `rviz_common::ViewController` |
 
 Every plugin must be of the corresponding base type in order to be recognized by RViz.


### PR DESCRIPTION
Reformat and polish the plugin development guide.

No CI since only markdown files have been changed.