### PR TITLE
Remove gnu-zero-variadic-macro-arguments

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -24,12 +24,6 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
-  # TODO(wjwwood): try to remove this -- currently needed to pass on CI
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag(-Wno-gnu-zero-variadic-macro-arguments HAS_W_FLAG)
-  if(HAS_W_FLAG)
-    add_compile_options(-Wno-gnu-zero-variadic-macro-arguments)
-  endif()
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Updates to rviz_common to fix some warnings that popped up in gcc-9:

- Updates to rviz_common::Config to silence new `-Wdeprecated-copy` warnings
- Remove broken conditional to disable the `-Wgnu-zero-variadic-macro-arguments` (see #402 

With these fixes, rviz_common builds without warnings with gcc-9.

See the commit messages for more details.