### PR TITLE
Revert workaround for identity transform after geometry2 fix

### DIFF
--- a/rviz_common/src/rviz_common/frame_manager.cpp
+++ b/rviz_common/src/rviz_common/frame_manager.cpp
@@ -249,14 +249,6 @@ bool FrameManager::transform(
   Ogre::Vector3 & position,
   Ogre::Quaternion & orientation)
 {
-  // TODO(Martin-Idel-SI): Remove when https://github.com/ros2/geometry2/issues/58 closed
-  if (frame == fixed_frame_) {
-    position = rviz_common::pointMsgToOgre(pose_msg.position);
-    orientation = rviz_common::quaternionMsgToOgre(pose_msg.orientation);
-
-    return true;
-  }
-
   if (!adjustTime(frame, time)) {
     return false;
   }
@@ -308,11 +300,6 @@ bool FrameManager::frameHasProblems(
   const std::string & frame,
   std::string & error)
 {
-  // TODO(Martin-Idel-SI): Remove when https://github.com/ros2/geometry2/issues/58 closed
-  if (frame == fixed_frame_) {
-    return false;
-  }
-
   if (!buffer_->_frameExists(frame)) {
     error = "Frame [" + frame + "] does not exist";
     if (frame == fixed_frame_) {


### PR DESCRIPTION
The workaround was introduced in PR #298 and is now fixed in geometry2 (https://github.com/ros2/geometry2/pull/65)