### PR TITLE
Update ROS node graph API

### DIFF
--- a/rviz_common/src/rviz_common/add_display_dialog.cpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.cpp
@@ -587,6 +587,24 @@ void TopicDisplayWidget::findPlugins(DisplayFactory * factory)
   for (const auto & plugin : plugins) {
     QSet<QString> topic_types = factory->getMessageTypes(plugin.id);
     Q_FOREACH (QString topic_type, topic_types) {
+      // Check if the type name is fully qualified (e.g. in 'msg' namespace).
+      // If not, then insert 'msg' and log a warning.
+      // For now, we assume that all types supported by plugins have the form
+      // "<pkg_name>/msg/<type_name>", though in the future zero or more namespaces may be
+      // permitted.
+      QRegExp delim("/");
+      QStringList topic_type_parts = topic_type.split(delim);
+      if (topic_type_parts.size() == 2) {
+        topic_type = topic_type_parts.at(0) + "/msg/" + topic_type_parts.at(1);
+        RVIZ_COMMON_LOG_WARNING_STREAM(
+          "The plugin '" << plugin.id.toStdString() <<
+          "' message type may not be in a fully qualified namespace. " << std::endl <<
+          "Assuming that the type is in the 'msg' namespace with resultant type '" <<
+          topic_type.toStdString() << "'." << std::endl <<
+          "Please update the plugin description as this assumption will not be made in a " <<
+          "future release."
+        );
+      }
       datatype_plugins_.insertMulti(topic_type, plugin.id);
     }
   }

--- a/rviz_common/src/rviz_common/add_display_dialog.cpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.cpp
@@ -598,11 +598,11 @@ void TopicDisplayWidget::findPlugins(DisplayFactory * factory)
         topic_type = topic_type_parts.at(0) + "/msg/" + topic_type_parts.at(1);
         RVIZ_COMMON_LOG_WARNING_STREAM(
           "The plugin '" << plugin.id.toStdString() <<
-          "' message type may not be in a fully qualified namespace. " << std::endl <<
-          "Assuming that the type is in the 'msg' namespace with resultant type '" <<
-          topic_type.toStdString() << "'." << std::endl <<
-          "Please update the plugin description as this assumption will not be made in a " <<
-          "future release."
+            "' message type may not be in a fully qualified namespace. " << std::endl <<
+            "Assuming that the type is in the 'msg' namespace with resultant type '" <<
+            topic_type.toStdString() << "'." << std::endl <<
+            "Please update the plugin description as this assumption will not be made in a " <<
+            "future release."
         );
       }
       datatype_plugins_.insertMulti(topic_type, plugin.id);

--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -10,8 +10,8 @@
     <description>
       Displays an image from a camera, with the visualized world rendered behind it.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Camera"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>sensor_msgs/Image</message_type>
-    <message_type>sensor_msgs/CompressedImage</message_type>
+    <message_type>sensor_msgs/msg/Image</message_type>
+    <message_type>sensor_msgs/msg/CompressedImage</message_type>
   </class>
 
   <class
@@ -32,7 +32,7 @@
     <description>
       Displays data from a nav_msgs::GridCells message as billboards.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/GridCells"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>nav_msgs/GridCells</message_type>
+    <message_type>nav_msgs/msg/GridCells</message_type>
   </class>
 
   <class
@@ -43,7 +43,7 @@
     <description>
       Displays data from a sensor_msgs::FluidPressure as pointcloud with one point
     </description>
-    <message_type>sensor_msgs/FluidPressure</message_type>
+    <message_type>sensor_msgs/msg/FluidPressure</message_type>
   </class>
 
   <class
@@ -54,7 +54,7 @@
     <description>
       Displays data from a sensor_msgs::Illuminance as pointcloud with one point
     </description>
-    <message_type>sensor_msgs/Illuminance</message_type>
+    <message_type>sensor_msgs/msg/Illuminance</message_type>
   </class>
 
   <class
@@ -65,7 +65,7 @@
     <description>
       The Image display creates a new rendering window with an image.
     </description>
-    <message_type>sensor_msgs/Image</message_type>
+    <message_type>sensor_msgs/msg/Image</message_type>
   </class>
 
   <class
@@ -76,7 +76,7 @@
     <description>
       Displays the data from a sensor_msgs::LaserScan message as points in the world, drawn as points, billboards, or cubes.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/LaserScan"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>sensor_msgs/LaserScan</message_type>
+    <message_type>sensor_msgs/msg/LaserScan</message_type>
   </class>
 
   <class name="rviz_default_plugins/Map"
@@ -86,7 +86,7 @@
     <description>
       Displays an occupancy grid on the ground plane from a nav_msgs::OccupancyGrid.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Map"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>nav_msgs/OccupancyGrid</message_type>
+    <message_type>nav_msgs/msg/OccupancyGrid</message_type>
   </class>
 
   <class
@@ -97,7 +97,7 @@
     <description>
       The Point Cloud display shows data from a (legacy) sensor_msgs/PointCloud message.
     </description>
-    <message_type>sensor_msgs/PointCloud</message_type>
+    <message_type>sensor_msgs/msg/PointCloud</message_type>
   </class>
 
   <class
@@ -108,7 +108,7 @@
     <description>
       The Point Cloud2 display shows data from a (recommended) sensor_msgs/PointCloud2 message.
     </description>
-    <message_type>sensor_msgs/PointCloud2</message_type>
+    <message_type>sensor_msgs/msg/PointCloud2</message_type>
   </class>
 
   <class
@@ -119,7 +119,7 @@
     <description>
       Displays data from a geometry_msgs::PolygonStamped message as lines.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Polygon"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>geometry_msgs/PolygonStamped</message_type>
+    <message_type>geometry_msgs/msg/PolygonStamped</message_type>
   </class>
 
   <class
@@ -130,7 +130,7 @@
     <description>
       Displays a geometry_msgs::PoseStamped message.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Pose"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>geometry_msgs/PoseStamped</message_type>
+    <message_type>geometry_msgs/msg/PoseStamped</message_type>
   </class>
 
   <class
@@ -141,7 +141,7 @@
     <description>
       Displays the data from sensor_msgs::Range messages as cones. &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Range"&gt;More Information&lt;/a&gt;
     </description>
-    <message_type>sensor_msgs/Range</message_type>
+    <message_type>sensor_msgs/msg/Range</message_type>
   </class>
 
   <class
@@ -152,7 +152,7 @@
     <description>
       Displays the data from sensor_msgs::RelativeHumidity messages as point cloud with one point
     </description>
-    <message_type>sensor_msgs/RelativeHumidity</message_type>
+    <message_type>sensor_msgs/msg/RelativeHumidity</message_type>
   </class>
 
   <class
@@ -173,7 +173,7 @@
     <description>
       Displays the data from sensor_msgs::Temperature messages as point cloud with one point
     </description>
-    <message_type>sensor_msgs/Temperature</message_type>
+    <message_type>sensor_msgs/msg/Temperature</message_type>
   </class>
 
   <class
@@ -184,7 +184,7 @@
     <description>
       Displays the TF transform hierarchy.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/TF"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>tf2_msgs/TFMessage</message_type>
+    <message_type>tf2_msgs/msg/TFMessage</message_type>
   </class>
 
   <class
@@ -195,7 +195,7 @@
     <description>
       Displays visualization_msgs::Marker messages. &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Marker"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>visualization_msgs/Marker</message_type>
+    <message_type>visualization_msgs/msg/Marker</message_type>
   </class>
 
   <class
@@ -206,7 +206,7 @@
           Displays visualization_msgs::MarkerArray messages without presuming the topic name ends in "_array".
           <a href="http://www.ros.org/wiki/rviz/DisplayTypes/Marker">More Information</a>.
       </description>
-      <message_type>visualization_msgs/MarkerArray</message_type>
+      <message_type>visualization_msgs/msg/MarkerArray</message_type>
   </class>
 
   <class
@@ -217,7 +217,7 @@
     <description>
       Accumulates and displays poses from a nav_msgs::Odometry message.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Odometry"&gt;More Information&lt;/a&gt;
     </description>
-    <message_type>nav_msgs/Odometry</message_type>
+    <message_type>nav_msgs/msg/Odometry</message_type>
   </class>
 
   <class
@@ -228,7 +228,7 @@
     <description>
       The Pose Array display shows a geometry_msgs/PoseArray message, as a collection of arrows.  &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/PoseArray"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>geometry_msgs/PoseArray</message_type>
+    <message_type>geometry_msgs/msg/PoseArray</message_type>
   </class>
 
   <class
@@ -239,7 +239,7 @@
     <description>
       Displays data from a nav_msgs::Path message as lines. &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Path"&gt;More Information&lt;/a&gt;.
     </description>
-    <message_type>nav_msgs/Path</message_type>
+    <message_type>nav_msgs/msg/Path</message_type>
   </class>
 
   <class
@@ -250,7 +250,7 @@
     <description>
       Displays from geometry_msgs/PointStamped message
     </description>
-    <message_type>geometry_msgs/PointStamped</message_type>
+    <message_type>geometry_msgs/msg/PointStamped</message_type>
   </class>
 
   <!-- Tool plugins -->


### PR DESCRIPTION
The node function get_topic_names_and_types() now returns a vector for each type name
containing the parts of the fully qualified name.

Connects to ros2/ros2#677
