### PR TITLE
Fix delay in displaying TF frames

### DIFF
--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -392,7 +392,7 @@ void VisualizationManager::onUpdate()
     resetTime();
   }
 
-  executor_->spin_once(std::chrono::milliseconds(10));
+  executor_->spin_some(std::chrono::milliseconds(10));
 
   Q_EMIT preUpdate();
 


### PR DESCRIPTION
This fixes ros2/ros1_bridge#133 . Displayed tf data was delayed because rviz wasn't able to call callbacks fast enough to service the transform listener subscription. This resulted in tf2 always having out of date transforms (see ros2/geometry2#71), and gave the mistaken impression that rviz2 was receiving data slower than rviz over the bridge.

To fix this executors now have a parameter `max_duration` on `spin_some()`. This prevents `spin_some()` from blocking the gui update while allowing callbacks to be executed faster than the gui updates.

rviz left, rviz2 right

Before this PR
![peek 2018-09-14 11-14_tf_lag](https://user-images.githubusercontent.com/4175662/45580634-6404ea80-b848-11e8-824e-ec5b5eafaf54.gif)

With this PR
![peek 2018-09-14 17-54_rviz_tf_fix](https://user-images.githubusercontent.com/4175662/45580637-68c99e80-b848-11e8-83b7-21452b8dbccc.gif)

To reproduce the gifs see https://github.com/ros2/ros1_bridge/issues/133#issuecomment-421444534
