### PR TITLE
Skip the system directories when looking for OGRE

### DIFF
--- a/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
+++ b/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
@@ -14,7 +14,7 @@ message(STATUS "Setting OGRE_DIR to: '${OGRE_DIR}'")
 set(FREETYPE_HOME "${rviz_ogre_vendor_DIR}/../../../opt/rviz_ogre_vendor")
 set(ZLIB_HOME "${rviz_ogre_vendor_DIR}/../../../opt/rviz_ogre_vendor")
 
-find_package(OGRE REQUIRED)
+find_package(OGRE REQUIRED NO_SYSTEM_ENVIRONMENT_PATH)
 message(STATUS "OGRE_LIBRARIES: ${OGRE_LIBRARIES}")
 message(STATUS "OGRE_LIBRARY_DIRS: ${OGRE_LIBRARY_DIRS}")
 message(STATUS "OGRE_PLUGINS: ${OGRE_PLUGINS}")


### PR DESCRIPTION
Fedora provides a CMake module for OGRE which is in a standard search location. This module seems to take precedence over the CMake config that is found via `OGRE_DIR`. This seemed like the least invasive change to keep that path out of the search without interfering with the module stuff going on to support Windows builds.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5952)](http://ci.ros2.org/job/ci_linux/5952/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2479)](http://ci.ros2.org/job/ci_linux-aarch64/2479/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4922)](http://ci.ros2.org/job/ci_osx/4922/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5844)](http://ci.ros2.org/job/ci_windows/5844/)