### PR TITLE
fix dependecy name for eigen

### DIFF
--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -31,7 +31,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>resource_retriever</depend>
-  <depend>eigen3</depend>
+  <depend>eigen</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>


### PR DESCRIPTION
This is needed to do the bloom release for Bouncy.