### PR TITLE
change display to load urdf content from parameter

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
@@ -115,7 +115,9 @@ protected:
    * "Robot Description" property, iterates through the links, and
    * loads any necessary models. */
   virtual void load_urdf();
+  virtual void load_urdf_parameter(const std::string & parameter);
   virtual void load_urdf_from(const std::string & filepath);
+  virtual void load_urdf_content(const std::string & content);
   void updateRobot();
 
   void processMessage(std_msgs::msg::String::ConstSharedPtr msg) override;


### PR DESCRIPTION
connects to ros2/robot_state_publisher#15

This is work in progress. The PR so far introduces a new option for the robot model to load from parameter.
I haven't figured out yet though how to spawn a remote parameter client while the node is already up and running (inside an executor).