### PR TITLE
cleanup dependencies for rviz_rendering_tests

### DIFF
--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -18,22 +18,25 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>ament_index_cpp</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>resource_retriever</build_depend>
   <build_depend>rviz_assimp_vendor</build_depend>
   <build_depend>qtbase5-dev</build_depend>
+  <build_depend>rviz_ogre_vendor</build_depend>
 
+  <build_export_depend>eigen</build_export_depend>
   <build_export_depend>qtbase5-dev</build_export_depend>
+  <build_export_depend>rviz_ogre_vendor</build_export_depend>
 
   <exec_depend>ament_index_cpp</exec_depend>
+  <exec_depend>eigen</exec_depend>
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
   <exec_depend>resource_retriever</exec_depend>
   <exec_depend>rviz_assimp_vendor</exec_depend>
-
-  <depend>eigen</depend>
-  <depend>rviz_ogre_vendor</depend>
+  <exec_depend>rviz_ogre_vendor</exec_depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -19,9 +19,9 @@
 
   <build_depend>ament_index_cpp</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
   <build_depend>resource_retriever</build_depend>
   <build_depend>rviz_assimp_vendor</build_depend>
-  <build_depend>qtbase5-dev</build_depend>
   <build_depend>rviz_ogre_vendor</build_depend>
 
   <build_export_depend>eigen</build_export_depend>

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -17,21 +17,23 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>ament_index_cpp</build_depend>
+  <build_depend>resource_retriever</build_depend>
   <build_depend>rviz_assimp_vendor</build_depend>
-  <build_depend>rviz_ogre_vendor</build_depend>
   <build_depend>qtbase5-dev</build_depend>
 
-  <build_export_depend>rviz_assimp_vendor</build_export_depend>
+  <build_export_depend>qtbase5-dev</build_export_depend>
 
+  <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
-  <exec_depend>rviz_ogre_vendor</exec_depend>
+  <exec_depend>resource_retriever</exec_depend>
+  <exec_depend>rviz_assimp_vendor</exec_depend>
 
-  <depend>ament_index_cpp</depend>
-  <depend>resource_retriever</depend>
   <depend>eigen</depend>
+  <depend>rviz_ogre_vendor</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>


### PR DESCRIPTION
Ran into an issue with Qt's CMake module not getting installed in the binary deb job for this package. But it already had a build depend on `qtbase5`.

I don't think these changes will fix anything, but I figured I'd go ahead and fix the dependencies up while I was double checking what the headers included and stuff.