### PR TITLE
Export libraries to trigger hooks.

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -291,6 +291,7 @@ ament_export_dependencies(
   tf2_ros
 )
 ament_export_include_directories(include)
+ament_export_libraries(rviz_common)
 
 install(
   TARGETS rviz_common

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -241,6 +241,7 @@ ament_target_dependencies(rviz_default_plugins
 
 ament_export_include_directories(include)
 ament_export_interfaces(rviz_default_plugins)
+ament_export_libraries(rviz_default_plugins)
 ament_export_dependencies(
   Qt5
   rviz_common

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -240,8 +240,7 @@ ament_target_dependencies(rviz_default_plugins
 )
 
 ament_export_include_directories(include)
-ament_export_interfaces(rviz_default_plugins)
-ament_export_libraries(rviz_default_plugins)
+ament_export_interfaces(rviz_default_plugins HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   Qt5
   rviz_common

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -131,6 +131,7 @@ ament_export_dependencies(
   ament_index_cpp)
 
 ament_export_include_directories(include)
+ament_export_libraries(rviz_rendering)
 
 install(
   TARGETS rviz_rendering


### PR DESCRIPTION
Add `ament_export_libraries` calls to export libraries and set necessary environment hooks. The rviz packages are some of a handful which install libraries exporting them.

In conversation with @wjwwood we surmised that this was likely a small oversight rather than something that was done intentionally.

Connects to ros2/ros_workspace#10