### PR TITLE
Revert "Visibility followup for marker"

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
@@ -68,15 +68,13 @@ class MapDisplay;
 class Swatch
 {
 public:
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  Swatch(
+  RVIZ_DEFAULT_PLUGINS_PUBLIC Swatch(
     Ogre::SceneManager * scene_manager,
     Ogre::SceneNode * parent_scene_node,
     size_t x, size_t y, size_t width, size_t height,
     float resolution, bool draw_under);
 
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  ~Swatch();
+  RVIZ_DEFAULT_PLUGINS_PUBLIC ~Swatch();
 
   RVIZ_DEFAULT_PLUGINS_PUBLIC
   void updateAlpha(

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/arrow_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/arrow_marker.hpp
@@ -38,14 +38,6 @@
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
-// This is necessary because of using stl types with this display. Nevertheless, if you are
-// experiencing problems when subclassing this class, please make sure ROS2 and your code were
-// compiled with the same compiler and version
-#ifdef _WIN32
-# pragma warning(push)
-# pragma warning(disable:4251)
-#endif
-
 namespace Ogre
 {
 class SceneNode;
@@ -62,14 +54,17 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC ArrowMarker : public MarkerBase
+class ArrowMarker : public MarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ArrowMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~ArrowMarker() override = default;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   S_MaterialPtr getMaterials() override;
 
 protected:
@@ -88,9 +83,5 @@ private:
 }  // namespace markers
 }  // namespace displays
 }  // namespace rviz_default_plugins
-
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 #endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKERS__ARROW_MARKER_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/line_list_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/line_list_marker.hpp
@@ -44,12 +44,13 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC LineListMarker : public LineMarkerBase
+class LineListMarker : public LineMarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   LineListMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
-
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~LineListMarker() override = default;
 
 private:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/line_marker_base.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/line_marker_base.hpp
@@ -37,14 +37,6 @@
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
-// This is necessary because of using stl types with this display. Nevertheless, if you are
-// experiencing problems when subclassing this class, please make sure ROS2 and your code were
-// compiled with the same compiler and version
-#ifdef _WIN32
-# pragma warning(push)
-# pragma warning(disable:4251)
-#endif
-
 namespace rviz_rendering
 {
 class BillboardLine;
@@ -62,12 +54,14 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC LineMarkerBase : public MarkerBase
+class LineMarkerBase : public MarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   LineMarkerBase(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   S_MaterialPtr getMaterials() override;
 
 protected:
@@ -91,9 +85,5 @@ private:
 }  // namespace markers
 }  // namespace displays
 }  // namespace rviz_default_plugins
-
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 #endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKERS__LINE_MARKER_BASE_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/line_strip_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/line_strip_marker.hpp
@@ -42,11 +42,13 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC LineStripMarker : public LineMarkerBase
+class LineStripMarker : public LineMarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   LineStripMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~LineStripMarker() override = default;
 
 protected:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_base.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_base.hpp
@@ -42,14 +42,6 @@
 #include "rviz_common/interaction/forwards.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
-// This is necessary because of using stl types with this display. Nevertheless, if you are
-// experiencing problems when subclassing this class, please make sure ROS2 and your code were
-// compiled with the same compiler and version
-#ifdef _WIN32
-# pragma warning(push)
-# pragma warning(disable:4251)
-#endif
-
 namespace Ogre
 {
 class SceneNode;
@@ -76,29 +68,38 @@ class MarkerSelectionHandler;
 typedef std::pair<std::string, int32_t> MarkerID;
 typedef std::set<Ogre::MaterialPtr> S_MaterialPtr;
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC MarkerBase
+class MarkerBase
 {
 public:
   typedef visualization_msgs::msg::Marker Marker;
   typedef visualization_msgs::msg::Marker::ConstSharedPtr MarkerConstSharedPtr;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   MarkerBase(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   virtual ~MarkerBase();
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void setMessage(const Marker & message);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void setMessage(const MarkerConstSharedPtr & message);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   bool expired();
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void updateFrameLocked();
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   const MarkerConstSharedPtr & getMessage() const {return message_;}
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   MarkerID getID() {return MarkerID(message_->ns, message_->id);}
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   std::string getStringID()
   {
     return message_->ns + "/" + std::to_string(message_->id);
@@ -108,14 +109,19 @@ public:
   /** @brief Associate an InteractiveObject with this MarkerBase. */
   // void setInteractiveObject(InteractiveObjectWPtr object);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   virtual void setPosition(const Ogre::Vector3 & position);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   virtual void setOrientation(const Ogre::Quaternion & orientation);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   const Ogre::Vector3 & getPosition();
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   const Ogre::Quaternion & getOrientation();
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   virtual S_MaterialPtr getMaterials() {return S_MaterialPtr();}
 
 protected:
@@ -145,9 +151,5 @@ protected:
 }  // namespace markers
 }  // namespace displays
 }  // namespace rviz_default_plugins
-
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 #endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKERS__MARKER_BASE_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_factory.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_factory.hpp
@@ -58,7 +58,7 @@ namespace markers
  * Markers come in as visualization_msgs::msg::Marker messages.
  * See the Marker message for more information.
 */
-class RVIZ_DEFAULT_PLUGINS_PUBLIC MarkerFactory
+class MarkerFactory
 {
 public:
   /// Initialization of the marker factory
@@ -69,6 +69,7 @@ public:
    * \param context Display context.
    * \param parent_node Ogre parent scene node.
    */
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void initialize(
     MarkerCommon * owner, rviz_common::DisplayContext * context,
     Ogre::SceneNode * parent_node);
@@ -79,6 +80,7 @@ public:
    * \param marker_type marker type of the marker message
    * \return shared pointer of the generated marker
    */
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   std::shared_ptr<MarkerBase>
   createMarkerForType(visualization_msgs::msg::Marker::_type_type marker_type);
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_selection_handler.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_selection_handler.hpp
@@ -58,23 +58,29 @@ class InteractiveMarkerControl;
 class MarkerBase;
 typedef std::pair<std::string, int32_t> MarkerID;
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC MarkerSelectionHandler : public
+class MarkerSelectionHandler : public
   rviz_common::interaction::SelectionHandler
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   MarkerSelectionHandler(
     const MarkerBase * marker, MarkerID id, rviz_common::DisplayContext * context);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~MarkerSelectionHandler() override;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   Ogre::Vector3 getPosition();
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   Ogre::Quaternion getOrientation();
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void createProperties(
     const rviz_common::interaction::Picked & obj,
     rviz_common::properties::Property * parent_property) override;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void updateProperties() override;
 
 private:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
@@ -39,14 +39,6 @@
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
-// This is necessary because of using stl types with this display. Nevertheless, if you are
-// experiencing problems when subclassing this class, please make sure ROS2 and your code were
-// compiled with the same compiler and version
-#ifdef _WIN32
-# pragma warning(push)
-# pragma warning(disable:4251)
-#endif
-
 namespace Ogre
 {
 class SceneNode;
@@ -65,14 +57,17 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC MeshResourceMarker : public MarkerBase
+class MeshResourceMarker : public MarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   MeshResourceMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~MeshResourceMarker() override;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   S_MaterialPtr getMaterials() override;
 
 protected:
@@ -99,9 +94,5 @@ private:
 }  // namespace markers
 }  // namespace displays
 }  // namespace rviz_default_plugins
-
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 #endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKERS__MESH_RESOURCE_MARKER_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/points_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/points_marker.hpp
@@ -48,14 +48,17 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC PointsMarker : public MarkerBase
+class PointsMarker : public MarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   PointsMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~PointsMarker() override;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void setHighlightColor(float red, float green, float blue);
 
 protected:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/shape_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/shape_marker.hpp
@@ -36,14 +36,6 @@
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
-// This is necessary because of using stl types with this display. Nevertheless, if you are
-// experiencing problems when subclassing this class, please make sure ROS2 and your code were
-// compiled with the same compiler and version
-#ifdef _WIN32
-# pragma warning(push)
-# pragma warning(disable:4251)
-#endif
-
 namespace rviz_rendering
 {
 class Shape;
@@ -56,12 +48,14 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC ShapeMarker : public MarkerBase
+class ShapeMarker : public MarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ShapeMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   S_MaterialPtr getMaterials() override;
 
 protected:
@@ -77,9 +71,5 @@ private:
 }  // namespace markers
 }  // namespace displays
 }  // namespace rviz_default_plugins
-
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 #endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKERS__SHAPE_MARKER_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.hpp
@@ -51,16 +51,20 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC TextViewFacingMarker : public MarkerBase
+class TextViewFacingMarker : public MarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   TextViewFacingMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~TextViewFacingMarker() override;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   void setOrientation(const Ogre::Quaternion & orientation) override {(void) orientation;}
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   S_MaterialPtr getMaterials() override;
 
 protected:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/triangle_list_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/triangle_list_marker.hpp
@@ -54,14 +54,6 @@
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
-// This is necessary because of using stl types with this display. Nevertheless, if you are
-// experiencing problems when subclassing this class, please make sure ROS2 and your code were
-// compiled with the same compiler and version
-#ifdef _WIN32
-# pragma warning(push)
-# pragma warning(disable:4251)
-#endif
-
 namespace Ogre
 {
 class SceneNode;
@@ -75,14 +67,17 @@ namespace displays
 namespace markers
 {
 
-class RVIZ_DEFAULT_PLUGINS_PUBLIC TriangleListMarker : public MarkerBase
+class TriangleListMarker : public MarkerBase
 {
 public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   TriangleListMarker(
     MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node);
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   ~TriangleListMarker() override;
 
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
   S_MaterialPtr getMaterials() override;
 
 protected:
@@ -114,9 +109,5 @@ private:
 }  // namespace markers
 }  // namespace displays
 }  // namespace rviz_default_plugins
-
-#ifdef _WIN32
-# pragma warning(pop)
-#endif
 
 #endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKERS__TRIANGLE_LIST_MARKER_HPP_


### PR DESCRIPTION
Reverts ros2/rviz#297

This appeared to cause issues in our CI, so I'll revert and look into it when I have time. See:

- https://github.com/ros2/rviz/issues/368
- https://ci.ros2.org/job/ci_linux-aarch64/2467/