### PR TITLE
Fix camera info for camera display

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -283,7 +283,7 @@ void CameraDisplay::createCameraInfoSubscription()
     // TODO(anyone) Store this in a member variable
     auto camera_info_topic = topic_property_->getTopicStd();
     camera_info_topic =
-        camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
+      camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
 
     caminfo_sub_ = rviz_ros_node_.lock()->get_raw_node()->
       template create_subscription<sensor_msgs::msg::CameraInfo>(
@@ -334,7 +334,7 @@ void CameraDisplay::clear()
 
   auto camera_info_topic = topic_property_->getTopicStd();
   camera_info_topic =
-      camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
+    camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
 
   setStatus(StatusLevel::Warn, CAM_INFO_STATUS,
     "No CameraInfo received on [" + QString::fromStdString(camera_info_topic) + "]. "
@@ -376,7 +376,7 @@ bool CameraDisplay::updateCamera()
   if (!info) {
     auto camera_info_topic = topic_property_->getTopicStd();
     camera_info_topic =
-        camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
+      camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
 
     setStatus(StatusLevel::Warn, CAM_INFO_STATUS,
       "Expecting Camera Info on topic [" + QString::fromStdString(camera_info_topic) + "]. "

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -278,10 +278,17 @@ void CameraDisplay::createCameraInfoSubscription()
 {
   try {
     // TODO(anhosi,wjwwood): replace with abstraction for subscriptions one available
+
+    // The camera_info topic should be at the same level as the image topic
+    // TODO(anyone) Store this in a member variable
+    auto camera_info_topic = topic_property_->getTopicStd();
+    camera_info_topic =
+        camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
+
     caminfo_sub_ = rviz_ros_node_.lock()->get_raw_node()->
       template create_subscription<sensor_msgs::msg::CameraInfo>(
-      topic_property_->getTopicStd() + "/camera_info",
-      qos_profile,
+      camera_info_topic,
+      rclcpp::SensorDataQoS(),
       [this](sensor_msgs::msg::CameraInfo::ConstSharedPtr msg) {
         std::unique_lock<std::mutex> lock(caminfo_mutex_);
         current_caminfo_ = msg;
@@ -325,8 +332,12 @@ void CameraDisplay::clear()
   new_caminfo_ = false;
   current_caminfo_.reset();
 
+  auto camera_info_topic = topic_property_->getTopicStd();
+  camera_info_topic =
+      camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
+
   setStatus(StatusLevel::Warn, CAM_INFO_STATUS,
-    "No CameraInfo received on [" + topic_property_->getTopic() + "/camera_info" + "]. "
+    "No CameraInfo received on [" + QString::fromStdString(camera_info_topic) + "]. "
     "Topic may not exist.");
 
   rviz_rendering::RenderWindowOgreAdapter::getOgreCamera(
@@ -363,8 +374,12 @@ bool CameraDisplay::updateCamera()
   }
 
   if (!info) {
+    auto camera_info_topic = topic_property_->getTopicStd();
+    camera_info_topic =
+        camera_info_topic.substr(0, camera_info_topic.rfind("/") + 1) + "camera_info";
+
     setStatus(StatusLevel::Warn, CAM_INFO_STATUS,
-      "Expecting Camera Info on topic [" + topic_property_->getTopic() + "/camera_info" + "]. "
+      "Expecting Camera Info on topic [" + QString::fromStdString(camera_info_topic) + "]. "
       "No CameraInfo received. Topic may not exist.");
     return false;
   }


### PR DESCRIPTION
A quick and dirty solution to #207 .

You can try it out with Gazebo:

1. Launch Gazebo with the [camera demo world](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/ros2/gazebo_plugins/worlds/gazebo_ros_camera_demo.world)

        gazebo gazebo_ros_camera_demo.world

1. Launch RViz with [this config](https://bitbucket.org/snippets/chapulina/8A7rMa)

1. Publish a marker with:

        ros2 topic pub -1 /visualization_marker visualization_msgs/msg/Marker '{header: {frame_id: "camera_link"}, id: 1, type: 1, action: 0, pose: {position: {z: 2}, orientation: {y: 0.38, w: 0.92}}, scale: {x: 1., y: 1., z: 1.}, color: {r: 1., g: 0., b: 1., a: 1.}}'

On RViz, the marker should be correctly projected onto the camera image:

![camera_info_rviz](https://user-images.githubusercontent.com/5751272/60280098-22b16900-98b7-11e9-893c-68bdf6a8980d.gif)
