### PR TITLE
Fix STL loader

### DIFF
--- a/rviz_rendering/include/rviz_rendering/material_manager.hpp
+++ b/rviz_rendering/include/rviz_rendering/material_manager.hpp
@@ -60,6 +60,8 @@ public:
 
   static Ogre::MaterialPtr createMaterialWithShadowsAndNoLighting(std::string name);
 
+  static void createDefaultMaterials();
+
   static void enableAlphaBlending(Ogre::MaterialPtr material, float alpha);
 
   static void enableAlphaBlending(Ogre::SceneBlendType & blending, bool & depth_write, float alpha);

--- a/rviz_rendering/src/rviz_rendering/material_manager.cpp
+++ b/rviz_rendering/src/rviz_rendering/material_manager.cpp
@@ -120,4 +120,11 @@ void MaterialManager::enableAlphaBlending(
   }
 }
 
+void MaterialManager::createDefaultMaterials()
+{
+  auto material = Ogre::MaterialManager::getSingleton().create(
+    "BaseWhiteNoLighting", "rviz_rendering");
+  material->setLightingEnabled(false);
+}
+
 }  // namespace rviz_rendering

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/stl_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/stl_loader.cpp
@@ -42,6 +42,8 @@
 
 #include "rviz_rendering/logging.hpp"
 
+#define ROS_PACKAGE_NAME "rviz_rendering"
+
 namespace rviz_rendering
 {
 
@@ -185,7 +187,7 @@ Ogre::MeshPtr STLLoader::toMesh(const std::string & name)
 {
   std::shared_ptr<Ogre::ManualObject> object =
     std::make_shared<Ogre::ManualObject>("the one and only");
-  object->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
+  object->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST, ROS_PACKAGE_NAME);
 
   unsigned int vertexCount = 0;
   for (const STLLoader::Triangle & triangle : triangles_) {
@@ -193,7 +195,8 @@ Ogre::MeshPtr STLLoader::toMesh(const std::string & name)
       // Subdivide large meshes into submeshes with at most 2004
       // vertices to prevent problems on some graphics cards.
       object->end();
-      object->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
+      object->begin(
+        "BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST, ROS_PACKAGE_NAME);
       vertexCount = 0;
     }
 
@@ -208,8 +211,7 @@ Ogre::MeshPtr STLLoader::toMesh(const std::string & name)
 
   object->end();
 
-  Ogre::MeshPtr mesh = object->convertToMesh(name,
-      Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+  Ogre::MeshPtr mesh = object->convertToMesh(name, ROS_PACKAGE_NAME);
   mesh->buildEdgeList();
 
   return mesh;

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -48,6 +48,7 @@
 
 #include "ament_index_cpp/get_resource.hpp"
 #include "ament_index_cpp/get_resources.hpp"
+#include "rviz_rendering/material_manager.hpp"
 #include "rviz_rendering/logging.hpp"
 #include "rviz_rendering/ogre_logging.hpp"
 #include "rviz_rendering/resource_config.hpp"
@@ -354,6 +355,7 @@ RenderSystem::setupResources()
   }
 
   addAdditionalResourcesFromAmentIndex();
+  MaterialManager::createDefaultMaterials();
 }
 
 void RenderSystem::addAdditionalResourcesFromAmentIndex() const

--- a/rviz_rendering_tests/test/mesh_loader_test.cpp
+++ b/rviz_rendering_tests/test/mesh_loader_test.cpp
@@ -148,6 +148,13 @@ TEST_F(MeshLoaderTestFixture, loading_almost_valid_stl_files_should_succed) {
   ASSERT_TRUE(rviz_rendering::loadMeshFromResource(mesh_path));
 }
 
+TEST_F(MeshLoaderTestFixture, loading_stl_mesh_twice_should_not_fail) {
+  std::string mesh_path = "package://rviz_rendering_tests/test_meshes/F2.stl";
+
+  ASSERT_TRUE(rviz_rendering::loadMeshFromResource(mesh_path));
+  ASSERT_TRUE(rviz_rendering::loadMeshFromResource(mesh_path));
+}
+
 TEST_F(MeshLoaderTestFixture, can_load_assimp_mesh_files) {
   std::string mesh_path = "package://rviz_rendering_tests/test_meshes/pr2-base.dae";
 


### PR DESCRIPTION
Probably fix #355 

The STL loader has a bug where it loads the meshes into the wrong resource group. This results in a crash when a mesh with the same name (the resource location) is loaded twice at runtime. Normally, the already loaded mesh should be returned.

The first commit adds a test demonstrating this bug, which is probably the root cause for #355.
The second commit fixes that bug. 

I don't have a good way to deal with the fact that we define the "ROS_PACKAGE_NAME" in several files. We could define it via CMake but that's not very nice either so for now I suggest duplicating the definition (as is already done throughout `rviz_rendering`). Since we have a test now, any problematic updates should be caught.