### PR TITLE
add 20min ogre download timeout

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -124,6 +124,7 @@ macro(build_ogre)
   ExternalProject_Add(ogre-master-ca665a6
     URL https://github.com/OGRECave/ogre/archive/v1.10.11.zip
     URL_MD5 6ffd5048fae72805e287bfc0b462b2ea
+    TIMEOUT 1200
     LOG_CONFIGURE ${should_log}
     LOG_BUILD ${should_log}
     CMAKE_ARGS


### PR DESCRIPTION
Without timeout if cmake hangs during the download the jobs will never finish: e.g. https://github.com/ros2/build_cop/issues/77#issuecomment-400836869

This 20min timeout requires a download speed of ~100kb/s.
I can make it higher if we think it's too hard of a requirement