### PR TITLE
Free the transformation_manager so that rviz doesn't crash at shutdown

### DIFF
--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -272,6 +272,7 @@ VisualizationManager::~VisualizationManager()
   delete display_factory_;
   delete frame_manager_;
   delete private_;
+  delete transformation_manager_;
 
 #if 0
   Ogre::Root::getSingletonPtr()->removeFrameListener(ogre_render_queue_clearer_);


### PR DESCRIPTION
The transformation_manager_ was not properly deleted, causing rviz to stall and crash at shutdown. 