### PR TITLE
backport changes for bouncy patch release 2

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -77,6 +77,7 @@ void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPt
       *scan,
       *cloud,
       *buffer,
+      -1,
       laser_geometry::channel_option::Intensity);
   } catch (tf2::TransformException & e) {
     RVIZ_COMMON_LOG_DEBUG_STREAM(


### PR DESCRIPTION
Backported changes:

- fixes laserscan 1 meter limit bug (#345)

This will be released as `4.0.2`.

See: https://github.com/ros2/ros2/issues/563