### PR TITLE
Use node to create clock used to stamp publications 

### DIFF
--- a/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction_iface.hpp
+++ b/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction_iface.hpp
@@ -64,6 +64,7 @@ public:
   get_topic_names_and_types() const = 0;
 
   // TODO(anhosi): remove once the RosNodeAbstraction is extended to handle subscriptions
+  //               and clock
   virtual rclcpp::Node::SharedPtr
   get_raw_node() = 0;
 };

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -325,7 +325,7 @@ void VisualizationFrame::initialize(
   //                render_panel and VisualizationManager
   render_panel_->getRenderWindow()->initialize();
 
-  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto clock = rviz_ros_node.lock()->get_raw_node()->get_clock();
   manager_ = new VisualizationManager(render_panel_, rviz_ros_node, this, clock);
   manager_->setHelpPath(help_path_);
   panel_factory_ = new PanelFactory(rviz_ros_node_, manager_);


### PR DESCRIPTION
Existing behavior is that `initialpose` is always published with the wall time, even when `use_sim_time` is `true`.

I'm hoping there is a better way to get a hold of the ROS clock - let me know and I'll update this PR.