### PR TITLE
Remove -Werror

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
   # TODO(wjwwood): try to remove this -- currently needed to pass on CI
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag(-Wno-gnu-zero-variadic-macro-arguments HAS_W_FLAG)

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 # Tests currently only run on OS X @ OSRF jenkins

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 # Tests currently only run on OS X @ OSRF jenkins

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 # Tests currently only run on OS X @ OSRF jenkins

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
This removes `-Werror` from the default set of compiler flags, as @wjwwood mentioned was alright to do [in this comment](https://github.com/ros2/rviz/issues/402#issuecomment-50644687).

This should resolve #402.

