### PR TITLE
Add virtual destructors for WindowManagerInterface and ViewportProjectionFinder

### DIFF
--- a/rviz_common/include/rviz_common/window_manager_interface.hpp
+++ b/rviz_common/include/rviz_common/window_manager_interface.hpp
@@ -49,6 +49,8 @@ class PanelDockWidget;
 class WindowManagerInterface
 {
 public:
+  virtual ~WindowManagerInterface() = default;
+
   /// Return the parent QWidget.
   virtual
   QWidget *

--- a/rviz_rendering/include/rviz_rendering/viewport_projection_finder.hpp
+++ b/rviz_rendering/include/rviz_rendering/viewport_projection_finder.hpp
@@ -52,6 +52,7 @@ class RVIZ_RENDERING_PUBLIC ViewportProjectionFinder
 {
 public:
   ViewportProjectionFinder() = default;
+  virtual ~ViewportProjectionFinder() = default;
 
   virtual std::pair<bool, Ogre::Vector3> getViewportPointProjectionOnXYPlane(
     RenderWindow * render_window, int x, int y);


### PR DESCRIPTION
To fix the following warnings (converted to errors by compile options):
```
error: destructor called on non-final 'MockProjectionFinder' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
error: destructor called on non-final 'MockWindowManagerInterface' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
```
This is when compiling with clang 7 on ArchLinux.