### PR TITLE
Fixes #341

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -77,6 +77,7 @@ void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPt
       *scan,
       *cloud,
       *buffer,
+      -1,
       laser_geometry::channel_option::Intensity);
   } catch (tf2::TransformException & exception) {
     setMissingTransformToFixedFrame(scan->header.frame_id);


### PR DESCRIPTION
This pull request is in regards to #341 

After filing the bug report I went an did some digging to figure out why the bug was occurring.
As it turns out, in `laser_scan_display:75`, the function call:
```cpp
    projector_->transformLaserScanToPointCloud(
      fixed_frame_.toStdString(),
      *scan,
      *cloud,
      *buffer,
      laser_geometry::channel_option::Intensity);
```
calls a function in laser_geometry with a prototype as such:
```cpp
  void transformLaserScanToPointCloud(
    const std::string & target_frame,
    const sensor_msgs::msg::LaserScan & scan_in,
    sensor_msgs::msg::PointCloud2 & cloud_out,
    tf2::BufferCore & tf,
    double range_cutoff = -1.0,
    int channel_options = channel_option::Default)
```
The relevant parameter here is the `range_cutoff`, which controls at what range reading the transform should discard the readings. By default this value is implicitly set to -1 as seen, which means the `range_cutoff` would be inherited from the `max_range` of the incoming `Laserscan`, this is usually desired behavior.

However, `range_cutoff` is not the only default argument, `channel_options` is one as well, and the bug was caused by ambigious interpretation of the arguments due to the original call above omitting the range_cutoff. Since both arguments can be implicitly converted to one another's type, both are default, and `range_cutoff` comes first, this results in the interpretation that 
```cpp 
range_cutoff = laser_geometry::channel_option::Intensity
```
cutoff is one meter because `laser_geometry::channel_option::Intensity = 0x01`

The proposed fix is the simplest possible solution, which is to explicitly set `range_cutoff` and correct the positioning. 
