### PR TITLE
Add Qt dependency to testing packages.

### DIFF
--- a/rviz_rendering_tests/package.xml
+++ b/rviz_rendering_tests/package.xml
@@ -12,6 +12,8 @@
 
     <buildtool_depend>ament_cmake</buildtool_depend>
 
+    <build_depend>qtbase5-dev</build_depend>
+
     <depend>rviz_rendering</depend>
     <depend>resource_retriever</depend>
 

--- a/rviz_visual_testing_framework/package.xml
+++ b/rviz_visual_testing_framework/package.xml
@@ -15,6 +15,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>qtbase5-dev</build_depend>
+
   <depend>rviz_common</depend>
   <depend>ament_cmake_gtest</depend>
 


### PR DESCRIPTION
The binarydeb builds for these packages are currently failing to configure

```
05:09:46 CMake Error at CMakeLists.txt:26 (find_package):
05:09:46   By not providing "FindQt5.cmake" in CMAKE_MODULE_PATH this project has
05:09:46   asked CMake to find a package configuration file provided by "Qt5", but
05:09:46   CMake did not find one.
05:09:46 
05:09:46   Could not find a package configuration file provided by "Qt5" with any of
05:09:46   the following names:
05:09:46 
05:09:46     Qt5Config.cmake
05:09:46     qt5-config.cmake
05:09:46 
05:09:46   Add the installation prefix of "Qt5" to CMAKE_PREFIX_PATH or set "Qt5_DIR"
05:09:46   to a directory containing one of the above files.  If "Qt5" provides a
05:09:46   separate development package or SDK, be sure it has been installed.
05:09:46 
05:09:46 
05:09:46 -- Configuring incomplete, errors occurred!
```

The example above was excerpted from [this build](http://build.ros2.org/view/Bbin_uB64/job/Bbin_uB64__rviz_rendering_tests__ubuntu_bionic_amd64__binary/3) of rviz_rendering_tests.

rviz_visual_testing_framework actually gets this dependency satisfied by the build_export_depend in rviz_common so we could take that out. I'm not sure if there's a preference to depend directly on any package that's used directly or not. 