### PR TITLE
[Windows][Crystal] Constraint Freetype dependencies for more predictable build result.

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -39,6 +39,10 @@ macro(build_freetype)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/freetype_install
       ${extra_cmake_args}
       -Wno-dev
+      -WITH_ZLIB=OFF
+      -WITH_BZip2=OFF
+      -WITH_PNG=OFF
+      -WITH_HarfBuzz=OFF
   )
 
   install(

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -39,10 +39,10 @@ macro(build_freetype)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/freetype_install
       ${extra_cmake_args}
       -Wno-dev
-      -WITH_ZLIB=OFF
-      -WITH_BZip2=OFF
-      -WITH_PNG=OFF
-      -WITH_HarfBuzz=OFF
+      -DWITH_ZLIB=OFF
+      -DWITH_BZip2=OFF
+      -DWITH_PNG=OFF
+      -DWITH_HarfBuzz=OFF
   )
 
   install(


### PR DESCRIPTION
This `freetype` library in Crystal release on Windows is a static library and that implies any dependencies of `freetype` also need to be exported to the downstream project which consumes `freetype`.

If following the steps from `https://index.ros.org/doc/ros2/Installation/Windows-Development-Setup/`, there is no problem because no other unexpected libraries in CMAKE search path. However, for example, `ZLib` just happens to be in the CMAKE search path, then `freetype` will be intellegently try to discover and link against `ZLib` and however the freetype CMake config was not exposing its dependencies to the downstream projects consuming `freetype`.

In order to make the build more predictable for different environment, I added the flags to explicitly disable all the optional dependencies discovery.


UPDATED: Here is a example of the build error when running into this.
```
Microsoft (R) Build Engine version 16.3.0+0f4c62fea for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  OgreMain.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreMain.dll
  Codec_STBI.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\Codec_STBI.dll
  OgreGLSupport.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\lib\Release\OgreGLSupport.lib
  OgreHLMS.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreHLMS.dll
  OgreMeshLodGenerator.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreMeshLodGenerator.dll
  OgreMeshUpgrader.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreMeshUpgrader.exe
     Creating library F:/workspace/ros2__ws/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src/ogre-v1.12.1-build/lib/Release/OgreOverlay.lib and object F:/workspace/ros2__ws/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src/ogre-v1.12.1-build/lib/Release/OgreOverlay.exp
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_create_read_struct referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_longjmp_fn referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_create_info_struct referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_read_info referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_expand_gray_1_2_4_to_8 referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_palette_to_rgb referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_tRNS_to_alpha referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_gray_to_rgb referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_filler referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_packing referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_interlace_handling referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_strip_16 referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_read_update_info referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_read_image referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_read_end referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_destroy_read_struct referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_get_error_ptr referenced in function error_callback [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_read_fn referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_get_io_ptr referenced in function read_data_from_FT_Stream [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_set_read_user_transform_fn referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_error referenced in function read_data_from_FT_Stream [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_get_valid referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
freetype.lib(sfnt.obj) : error LNK2019: unresolved external symbol png_get_IHDR referenced in function Load_SBit_Png [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreOverlay.dll : fatal error LNK1120: 23 unresolved externals [F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\Components\Overlay\OgreOverlay.vcxproj]
  OgrePaging.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgrePaging.dll
  OgreProperty.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreProperty.dll
  OgreRTShaderSystem.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreRTShaderSystem.dll
  OgreTerrain.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreTerrain.dll
  OgreVolume.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreVolume.dll
  OgreXMLConverter.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\OgreXMLConverter.exe
  Plugin_BSPSceneManager.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\Plugin_BSPSceneManager.dll
  Plugin_OctreeSceneManager.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\Plugin_OctreeSceneManager.dll
  Plugin_PCZSceneManager.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\Plugin_PCZSceneManager.dll
  Plugin_OctreeZone.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\Plugin_OctreeZone.dll
  Plugin_ParticleFX.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\Plugin_ParticleFX.dll
  RenderSystem_GL.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\RenderSystem_GL.dll
  RenderSystem_GL3Plus.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\RenderSystem_GL3Plus.dll
  VRMLConverter.vcxproj -> F:\workspace\ros2__ws\build\rviz_ogre_vendor\ogre-v1.12.1-prefix\src\ogre-v1.12.1-build\bin\Release\VRMLConverter.exe
```