### PR TITLE
Fix missing status in laser scan display

### DIFF
--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -223,7 +223,6 @@ void Display::setMissingTransformToFixedFrame(
     "Could not transform " + (additional_info.empty() ? "from [" : additional_info + " from [") +
     frame + "] to [" + fixed_frame_.toStdString() + "]";
   setStatusStd(properties::StatusProperty::Error, "Transform", error_string);
-  RVIZ_COMMON_LOG_DEBUG(error_string);
 }
 
 void Display::setTransformOk()

--- a/rviz_common/src/rviz_common/frame_manager.cpp
+++ b/rviz_common/src/rviz_common/frame_manager.cpp
@@ -180,29 +180,16 @@ bool FrameManager::adjustTime(const std::string & frame, rclcpp::Time & time)
             time = sync_time_;
           }
         } catch (const tf2::LookupException & exception) {
-          RVIZ_COMMON_LOG_ERROR_STREAM("Lookup failed while getting latest time from frame " <<
-            frame.c_str() << " to frame " <<
-            fixed_frame_.c_str() << ": " <<
-            exception.what());
+          RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
           return false;
         } catch (const tf2::ConnectivityException & exception) {
-          RVIZ_COMMON_LOG_ERROR_STREAM("Connection exception getting latest time from frame " <<
-            frame.c_str() << " to frame " <<
-            fixed_frame_.c_str() << ": " <<
-            exception.what());
+          RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
           return false;
         } catch (const tf2::ExtrapolationException & exception) {
-          RVIZ_COMMON_LOG_ERROR_STREAM("Extrapolation exception getting latest time from frame " <<
-            frame.c_str() << " to frame " <<
-            fixed_frame_.c_str() << ": " <<
-            exception.what());
+          RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
           return false;
         } catch (const tf2::InvalidArgumentException & exception) {
-          RVIZ_COMMON_LOG_ERROR_STREAM("Invalid argument exception "
-            "getting latest time from frame " <<
-            frame.c_str() << " to frame " <<
-            fixed_frame_.c_str() << ": " <<
-            exception.what());
+          RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
           return false;
         }
       }
@@ -299,16 +286,16 @@ bool FrameManager::transform(
   try {
     buffer_->transform(pose_in, pose_out, stripped_fixed_frame);
   } catch (const tf2::LookupException & exception) {
-    (void) exception;
+    RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
     return false;
   } catch (const tf2::ConnectivityException & exception) {
-    (void) exception;
+    RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
     return false;
   } catch (const tf2::ExtrapolationException & exception) {
-    (void) exception;
+    RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
     return false;
   } catch (const tf2::InvalidArgumentException & exception) {
-    (void) exception;
+    RVIZ_COMMON_LOG_ERROR_STREAM(exception.what());
     return false;
   }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -79,10 +79,11 @@ void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPt
       *buffer,
       laser_geometry::channel_option::Intensity);
   } catch (tf2::TransformException & e) {
-    RVIZ_COMMON_LOG_DEBUG_STREAM(
-      "LaserScan [" << qPrintable(getName()) << "]: failed to transform scan:" << e.what() << ".");
+    (void) e;
+    setMissingTransformToFixedFrame(scan->header.frame_id);
     return;
   }
+  setTransformOk();
 
   point_cloud_common_->addMessage(cloud);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -78,9 +78,9 @@ void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPt
       *cloud,
       *buffer,
       laser_geometry::channel_option::Intensity);
-  } catch (tf2::TransformException & e) {
-    (void) e;
+  } catch (tf2::TransformException & exception) {
     setMissingTransformToFixedFrame(scan->header.frame_id);
+    RVIZ_COMMON_LOG_ERROR(exception.what());
     return;
   }
   setTransformOk();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -541,9 +541,6 @@ void MapDisplay::transformMap()
     !context_->getFrameManager()->transform(frame_, context_->getClock()->now(),
     current_map_.info.origin, position, orientation))
   {
-    RVIZ_COMMON_LOG_ERROR_STREAM("Error transforming map '" << getName().toStdString() <<
-      "' from frame '" << frame_ << "' to '" << fixed_frame_.toStdString() << "'.");
-
     setMissingTransformToFixedFrame(frame_);
     scene_node_->setVisible(false);
   } else {


### PR DESCRIPTION
This is part of #332 . This will not solve the bug #332 - it will merely improve error messaging. 

- RViz should complain in the GUI when the transform of the laser scan is missing. 
- Furthermore, error messages printed to the console are improved by using the tf2 error message directly. 

Note: Showing tf2 error messages in the GUI would require a heavier refactoring as the status is handled at a different level than error processing (`display` vs `frame_manager`).

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4890)](http://ci.ros2.org/job/ci_linux/4890/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1726)](http://ci.ros2.org/job/ci_linux-aarch64/1726/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4065)](http://ci.ros2.org/job/ci_osx/4065/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4922)](http://ci.ros2.org/job/ci_windows/4922/)