### PR TITLE
Increase visual testing stability

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp
@@ -89,6 +89,7 @@ public:
 
 private Q_SLOTS:
   void updateAlpha();
+  void updateColor();
 
 private:
   bool messageIsValid(nav_msgs::msg::GridCells::ConstSharedPtr msg);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
@@ -62,7 +62,7 @@ GridCellsDisplay::GridCellsDisplay()
 : last_frame_count_(uint64_t(-1))
 {
   color_property_ = new rviz_common::properties::ColorProperty("Color", QColor(25, 255, 0),
-      "Color of the grid cells.", this);
+      "Color of the grid cells.", this, SLOT(updateColor()));
 
   alpha_property_ = new rviz_common::properties::FloatProperty("Alpha", 1.0f,
       "Amount of transparency to apply to the cells.",
@@ -98,6 +98,12 @@ GridCellsDisplay::~GridCellsDisplay()
 void GridCellsDisplay::updateAlpha()
 {
   cloud_->setAlpha(alpha_property_->getFloat());
+  context_->queueRender();
+}
+
+void GridCellsDisplay::updateColor()
+{
+  cloud_->setPickColor(rviz_common::properties::qtToOgre(color_property_->getColor()));
   context_->queueRender();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
@@ -103,7 +103,7 @@ void GridCellsDisplay::updateAlpha()
 
 void GridCellsDisplay::updateColor()
 {
-  cloud_->setPickColor(rviz_common::properties::qtToOgre(color_property_->getColor()));
+  cloud_->setColor(rviz_common::properties::qtToOgre(color_property_->getColor()));
   context_->queueRender();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -104,7 +104,6 @@ ImageDisplay::ImageDisplay(std::unique_ptr<ROSImageTextureIface> texture)
 void ImageDisplay::onInitialize()
 {
   RTDClass::onInitialize();
-  topic_property_->setValue("image");
 
   updateNormalizeOptions();
   setupScreenRectangle();

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_visual_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_visual_test.cpp
@@ -44,6 +44,7 @@ TEST_F(VisualTestFixture, test_image_display_with_published_image) {
   setCamLookAt(Ogre::Vector3(0, 0, 0));
 
   auto image_display = addDisplay<ImageDisplayPageObject>();
+  image_display->setTopic("/image");
 
   captureRenderWindow(image_display);
 

--- a/rviz_rendering/include/rviz_rendering/objects/point_cloud.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/point_cloud.hpp
@@ -183,6 +183,9 @@ public:
   void setAlpha(float alpha, bool per_point_alpha = false);
 
   RVIZ_RENDERING_PUBLIC
+  void setColor(const Ogre::ColourValue & color);
+
+  RVIZ_RENDERING_PUBLIC
   void setPickColor(const Ogre::ColourValue & color);
 
   RVIZ_RENDERING_PUBLIC

--- a/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
@@ -457,7 +457,7 @@ void PointCloud::setAlpha(float alpha, bool per_point_alpha)
 
 void PointCloud::setColor(const Ogre::ColourValue & color)
 {
-  for(auto & point : points_) {
+  for (auto & point : points_) {
     point.setColor(color.r, color.g, color.b, color.a);
   }
   regenerateAll();

--- a/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
@@ -455,6 +455,14 @@ void PointCloud::setAlpha(float alpha, bool per_point_alpha)
   }
 }
 
+void PointCloud::setColor(const Ogre::ColourValue & color)
+{
+  for(auto & point : points_) {
+    point.setColor(color.r, color.g, color.b, color.a);
+  }
+  regenerateAll();
+}
+
 void PointCloud::addPoints(
   std::vector<Point>::iterator start_iterator,
   std::vector<Point>::iterator stop_iterator)

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/visual_test_publisher.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/visual_test_publisher.hpp
@@ -30,6 +30,7 @@
 #ifndef RVIZ_VISUAL_TESTING_FRAMEWORK__VISUAL_TEST_PUBLISHER_HPP_
 #define RVIZ_VISUAL_TESTING_FRAMEWORK__VISUAL_TEST_PUBLISHER_HPP_
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
@@ -86,7 +87,6 @@ private:
     auto transformer_publisher_node = std::make_shared<rclcpp::Node>("static_transform_publisher");
     tf2_ros::StaticTransformBroadcaster broadcaster(transformer_publisher_node);
 
-    rclcpp::WallRate loop_rate(0.2);
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(transformer_publisher_node);
 
@@ -101,7 +101,7 @@ private:
         broadcaster.sendTransform(msg);
       }
       executor.spin_some();
-      loop_rate.sleep();
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
   }
 


### PR DESCRIPTION
This PR stabilizes the visual tests for the `ImageDisplay` and the `GridCellsDisplay`.
Also discussed here: https://github.com/ros2/ci/pull/211#issuecomment-406607572