### PR TITLE
Fix wrong name of InitialPose plugin in default config

### DIFF
--- a/rviz_common/default.rviz
+++ b/rviz_common/default.rviz
@@ -61,7 +61,7 @@ Visualization Manager:
     - Class: rviz_default_plugins/Select
     - Class: rviz_default_plugins/FocusCamera
     - Class: rviz_default_plugins/Measure
-    - Class: rviz/SetInitialPose
+    - Class: rviz_default_plugins/SetInitialPose
       Topic: /initialpose
     - Class: rviz_default_plugins/SetGoal
       Topic: /move_base_simple/goal


### PR DESCRIPTION
Changed from incorrect `rviz/` to `rviz_default_plugins/`

No CI as it isn't picked up anywhere.