### PR TITLE
Handle FindEigen3 module's differing definitions

### DIFF
--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -42,6 +42,11 @@ find_package(ament_index_cpp REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(resource_retriever REQUIRED)
 
+# Handle FindEigen3 module's differing definitions
+if(NOT DEFINED EIGEN3_INCLUDE_DIRS AND DEFINED EIGEN3_INCLUDE_DIR)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
 if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
   get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)


### PR DESCRIPTION
The `FindEigen3.cmake` CMake module sets `EIGEN3_INCLUDE_DIR` instead of `EIGEN3_INCLUDE_DIRS`. Ubuntu only includes the `Eigen3Config.cmake` config, while Fedora includes both files. CMake gives precedence to the module over the config, so the config never gets processed.

Alternatively, we could pass `NO_MODULE` to the `find_package` call, but this would fail on systems that ONLY have the module, though I'm not aware of any such distributions.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5951)](http://ci.ros2.org/job/ci_linux/5951/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2478)](http://ci.ros2.org/job/ci_linux-aarch64/2478/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4921)](http://ci.ros2.org/job/ci_osx/4921/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5846)](http://ci.ros2.org/job/ci_windows/5846/)