### PR TITLE
Re-enable use of tf message filter

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -54,6 +54,7 @@ find_package(tinyxml_vendor REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(message_filters REQUIRED)
 find_package(urdf REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
@@ -143,6 +144,7 @@ set(rviz_common_headers_to_moc
   include/rviz_common/window_manager_interface.hpp
   include/rviz_common/validate_floats.hpp
   include/rviz_common/ros_topic_display.hpp
+  include/rviz_common/message_filter_display.hpp
 )
 
 set(rviz_common_source_files
@@ -265,6 +267,7 @@ ament_target_dependencies(rviz_common
   tf2
   tf2_geometry_msgs
   tf2_ros
+  message_filters
   urdf
   yaml_cpp_vendor
 )

--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * Copyright (c) 2017, Bosch Software Innovations GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef RVIZ_COMMON__MESSAGE_FILTER_DISPLAY_HPP_
+#define RVIZ_COMMON__MESSAGE_FILTER_DISPLAY_HPP_
+
+#include <message_filters/subscriber.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/message_filter.h>
+
+#include "rviz_common/ros_topic_display.hpp"
+
+namespace rviz_common
+{
+/** @brief Display subclass using a rclcpp::subscription, templated on the ROS message type.
+ *
+ * This class handles subscribing and unsubscribing to a ROS node when the display is
+ * enabled or disabled. */
+template<class MessageType>
+class MessageFilterDisplay : public _RosTopicDisplay
+{
+// No Q_OBJECT macro here, moc does not support Q_OBJECT in a templated class.
+
+public:
+  /** @brief Convenience typedef so subclasses don't have to use
+   * the long templated class name to refer to their super class. */
+  typedef MessageFilterDisplay<MessageType> MFDClass;
+
+  MessageFilterDisplay()
+  : tf_filter_(nullptr),
+    messages_received_(0)
+  {
+    // TODO(Martin-Idel-SI): We need a way to extract the MessageType from the template to set a
+    // correct string. Previously was:
+    // QString message_type = QString::fromStdString(message_filters::message_traits::datatype<MessageType>());
+    QString message_type = QString::fromStdString("");
+    topic_property_->setMessageType(message_type);
+    topic_property_->setDescription(message_type + " topic to subscribe to.");
+  }
+
+  /**
+  * When overriding this method, the onInitialize() method of this superclass has to be called.
+  * Otherwise, the ros node will not be initialized.
+  */
+  void onInitialize() override
+  {
+    rviz_ros_node_ = context_->getRosNodeAbstraction();
+    topic_property_->initialize(rviz_ros_node_);
+  }
+
+  ~MessageFilterDisplay() override
+  {
+    unsubscribe();
+  }
+
+  void reset() override
+  {
+    Display::reset();
+    if(tf_filter_) {
+        tf_filter_->clear();
+    }
+    messages_received_ = 0;
+  }
+
+  void setTopic(const QString & topic, const QString & datatype) override
+  {
+      (void) datatype;
+    topic_property_->setString(topic);
+  }
+
+protected:
+  void updateTopic() override
+  {
+    unsubscribe();
+    reset();
+    subscribe();
+    context_->queueRender();
+  }
+
+  virtual void subscribe()
+  {
+    if (!isEnabled() ) {
+      return;
+    }
+
+    if (topic_property_->isEmpty()) {
+      setStatus(properties::StatusProperty::Error,
+        "Topic",
+        QString("Error subscribing: Empty topic name"));
+      return;
+    }
+
+    try {
+      // TODO(anhosi,wjwwood): replace with abstraction for subscriptions once available
+      subscription_ = std::make_shared<message_filters::Subscriber<MessageType>>(rviz_ros_node_.lock()->get_raw_node(),
+                                      topic_property_->getTopicStd(), qos_profile);
+      tf_filter_ = std::make_shared<tf2_ros::MessageFilter<MessageType>>
+              (*buffer_, fixed_frame_.toStdString(), 10, rviz_ros_node_.lock()->get_raw_node());
+      tf_filter_->connectInput(*subscription_);
+      tf_filter_->registerCallback
+              (std::bind(&MessageFilterDisplay<MessageType>::incomingMessage, this, std::placeholders::_1));
+      setStatus(properties::StatusProperty::Ok, "Topic", "OK");
+    } catch (rclcpp::exceptions::InvalidTopicNameError & e) {
+      setStatus(properties::StatusProperty::Error, "Topic",
+        QString("Error subscribing: ") + e.what());
+    }
+  }
+
+  virtual void unsubscribe()
+  {
+    subscription_.reset();
+  }
+
+  void onEnable() override
+  {
+      subscribe();
+  }
+
+  void onDisable() override
+  {
+    unsubscribe();
+    reset();
+  }
+
+  void fixedFrameChanged() override
+  {
+    tf_filter_->setTargetFrame( fixed_frame_.toStdString() );
+    reset();
+  }
+
+  /** @brief Incoming message callback.  Checks if the message pointer
+   * is valid, increments messages_received_, then calls
+   * processMessage(). */
+  void incomingMessage(const typename MessageType::ConstSharedPtr msg)
+  {
+    if (!msg) {
+      return;
+    }
+
+    ++messages_received_;
+    setStatus(
+      properties::StatusProperty::Ok,
+      "Topic",
+      QString::number(messages_received_) + " messages received");
+
+    processMessage(msg);
+  }
+
+  /** @brief Implement this to process the contents of a message.
+   *
+   * This is called by incomingMessage(). */
+  virtual void processMessage(typename MessageType::ConstSharedPtr msg) = 0;
+
+  typename std::shared_ptr<message_filters::Subscriber<MessageType>> subscription_;
+  std::shared_ptr<tf2_ros::MessageFilter<MessageType>> tf_filter_;
+  std::shared_ptr<tf2_ros::Buffer> buffer_;
+  uint32_t messages_received_;
+};
+
+}  // end namespace rviz_common
+
+#endif  // RVIZ_COMMON__MESSAGE_FILTER_DISPLAY_HPP_

--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -39,10 +39,12 @@
 
 namespace rviz_common
 {
-/// Display subclass using a rclcpp::subscription and tf2_ros::MessageFilter,
-/// templated on the ROS message type.
-/// This class handles subscribing and unsubscribing to a ROS node using the
-/// message filter when the display is enabled or disabled.
+/// Display subclass using a rclcpp::subscription and tf2_ros::MessageFilter.
+/**
+ * This class handles subscribing and unsubscribing to a ROS node using the
+ * message filter when the display is enabled or disabled.
+ * This class is templated on the ROS message type.
+ */
 template<class MessageType>
 class MessageFilterDisplay : public _RosTopicDisplay
 {
@@ -67,9 +69,9 @@ public:
   }
 
   /**
-  * When overriding this method, the onInitialize() method of this superclass has to be called.
-  * Otherwise, the ros node will not be initialized.
-  */
+   * When overriding this method, the onInitialize() method of this superclass has to be called.
+   * Otherwise, the ros node will not be initialized.
+   */
   void onInitialize() override
   {
     _RosTopicDisplay::onInitialize();
@@ -169,9 +171,12 @@ protected:
     reset();
   }
 
-  /// Incoming message callback.  Checks if the message pointer
-  /// is valid, increments messages_received_, then calls
-  /// processMessage().
+  /// Incoming message callback.
+  /**
+   * Checks if the message pointer
+   * is valid, increments messages_received_, then calls
+   * processMessage().
+   */
   void incomingMessage(const typename MessageType::ConstSharedPtr msg)
   {
     if (!msg) {
@@ -188,7 +193,9 @@ protected:
   }
 
   /// Implement this to process the contents of a message.
-  /// This is called by incomingMessage().
+  /**
+   * This is called by incomingMessage().
+   */
   virtual void processMessage(typename MessageType::ConstSharedPtr msg) = 0;
 
   typename std::shared_ptr<message_filters::Subscriber<MessageType>> subscription_;

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -32,6 +32,7 @@
 
 #ifndef Q_MOC_RUN
 
+#include <memory>
 #include <string>
 
 #include <OgreSceneNode.h>
@@ -96,9 +97,18 @@ public:
   {
     rviz_ros_node_ = context_->getRosNodeAbstraction();
     topic_property_->initialize(rviz_ros_node_);
+
+    connect(
+      reinterpret_cast<QObject *>(context_->getTransformationManager()),
+      SIGNAL(transformerChanged(std::shared_ptr<rviz_common::transformation::FrameTransformer>)),
+      this,
+      SLOT(transformerChangedCallback()));
   }
 
 protected Q_SLOTS:
+  virtual void transformerChangedCallback()
+  {
+  }
   virtual void updateTopic() = 0;
   virtual void updateReliability()
   {

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -39,6 +39,7 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>message_filters</depend>
   <depend>tinyxml_vendor</depend>
   <depend>urdf</depend>
   <depend>yaml_cpp_vendor</depend>

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -50,8 +50,6 @@
 # include "rviz_rendering/render_window.hpp"
 # include "rviz_common/message_filter_display.hpp"
 # include "rviz_default_plugins/displays/image/ros_image_texture_iface.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 # include "rviz_default_plugins/visibility_control.hpp"
 #endif
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -48,8 +48,10 @@
 # include "sensor_msgs/msg/camera_info.hpp"
 
 # include "rviz_rendering/render_window.hpp"
-# include "rviz_common/ros_topic_display.hpp"
+# include "rviz_common/message_filter_display.hpp"
 # include "rviz_default_plugins/displays/image/ros_image_texture_iface.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 # include "rviz_default_plugins/visibility_control.hpp"
 #endif
 
@@ -96,7 +98,7 @@ struct ImageDimensions
  *
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC CameraDisplay
-  : public rviz_common::RosTopicDisplay<sensor_msgs::msg::Image>,
+  : public rviz_common::MessageFilterDisplay<sensor_msgs::msg::Image>,
   public Ogre::RenderTargetListener
 {
   Q_OBJECT

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp
@@ -38,9 +38,11 @@
 #include "nav_msgs/msg/map_meta_data.hpp"
 
 #include "rviz_common/display.hpp"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/display_context.hpp"
 
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering
@@ -68,7 +70,7 @@ namespace displays
  * \brief Displays a nav_msgs::GridCells message
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC GridCellsDisplay : public
-  rviz_common::RosTopicDisplay<nav_msgs::msg::GridCells>
+  rviz_common::MessageFilterDisplay<nav_msgs::msg::GridCells>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp
@@ -41,8 +41,6 @@
 #include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/display_context.hpp"
 
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
@@ -47,12 +47,8 @@
 # include "rviz_common/properties/float_property.hpp"
 # include "rviz_common/properties/int_property.hpp"
 # include "rviz_common/properties/queue_size_property.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
 # include "rviz_default_plugins/displays/image/ros_image_texture_iface.hpp"
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 # include "rviz_default_plugins/visibility_control.hpp"
 #endif
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
@@ -41,14 +41,18 @@
 # include <OgreRenderTargetListener.h>
 # include <OgreSharedPtr.h>
 
-# include "rviz_common/ros_topic_display.hpp"
+# include "rviz_common/message_filter_display.hpp"
 # include "rviz_common/render_panel.hpp"
 # include "rviz_common/properties/bool_property.hpp"
 # include "rviz_common/properties/float_property.hpp"
 # include "rviz_common/properties/int_property.hpp"
 # include "rviz_common/properties/queue_size_property.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
 
 # include "rviz_default_plugins/displays/image/ros_image_texture_iface.hpp"
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 # include "rviz_default_plugins/visibility_control.hpp"
 #endif
 
@@ -69,7 +73,7 @@ namespace displays
  *
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC ImageDisplay : public
-  rviz_common::RosTopicDisplay<sensor_msgs::msg::Image>
+  rviz_common::MessageFilterDisplay<sensor_msgs::msg::Image>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
@@ -38,8 +38,9 @@
 
 #include "laser_geometry/laser_geometry.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/transformation/frame_transformer.hpp"
+
 #include "rviz_default_plugins/transformation/transformer_guard.hpp"
 #include "rviz_default_plugins/transformation/tf_wrapper.hpp"
 #include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
@@ -62,7 +63,7 @@ namespace displays
 // TODO(botteroa-si): This display originally extended the MessageFilterDisplay. Revisit when
 // available
 class RVIZ_DEFAULT_PLUGINS_PUBLIC LaserScanDisplay : public
-  rviz_common::RosTopicDisplay<sensor_msgs::msg::LaserScan>
+  rviz_common::MessageFilterDisplay<sensor_msgs::msg::LaserScan>
 {
   Q_OBJECT
 
@@ -85,6 +86,7 @@ protected:
   std::unique_ptr<PointCloudCommon> point_cloud_common_;
   std::unique_ptr<rviz_common::QueueSizeProperty> queue_size_property_;
   std::unique_ptr<laser_geometry::LaserProjection> projector_;
+  rclcpp::Duration filter_tolerance_;
 
 private:
   std::unique_ptr<rviz_default_plugins::transformation::TransformerGuard<

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
@@ -60,8 +60,6 @@ class PointCloudCommon;
 namespace displays
 {
 /** @brief Visualizes a laser scan, received as a sensor_msgs::LaserScan. */
-// TODO(botteroa-si): This display originally extended the MessageFilterDisplay. Revisit when
-// available
 class RVIZ_DEFAULT_PLUGINS_PUBLIC LaserScanDisplay : public
   rviz_common::MessageFilterDisplay<sensor_msgs::msg::LaserScan>
 {

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -60,11 +60,7 @@
 #include "rclcpp/time.hpp"
 
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/map/swatch.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -59,8 +59,12 @@
 #include "map_msgs/msg/occupancy_grid_update.hpp"
 #include "rclcpp/time.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
 
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/map/swatch.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
@@ -96,7 +100,7 @@ class AlphaSetter;
  * \brief Displays a map along the XY plane.
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC MapDisplay : public
-  rviz_common::RosTopicDisplay<nav_msgs::msg::OccupancyGrid>
+  rviz_common::MessageFilterDisplay<nav_msgs::msg::OccupancyGrid>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_display.hpp
@@ -37,8 +37,12 @@
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include "rviz_common/properties/queue_size_property.hpp"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
 
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/marker/marker_common.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
@@ -55,7 +59,7 @@ namespace displays
  * See the Marker message for more information.
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC MarkerDisplay
-  : public rviz_common::RosTopicDisplay<visualization_msgs::msg::Marker>
+  : public rviz_common::MessageFilterDisplay<visualization_msgs::msg::Marker>
 {
 public:
   MarkerDisplay();

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_display.hpp
@@ -38,11 +38,7 @@
 
 #include "rviz_common/properties/queue_size_property.hpp"
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/marker/marker_common.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/odometry/odometry_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/odometry/odometry_display.hpp
@@ -44,8 +44,6 @@
 
 #include "rviz_rendering/objects/covariance_visual.hpp"
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/odometry/odometry_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/odometry/odometry_display.hpp
@@ -43,7 +43,9 @@
 #endif
 
 #include "rviz_rendering/objects/covariance_visual.hpp"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering
@@ -73,7 +75,7 @@ namespace displays
  * \brief Accumulates and displays the pose from a nav_msgs::Odometry message
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC OdometryDisplay : public
-  rviz_common::RosTopicDisplay<nav_msgs::msg::Odometry>
+  rviz_common::MessageFilterDisplay<nav_msgs::msg::Odometry>
 {
   Q_OBJECT
 
@@ -102,7 +104,7 @@ public:
   void processMessage(nav_msgs::msg::Odometry::ConstSharedPtr msg) override;
 
 protected:
-  /** @brief Overridden from RosTopicDisplay to get Arrow/Axes visibility correct. */
+  /** @brief Overridden from MessageFilterDisplay to get Arrow/Axes visibility correct. */
   void onEnable() override;
 
 public Q_SLOTS:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/path/path_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/path/path_display.hpp
@@ -36,15 +36,11 @@
 #include "nav_msgs/msg/path.hpp"
 
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/axes.hpp"
 #include "rviz_rendering/objects/billboard_line.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/path/path_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/path/path_display.hpp
@@ -35,10 +35,16 @@
 
 #include "nav_msgs/msg/path.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
+
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/axes.hpp"
 #include "rviz_rendering/objects/billboard_line.hpp"
+
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre
@@ -67,7 +73,7 @@ namespace displays
  * \brief Displays a nav_msgs::msg::Path message
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PathDisplay : public
-  rviz_common::RosTopicDisplay<nav_msgs::msg::Path>
+  rviz_common::MessageFilterDisplay<nav_msgs::msg::Path>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/point/point_stamped_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/point/point_stamped_display.hpp
@@ -44,11 +44,7 @@
 // #include <rviz/message_filter_display.h>
 
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/point/point_stamped_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/point/point_stamped_display.hpp
@@ -43,7 +43,12 @@
 // TODO(Martin-Idel-SI): Add again when available
 // #include <rviz/message_filter_display.h>
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
+
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre
@@ -74,7 +79,7 @@ namespace displays
 {
 
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PointStampedDisplay
-  : public rviz_common::RosTopicDisplay<geometry_msgs::msg::PointStamped>
+  : public rviz_common::MessageFilterDisplay<geometry_msgs::msg::PointStamped>
 {
   Q_OBJECT
 
@@ -89,6 +94,9 @@ public:
   void processMessage(geometry_msgs::msg::PointStamped::ConstSharedPtr msg) override;
 
 protected:
+  /** @brief Do initialization. Overridden from MessageFilterDisplay. */
+  void onInitialize() override;
+
   void reset() override;
 
 private Q_SLOTS:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
@@ -36,11 +36,7 @@
 
 #include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/queue_size_property.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
@@ -34,9 +34,13 @@
 
 #include "sensor_msgs/msg/point_cloud2.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/queue_size_property.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
 
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
@@ -68,7 +72,7 @@ struct Offsets
  * all being 8 bits.
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PointCloud2Display : public
-  rviz_common::RosTopicDisplay<sensor_msgs::msg::PointCloud2>
+  rviz_common::MessageFilterDisplay<sensor_msgs::msg::PointCloud2>
 {
 public:
   PointCloud2Display();
@@ -96,10 +100,10 @@ public:
   void onDisable() override;
 
 protected:
-  /** @brief Do initialization. Overridden from RosTopicDisplay. */
+  /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   void onInitialize() override;
 
-  /** @brief Process a single message.  Overridden from RosTopicDisplay. */
+  /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   void processMessage(sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud) override;
 
 private:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
@@ -39,11 +39,7 @@
 
 #include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/queue_size_property.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
@@ -37,9 +37,13 @@
 
 #include "sensor_msgs/msg/point_cloud.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/queue_size_property.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
 
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
@@ -68,7 +72,7 @@ namespace displays
  * all being 8 bits.
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PointCloudDisplay : public
-  rviz_common::RosTopicDisplay<sensor_msgs::msg::PointCloud>
+  rviz_common::MessageFilterDisplay<sensor_msgs::msg::PointCloud>
 {
 public:
   PointCloudDisplay();
@@ -80,10 +84,10 @@ public:
   void onDisable() override;
 
 protected:
-  /** @brief Do initialization. Overridden from RosTopicDisplay. */
+  /** @brief Do initialization. Overridden from MessageFilterDisplay. */
   void onInitialize() override;
 
-  /** @brief Process a single message.  Overridden from RosTopicDisplay. */
+  /** @brief Process a single message.  Overridden from MessageFilterDisplay. */
   void processMessage(sensor_msgs::msg::PointCloud::ConstSharedPtr cloud) override;
 
   std::unique_ptr<rviz_common::QueueSizeProperty> queue_size_property_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
@@ -43,8 +43,6 @@
 #include "rviz_common/properties/queue_size_property.hpp"
 #include "rviz_common/validate_floats.hpp"
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 #include "rviz_rendering/objects/point_cloud.hpp"
 
@@ -108,9 +106,6 @@ protected:
 private:
   void onInitialize() override
   {
-    auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-            rviz_common::Display::context_->getFrameManager()->getConnector().lock());
-    rviz_common::MessageFilterDisplay<MessageType>::buffer_ = tf_wrapper->getBuffer();
     rviz_common::MessageFilterDisplay<MessageType>::onInitialize();
     point_cloud_common_->initialize(
       this->context_, this->scene_node_);

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
@@ -39,10 +39,12 @@
 
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/queue_size_property.hpp"
 #include "rviz_common/validate_floats.hpp"
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 #include "rviz_rendering/objects/point_cloud.hpp"
 
@@ -63,7 +65,7 @@ namespace displays
 
 template<typename MessageType>
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PointCloudScalarDisplay
-  : public rviz_common::RosTopicDisplay<MessageType>
+  : public rviz_common::MessageFilterDisplay<MessageType>
 {
 public:
   PointCloudScalarDisplay()
@@ -106,7 +108,10 @@ protected:
 private:
   void onInitialize() override
   {
-    rviz_common::RosTopicDisplay<MessageType>::onInitialize();
+    auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+            rviz_common::Display::context_->getFrameManager()->getConnector().lock());
+    rviz_common::MessageFilterDisplay<MessageType>::buffer_ = tf_wrapper->getBuffer();
+    rviz_common::MessageFilterDisplay<MessageType>::onInitialize();
     point_cloud_common_->initialize(
       this->context_, this->scene_node_);
     setInitialValues();
@@ -120,18 +125,18 @@ private:
 
   void onEnable() override
   {
-    rviz_common::RosTopicDisplay<MessageType>::onEnable();
+    rviz_common::MessageFilterDisplay<MessageType>::onEnable();
   }
 
   void onDisable() override
   {
-    rviz_common::RosTopicDisplay<MessageType>::onDisable();
+    rviz_common::MessageFilterDisplay<MessageType>::onDisable();
     point_cloud_common_->onDisable();
   }
 
   void reset() override
   {
-    rviz_common::RosTopicDisplay<MessageType>::reset();
+    rviz_common::MessageFilterDisplay<MessageType>::reset();
     point_cloud_common_->reset();
   }
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/polygon/polygon_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/polygon/polygon_display.hpp
@@ -33,8 +33,12 @@
 
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
 
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre
@@ -61,7 +65,7 @@ namespace displays
  * \brief Displays a geometry_msgs::PolygonStamped message
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PolygonDisplay : public
-  rviz_common::RosTopicDisplay<geometry_msgs::msg::PolygonStamped>
+  rviz_common::MessageFilterDisplay<geometry_msgs::msg::PolygonStamped>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/polygon/polygon_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/polygon/polygon_display.hpp
@@ -34,11 +34,7 @@
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
@@ -37,11 +37,7 @@
 
 #include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/interaction/forwards.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
@@ -35,8 +35,13 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/interaction/forwards.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
+
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering
@@ -67,7 +72,7 @@ typedef std::shared_ptr<PoseDisplaySelectionHandler> PoseDisplaySelectionHandler
 
 /** @brief Accumulates and displays the pose from a geometry_msgs::PoseStamped message. */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PoseDisplay : public
-  rviz_common::RosTopicDisplay<geometry_msgs::msg::PoseStamped>
+  rviz_common::MessageFilterDisplay<geometry_msgs::msg::PoseStamped>
 {
   Q_OBJECT
 
@@ -85,7 +90,7 @@ public:
   void reset() override;
 
 protected:
-  /** @brief Overridden from RosTopicDisplay to get arrow/axes visibility correct. */
+  /** @brief Overridden from MessageFilterDisplay to get arrow/axes visibility correct. */
   void onEnable() override;
   void onDisable() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose_array/pose_array_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose_array/pose_array_display.hpp
@@ -37,8 +37,12 @@
 #include "geometry_msgs/msg/pose_array.hpp"
 
 #include "rviz_rendering/objects/shape.hpp"
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
 
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 // TODO(botteroa): Originally the display extended the MessageFilterDisplay. Revisit when available.
@@ -78,7 +82,7 @@ struct OgrePose
 
 /** @brief Displays a geometry_msgs/PoseArray message as a bunch of line-drawn arrows. */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC PoseArrayDisplay : public
-  rviz_common::RosTopicDisplay<geometry_msgs::msg::PoseArray>
+  rviz_common::MessageFilterDisplay<geometry_msgs::msg::PoseArray>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose_array/pose_array_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose_array/pose_array_display.hpp
@@ -38,11 +38,7 @@
 
 #include "rviz_rendering/objects/shape.hpp"
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 // TODO(botteroa): Originally the display extended the MessageFilterDisplay. Revisit when available.

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/range/range_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/range/range_display.hpp
@@ -35,7 +35,12 @@
 
 #include "sensor_msgs/msg/range.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/transformation/frame_transformer.hpp"
+
+#include "rviz_default_plugins/transformation/transformer_guard.hpp"
+#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
+#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering
@@ -64,7 +69,7 @@ namespace displays
  * \brief Displays a sensor_msgs::Range message as a cone.
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC RangeDisplay : public
-  rviz_common::RosTopicDisplay<sensor_msgs::msg::Range>
+  rviz_common::MessageFilterDisplay<sensor_msgs::msg::Range>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/range/range_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/range/range_display.hpp
@@ -36,11 +36,7 @@
 #include "sensor_msgs/msg/range.hpp"
 
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
-#include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
-#include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_rendering

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/wrench/wrench_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/wrench/wrench_display.hpp
@@ -35,7 +35,7 @@
 
 #include "geometry_msgs/msg/wrench_stamped.hpp"
 
-#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_common/message_filter_display.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace Ogre
@@ -65,7 +65,7 @@ namespace displays
 
 
 class RVIZ_DEFAULT_PLUGINS_PUBLIC WrenchDisplay : public
-  rviz_common::RosTopicDisplay<geometry_msgs::msg::WrenchStamped>
+  rviz_common::MessageFilterDisplay<geometry_msgs::msg::WrenchStamped>
 {
   Q_OBJECT
 

--- a/rviz_default_plugins/include/rviz_default_plugins/transformation/tf_wrapper.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/transformation/tf_wrapper.hpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/create_timer_ros.h"
 #include "tf2_ros/transform_listener.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 
@@ -129,7 +130,10 @@ public:
 
   RVIZ_DEFAULT_PLUGINS_PUBLIC
   void
-  initializeBuffer(rclcpp::Clock::SharedPtr clock, bool using_dedicated_thread);
+  initializeBuffer(
+    rclcpp::Clock::SharedPtr clock,
+    rclcpp::Node::SharedPtr node,
+    bool using_dedicated_thread);
 
 private:
   std::shared_ptr<tf2_ros::Buffer> buffer_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -132,9 +132,6 @@ CameraDisplay::~CameraDisplay()
 
 void CameraDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
 
   setupSceneNodes();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -132,7 +132,10 @@ CameraDisplay::~CameraDisplay()
 
 void CameraDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
 
   setupSceneNodes();
   setupRenderPanel();
@@ -267,7 +270,7 @@ void CameraDisplay::onDisable()
 
 void CameraDisplay::subscribe()
 {
-  RTDClass::subscribe();
+  MFDClass::subscribe();
 
   if ((!isEnabled()) || (topic_property_->getTopicStd().empty())) {
     return;
@@ -300,7 +303,7 @@ void CameraDisplay::createCameraInfoSubscription()
 
 void CameraDisplay::unsubscribe()
 {
-  RTDClass::unsubscribe();
+  MFDClass::unsubscribe();
   caminfo_sub_.reset();
 }
 
@@ -556,7 +559,7 @@ void CameraDisplay::processMessage(sensor_msgs::msg::Image::ConstSharedPtr msg)
 
 void CameraDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   clear();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
@@ -73,9 +73,6 @@ GridCellsDisplay::GridCellsDisplay()
 
 void GridCellsDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
 
   setupCloud();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
@@ -73,7 +73,10 @@ GridCellsDisplay::GridCellsDisplay()
 
 void GridCellsDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
 
   setupCloud();
   updateAlpha();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -103,9 +103,6 @@ ImageDisplay::ImageDisplay(std::unique_ptr<ROSImageTextureIface> texture)
 
 void ImageDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          rviz_common::Display::context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
 
   updateNormalizeOptions();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -103,7 +103,10 @@ ImageDisplay::ImageDisplay(std::unique_ptr<ROSImageTextureIface> texture)
 
 void ImageDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          rviz_common::Display::context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
 
   updateNormalizeOptions();
   setupScreenRectangle();
@@ -120,12 +123,12 @@ ImageDisplay::~ImageDisplay() = default;
 
 void ImageDisplay::onEnable()
 {
-  RTDClass::subscribe();
+  MFDClass::subscribe();
 }
 
 void ImageDisplay::onDisable()
 {
-  RTDClass::unsubscribe();
+  MFDClass::unsubscribe();
   clear();
 }
 
@@ -188,7 +191,7 @@ void ImageDisplay::update(float wall_dt, float ros_dt)
 
 void ImageDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   clear();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -111,7 +111,7 @@ void LaserScanDisplay::reset()
 
 void LaserScanDisplay::onDisable()
 {
-  MessageFilterDisplay::onDisable();
+  MFDClass::onDisable();
   point_cloud_common_->onDisable();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -58,9 +58,6 @@ LaserScanDisplay::LaserScanDisplay()
 
 void LaserScanDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
   transformer_guard_->initialize(context_);
@@ -70,10 +67,9 @@ void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPt
 {
   // TODO(Martin-Idel-SI): Reenable once tf_filter is ported or delete if necessary
 //  Compute tolerance necessary for this scan
-  rclcpp::Duration tolerance(
-          static_cast<int32_t>(static_cast<rcl_duration_value_t>(scan->time_increment * scan->ranges.size())), 0);
-  if (tolerance > filter_tolerance_)
-  {
+  rclcpp::Duration tolerance(static_cast<int32_t>(static_cast<rcl_duration_value_t>(
+      scan->time_increment * scan->ranges.size())), 0);
+  if (tolerance > filter_tolerance_) {
     filter_tolerance_ = tolerance;
     tf_filter_->setTolerance(filter_tolerance_);
   }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -65,7 +65,6 @@ void LaserScanDisplay::onInitialize()
 
 void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPtr scan)
 {
-  // TODO(Martin-Idel-SI): Reenable once tf_filter is ported or delete if necessary
 //  Compute tolerance necessary for this scan
   rclcpp::Duration tolerance(static_cast<int32_t>(static_cast<rcl_duration_value_t>(
       scan->time_increment * scan->ranges.size())), 0);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -50,6 +50,7 @@ LaserScanDisplay::LaserScanDisplay()
 : point_cloud_common_(std::make_unique<rviz_default_plugins::PointCloudCommon>(this)),
   queue_size_property_(std::make_unique<rviz_common::QueueSizeProperty>(this, 10)),
   projector_(std::make_unique<laser_geometry::LaserProjection>()),
+  filter_tolerance_(0, 0),
   transformer_guard_(
     std::make_unique<rviz_default_plugins::transformation::TransformerGuard<
       rviz_default_plugins::transformation::TFFrameTransformer>>(this, "TF"))
@@ -57,7 +58,10 @@ LaserScanDisplay::LaserScanDisplay()
 
 void LaserScanDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
   transformer_guard_->initialize(context_);
 }
@@ -66,13 +70,13 @@ void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPt
 {
   // TODO(Martin-Idel-SI): Reenable once tf_filter is ported or delete if necessary
 //  Compute tolerance necessary for this scan
-//  ros::Duration tolerance(scan->time_increment * scan->ranges.size());
-//  if (tolerance > filter_tolerance_)
-//  {
-//    filter_tolerance_ = tolerance;
-//    tf_filter_->setTolerance(filter_tolerance_);
-//  }
-
+  rclcpp::Duration tolerance(
+          static_cast<int32_t>(static_cast<rcl_duration_value_t>(scan->time_increment * scan->ranges.size())), 0);
+  if (tolerance > filter_tolerance_)
+  {
+    filter_tolerance_ = tolerance;
+    tf_filter_->setTolerance(filter_tolerance_);
+  }
   auto cloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
   auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
     context_->getFrameManager()->getConnector().lock());
@@ -106,13 +110,13 @@ void LaserScanDisplay::update(float wall_dt, float ros_dt)
 
 void LaserScanDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   point_cloud_common_->reset();
 }
 
 void LaserScanDisplay::onDisable()
 {
-  RosTopicDisplay::onDisable();
+  MessageFilterDisplay::onDisable();
   point_cloud_common_->onDisable();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -161,7 +161,7 @@ MapDisplay::MapDisplay(rviz_common::DisplayContext * context)
 
 void MapDisplay::onInitialize()
 {
-  MessageFilterDisplay::onInitialize();
+  MFDClass::onInitialize();
   // Order of palette textures here must match option indices for color_scheme_property_ above.
   palette_textures_.push_back(makePaletteTexture(makeMapPalette()));
   color_scheme_transparency_.push_back(false);
@@ -569,7 +569,7 @@ void MapDisplay::fixedFrameChanged()
 
 void MapDisplay::reset()
 {
-  MessageFilterDisplay::reset();
+  MFDClass::reset();
   update_messages_received_ = 0;
   clear();
 }
@@ -584,7 +584,7 @@ void MapDisplay::update(float wall_dt, float ros_dt)
 
 void MapDisplay::onEnable()
 {
-  MessageFilterDisplay::onEnable();
+  MFDClass::onEnable();
   setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -123,7 +123,7 @@ MapDisplay::MapDisplay()
     "Orientation", Ogre::Quaternion::IDENTITY, "Orientation of the map. (not editable)", this);
   orientation_property_->setReadOnly(true);
 
-  transform_timestamp_property_ = new rviz_common::properties::BoolProperty("Use Timestamp", false,
+  transform_timestamp_property_ = new rviz_common::properties::BoolProperty("Use Timestamp", true,
       "Use map header timestamp when transforming", this, SLOT(transformMap()));
 }
 
@@ -161,7 +161,10 @@ MapDisplay::MapDisplay(rviz_common::DisplayContext * context)
 
 void MapDisplay::onInitialize()
 {
-  RosTopicDisplay::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MessageFilterDisplay::onInitialize();
   // Order of palette textures here must match option indices for color_scheme_property_ above.
   palette_textures_.push_back(makePaletteTexture(makeMapPalette()));
   color_scheme_transparency_.push_back(false);
@@ -184,7 +187,7 @@ void MapDisplay::subscribe()
     return;
   }
 
-  RTDClass::subscribe();
+  MFDClass::subscribe();
 
   try {
     // TODO(wjwwood): update this class to use rclcpp::QoS.
@@ -207,7 +210,7 @@ void MapDisplay::subscribe()
 
 void MapDisplay::unsubscribe()
 {
-  RTDClass::unsubscribe();
+  MFDClass::unsubscribe();
   update_subscription_.reset();
 }
 
@@ -569,7 +572,7 @@ void MapDisplay::fixedFrameChanged()
 
 void MapDisplay::reset()
 {
-  RosTopicDisplay::reset();
+  MessageFilterDisplay::reset();
   update_messages_received_ = 0;
   clear();
 }
@@ -584,7 +587,7 @@ void MapDisplay::update(float wall_dt, float ros_dt)
 
 void MapDisplay::onEnable()
 {
-  RosTopicDisplay::onEnable();
+  MessageFilterDisplay::onEnable();
   setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -123,7 +123,7 @@ MapDisplay::MapDisplay()
     "Orientation", Ogre::Quaternion::IDENTITY, "Orientation of the map. (not editable)", this);
   orientation_property_->setReadOnly(true);
 
-  transform_timestamp_property_ = new rviz_common::properties::BoolProperty("Use Timestamp", true,
+  transform_timestamp_property_ = new rviz_common::properties::BoolProperty("Use Timestamp", false,
       "Use map header timestamp when transforming", this, SLOT(transformMap()));
 }
 
@@ -161,9 +161,6 @@ MapDisplay::MapDisplay(rviz_common::DisplayContext * context)
 
 void MapDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MessageFilterDisplay::onInitialize();
   // Order of palette textures here must match option indices for color_scheme_property_ above.
   palette_textures_.push_back(makePaletteTexture(makeMapPalette()));

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
@@ -40,15 +40,17 @@ namespace displays
 {
 
 MarkerDisplay::MarkerDisplay()
-: rviz_common::RosTopicDisplay<visualization_msgs::msg::Marker>(),
+: rviz_common::MessageFilterDisplay<visualization_msgs::msg::Marker>(),
   marker_common_(std::make_unique<MarkerCommon>(this)),
   queue_size_property_(std::make_unique<rviz_common::QueueSizeProperty>(this, 10)) {}
 
 void MarkerDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   marker_common_->initialize(context_, scene_node_);
-
   topic_property_->setDescription(
     "visualization_msgs::msg::Marker topic to subscribe to. <topic>_array will also"
     " automatically be subscribed with type visualization_msgs::msg::MarkerArray.");
@@ -62,7 +64,7 @@ void MarkerDisplay::load(const rviz_common::Config & config)
 
 void MarkerDisplay::subscribe()
 {
-  RTDClass::subscribe();
+  MFDClass::subscribe();
 
   if ((!isEnabled()) || (topic_property_->getTopicStd().empty())) {
     return;
@@ -93,7 +95,7 @@ void MarkerDisplay::createMarkerArraySubscription()
 
 void MarkerDisplay::unsubscribe()
 {
-  RTDClass::unsubscribe();
+  MFDClass::unsubscribe();
   array_sub_.reset();
 }
 
@@ -110,7 +112,7 @@ void MarkerDisplay::update(float wall_dt, float ros_dt)
 
 void MarkerDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   marker_common_->clearMarkers();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
@@ -46,9 +46,6 @@ MarkerDisplay::MarkerDisplay()
 
 void MarkerDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
   marker_common_->initialize(context_, scene_node_);
   topic_property_->setDescription(

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
@@ -134,13 +134,16 @@ OdometryDisplay::~OdometryDisplay() = default;
 
 void OdometryDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   updateShapeChoice();
 }
 
 void OdometryDisplay::onEnable()
 {
-  RTDClass::onEnable();
+  MFDClass::onEnable();
   updateShapeVisibility();
 }
 
@@ -392,7 +395,7 @@ void OdometryDisplay::update(float wall_dt, float ros_dt)
 
 void OdometryDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   clear();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
@@ -134,9 +134,6 @@ OdometryDisplay::~OdometryDisplay() = default;
 
 void OdometryDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
   updateShapeChoice();
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
@@ -155,13 +155,13 @@ PathDisplay::~PathDisplay()
 
 void PathDisplay::onInitialize()
 {
-  MessageFilterDisplay::onInitialize();
+  MFDClass::onInitialize();
   updateBufferLength();
 }
 
 void PathDisplay::reset()
 {
-  MessageFilterDisplay::reset();
+  MFDClass::reset();
   updateBufferLength();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
@@ -155,9 +155,6 @@ PathDisplay::~PathDisplay()
 
 void PathDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MessageFilterDisplay::onInitialize();
   updateBufferLength();
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
@@ -155,13 +155,16 @@ PathDisplay::~PathDisplay()
 
 void PathDisplay::onInitialize()
 {
-  RosTopicDisplay::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MessageFilterDisplay::onInitialize();
   updateBufferLength();
 }
 
 void PathDisplay::reset()
 {
-  RosTopicDisplay::reset();
+  MessageFilterDisplay::reset();
   updateBufferLength();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/point/point_stamped_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/point/point_stamped_display.cpp
@@ -68,6 +68,14 @@ PointStampedDisplay::PointStampedDisplay()
   setUpProperties();
 }
 
+void PointStampedDisplay::onInitialize()
+{
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
+}
+
 void PointStampedDisplay::setUpProperties()
 {
   color_property_ = new rviz_common::properties::ColorProperty(
@@ -91,7 +99,7 @@ PointStampedDisplay::~PointStampedDisplay() = default;
 
 void PointStampedDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   visuals_.clear();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/point/point_stamped_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/point/point_stamped_display.cpp
@@ -70,9 +70,6 @@ PointStampedDisplay::PointStampedDisplay()
 
 void PointStampedDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -56,7 +56,10 @@ PointCloud2Display::PointCloud2Display()
 
 void PointCloud2Display::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 }
 
@@ -179,13 +182,13 @@ void PointCloud2Display::update(float wall_dt, float ros_dt)
 
 void PointCloud2Display::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   point_cloud_common_->reset();
 }
 
 void PointCloud2Display::onDisable()
 {
-  RosTopicDisplay::onDisable();
+  MessageFilterDisplay::onDisable();
   point_cloud_common_->onDisable();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -185,7 +185,7 @@ void PointCloud2Display::reset()
 
 void PointCloud2Display::onDisable()
 {
-  MessageFilterDisplay::onDisable();
+  MFDClass::onDisable();
   point_cloud_common_->onDisable();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -56,9 +56,6 @@ PointCloud2Display::PointCloud2Display()
 
 void PointCloud2Display::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -74,7 +74,7 @@ void PointCloudDisplay::reset()
 
 void PointCloudDisplay::onDisable()
 {
-  MessageFilterDisplay::onDisable();
+  MFDClass::onDisable();
   point_cloud_common_->onDisable();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -52,9 +52,6 @@ PointCloudDisplay::PointCloudDisplay()
 
 void PointCloudDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -52,7 +52,10 @@ PointCloudDisplay::PointCloudDisplay()
 
 void PointCloudDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   point_cloud_common_->initialize(context_, scene_node_);
 }
 
@@ -68,13 +71,13 @@ void PointCloudDisplay::update(float wall_dt, float ros_dt)
 
 void PointCloudDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   point_cloud_common_->reset();
 }
 
 void PointCloudDisplay::onDisable()
 {
-  RosTopicDisplay::onDisable();
+  MessageFilterDisplay::onDisable();
   point_cloud_common_->onDisable();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
@@ -75,8 +75,10 @@ PolygonDisplay::~PolygonDisplay()
 
 void PolygonDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
-
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   manual_object_ = scene_manager_->createManualObject();
   manual_object_->setDynamic(true);
   scene_node_->attachObject(manual_object_);
@@ -84,7 +86,7 @@ void PolygonDisplay::onInitialize()
 
 void PolygonDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   manual_object_->clear();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/polygon/polygon_display.cpp
@@ -75,10 +75,8 @@ PolygonDisplay::~PolygonDisplay()
 
 void PolygonDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
+
   manual_object_ = scene_manager_->createManualObject();
   manual_object_->setDynamic(true);
   scene_node_->attachObject(manual_object_);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
@@ -99,9 +99,6 @@ PoseDisplay::PoseDisplay()
 
 void PoseDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
 
   arrow_ = std::make_unique<rviz_rendering::Arrow>(scene_manager_, scene_node_,

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp
@@ -99,7 +99,10 @@ PoseDisplay::PoseDisplay()
 
 void PoseDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
 
   arrow_ = std::make_unique<rviz_rendering::Arrow>(scene_manager_, scene_node_,
       shaft_length_property_->getFloat(),
@@ -120,7 +123,7 @@ PoseDisplay::~PoseDisplay() = default;
 
 void PoseDisplay::onEnable()
 {
-  RTDClass::onEnable();
+  MFDClass::onEnable();
   updateShapeVisibility();
   setupSelectionHandler();
 }
@@ -135,7 +138,7 @@ void PoseDisplay::setupSelectionHandler()
 
 void PoseDisplay::onDisable()
 {
-  RTDClass::onDisable();
+  MFDClass::onDisable();
   coll_handler_.reset();
 }
 
@@ -227,7 +230,7 @@ void PoseDisplay::processMessage(geometry_msgs::msg::PoseStamped::ConstSharedPtr
 
 void PoseDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   pose_valid_ = false;
   updateShapeVisibility();
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
@@ -163,7 +163,10 @@ PoseArrayDisplay::~PoseArrayDisplay()
 
 void PoseArrayDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   arrows2d_ = std::make_unique<FlatArrowsArray>(scene_manager_);
   arrows2d_->createAndAttachManualObject(scene_node_);
   arrow_node_ = scene_node_->createChildSceneNode();
@@ -308,7 +311,7 @@ std::unique_ptr<rviz_rendering::Axes> PoseArrayDisplay::makeAxes()
 
 void PoseArrayDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   arrows2d_->clear();
   arrows3d_.clear();
   axes_.clear();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
@@ -163,9 +163,6 @@ PoseArrayDisplay::~PoseArrayDisplay()
 
 void PoseArrayDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
   arrows2d_ = std::make_unique<FlatArrowsArray>(scene_manager_);
   arrows2d_->createAndAttachManualObject(scene_node_);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/range/range_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/range/range_display.cpp
@@ -76,9 +76,6 @@ RangeDisplay::RangeDisplay()
 
 void RangeDisplay::onInitialize()
 {
-  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
-          context_->getFrameManager()->getConnector().lock());
-  buffer_ = tf_wrapper->getBuffer();
   MFDClass::onInitialize();
   updateBufferLength();
   updateColorAndAlpha();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/range/range_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/range/range_display.cpp
@@ -76,7 +76,10 @@ RangeDisplay::RangeDisplay()
 
 void RangeDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  auto tf_wrapper = std::dynamic_pointer_cast<transformation::TFWrapper>(
+          context_->getFrameManager()->getConnector().lock());
+  buffer_ = tf_wrapper->getBuffer();
+  MFDClass::onInitialize();
   updateBufferLength();
   updateColorAndAlpha();
 }
@@ -85,7 +88,7 @@ RangeDisplay::~RangeDisplay() = default;
 
 void RangeDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   updateBufferLength();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -82,7 +82,7 @@ WrenchDisplay::WrenchDisplay()
 
 void WrenchDisplay::onInitialize()
 {
-  RTDClass::onInitialize();
+  MFDClass::onInitialize();
   updateHistoryLength();
 }
 
@@ -90,7 +90,7 @@ WrenchDisplay::~WrenchDisplay() = default;
 
 void WrenchDisplay::reset()
 {
-  RTDClass::reset();
+  MFDClass::reset();
   visuals_.clear();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/transformation/tf_wrapper.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/transformation/tf_wrapper.cpp
@@ -122,14 +122,18 @@ void TFWrapper::initialize(
   rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr rviz_ros_node,
   bool using_dedicated_thread)
 {
-  initializeBuffer(clock, using_dedicated_thread);
+  initializeBuffer(clock, rviz_ros_node.lock()->get_raw_node(), using_dedicated_thread);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(
     *buffer_, rviz_ros_node.lock()->get_raw_node(), false);
 }
 
-void TFWrapper::initializeBuffer(rclcpp::Clock::SharedPtr clock, bool using_dedicated_thread)
+void TFWrapper::initializeBuffer(
+  rclcpp::Clock::SharedPtr clock, rclcpp::Node::SharedPtr node, bool using_dedicated_thread)
 {
   buffer_ = std::make_shared<tf2_ros::Buffer>(clock);
+  auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+    node->get_node_base_interface(), node->get_node_timers_interface());
+  buffer_->setCreateTimerInterface(timer_interface);
   buffer_->setUsingDedicatedThread(using_dedicated_thread);
 }
 

--- a/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
@@ -73,6 +73,11 @@ public:
     return transform_stamped;
   }
 
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+
   geometry_msgs::msg::PoseStamped getPoseStamped()
   {
     std_msgs::msg::Header header;

--- a/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
@@ -44,15 +44,6 @@ class FrameTransformerTfFixture : public testing::Test
 public:
   FrameTransformerTfFixture()
   {
-    auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-    if (!rclcpp::is_initialized()) {
-      rclcpp::init(0, nullptr);
-    }
-    auto node = std::make_shared<rclcpp::Node>("test_node");
-    tf_wrapper_ = std::make_shared<rviz_default_plugins::transformation::TFWrapper>();
-    tf_wrapper_->initializeBuffer(clock, node, false);
-    tf_transformer_ = std::make_unique<rviz_default_plugins::transformation::TFFrameTransformer>(
-      tf_wrapper_);
   }
 
   geometry_msgs::msg::TransformStamped getTransformStamped(
@@ -71,6 +62,17 @@ public:
     transform_stamped.transform = transform;
 
     return transform_stamped;
+  }
+
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+    auto node = std::make_shared<rclcpp::Node>("test_node");
+    tf_wrapper_ = std::make_shared<rviz_default_plugins::transformation::TFWrapper>();
+    tf_wrapper_->initializeBuffer(clock, node, false);
+    tf_transformer_ = std::make_unique<rviz_default_plugins::transformation::TFFrameTransformer>(
+      tf_wrapper_);
   }
 
   void TearDown() override

--- a/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
@@ -42,10 +42,6 @@
 class FrameTransformerTfFixture : public testing::Test
 {
 public:
-  FrameTransformerTfFixture()
-  {
-  }
-
   geometry_msgs::msg::TransformStamped getTransformStamped(
     std::string frame = "frame", std::string fixed_frame = "fixed_frame")
   {

--- a/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
@@ -45,8 +45,12 @@ public:
   FrameTransformerTfFixture()
   {
     auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+    if (!rclcpp::is_initialized()) {
+      rclcpp::init(0, nullptr);
+    }
+    auto node = std::make_shared<rclcpp::Node>("test_node");
     tf_wrapper_ = std::make_shared<rviz_default_plugins::transformation::TFWrapper>();
-    tf_wrapper_->initializeBuffer(clock, false);
+    tf_wrapper_->initializeBuffer(clock, node, false);
     tf_transformer_ = std::make_unique<rviz_default_plugins::transformation::TFFrameTransformer>(
       tf_wrapper_);
   }

--- a/rviz_default_plugins/test/rviz_default_plugins/transformation/transformer_guard_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/transformation/transformer_guard_test.cpp
@@ -59,8 +59,9 @@ public:
     display_->initialize(context_.get());
     base_transformer_ = std::make_shared<MockFrameTransformer>();
     auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+    auto node = std::make_shared<rclcpp::Node>("test_node");
     auto tf_wrapper = std::make_shared<rviz_default_plugins::transformation::TFWrapper>();
-    tf_wrapper->initializeBuffer(clock, false);
+    tf_wrapper->initializeBuffer(clock, node, false);
     tf_transformer_ = std::make_shared<rviz_default_plugins::transformation::TFFrameTransformer>(
       tf_wrapper);
 


### PR DESCRIPTION
Re enable use of TF Filter in rviz_common and rviz_default_plugins. This connects to [issue#55](https://github.com/ros2/rviz/issues/55) [issue#359](https://github.com/ros2/rviz/issues/359)