### PR TITLE
Add stdc++fs as a link library for clang compiler on linux

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -32,6 +32,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif()
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    link_libraries(stdc++fs)
+endif()
+
 find_package(ament_cmake REQUIRED)
 # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
 find_package(rviz_ogre_vendor REQUIRED)


### PR DESCRIPTION
This change is needed to compile rviz_common and packages which
depend on it on linux clang compiler.