### PR TITLE
Disambiguate "estimate" pose from "goal" pose in log

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/tools/pose/pose_tool.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/tools/pose/pose_tool.hpp
@@ -84,6 +84,7 @@ protected:
   geometry_msgs::msg::Quaternion orientationAroundZAxis(double angle);
 
   void logPose(
+    std::string designation,
     geometry_msgs::msg::Point position,
     geometry_msgs::msg::Quaternion orientation,
     double angle,

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/nav_goal/goal_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/nav_goal/goal_tool.cpp
@@ -83,7 +83,7 @@ void GoalTool::onPoseSet(double x, double y, double theta)
 
   goal.pose.orientation = orientationAroundZAxis(theta);
 
-  logPose(goal.pose.position, goal.pose.orientation, theta, fixed_frame);
+  logPose("goal", goal.pose.position, goal.pose.orientation, theta, fixed_frame);
 
   publisher_->publish(goal);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/pose/pose_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/pose/pose_tool.cpp
@@ -175,17 +175,15 @@ geometry_msgs::msg::Quaternion PoseTool::orientationAroundZAxis(double angle)
   return orientation;
 }
 
-void
-PoseTool::logPose(
-  geometry_msgs::msg::Point position,
-  geometry_msgs::msg::Quaternion orientation,
-  double angle,
-  std::string frame)
+void PoseTool::logPose(
+  std::string designation, geometry_msgs::msg::Point position,
+  geometry_msgs::msg::Quaternion orientation, double angle, std::string frame)
 {
-  RVIZ_COMMON_LOG_INFO_STREAM("Setting goal: Frame:" << frame << ", Position(" <<
-    position.x << ", " << position.y << ", " << position.z << "), Orientation(" <<
-    orientation.x << ", " << orientation.y << ", " << orientation.z << ", " << orientation.w <<
-    ") = Angle: " << angle);
+  RVIZ_COMMON_LOG_INFO_STREAM(
+    "Setting " << designation << " pose: Frame:" << frame << ", Position(" << position.x << ", "
+               << position.y << ", " << position.z << "), Orientation(" << orientation.x << ", "
+               << orientation.y << ", " << orientation.z << ", " << orientation.w
+               << ") = Angle: " << angle);
 }
 
 }  // namespace tools

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/pose/pose_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/pose/pose_tool.cpp
@@ -180,10 +180,10 @@ void PoseTool::logPose(
   geometry_msgs::msg::Quaternion orientation, double angle, std::string frame)
 {
   RVIZ_COMMON_LOG_INFO_STREAM(
-    "Setting " << designation << " pose: Frame:" << frame << ", Position(" << position.x << ", "
-               << position.y << ", " << position.z << "), Orientation(" << orientation.x << ", "
-               << orientation.y << ", " << orientation.z << ", " << orientation.w
-               << ") = Angle: " << angle);
+    "Setting " << designation << " pose: Frame:" << frame << ", Position(" << position.x << ", " <<
+      position.y << ", " << position.z << "), Orientation(" << orientation.x << ", " <<
+      orientation.y << ", " << orientation.z << ", " << orientation.w <<
+      ") = Angle: " << angle);
 }
 
 }  // namespace tools

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.cpp
@@ -86,7 +86,7 @@ void InitialPoseTool::onPoseSet(double x, double y, double theta)
   pose.pose.covariance[6 * 1 + 1] = 0.5 * 0.5;
   pose.pose.covariance[6 * 5 + 5] = M_PI / 12.0 * M_PI / 12.0;
 
-  logPose(pose.pose.pose.position, pose.pose.pose.orientation, theta, fixed_frame);
+  logPose("estimate", pose.pose.pose.position, pose.pose.pose.orientation, theta, fixed_frame);
 
   publisher_->publish(pose);
 }


### PR DESCRIPTION
Fixes #417 
Previously setting a 2D Pose Estimate then a 2D Nav Goal would log something like:
```
[INFO] [rviz2]: Setting goal: Frame:map, Position(1.30849, -2.7475, 0), Orientation(0, 0, 0.624316, 0.781172) = Angle: 1.34851
[INFO] [rviz2]: Setting goal: Frame:map, Position(-2.8186, 2.15941, 0), Orientation(0, 0, 0.555852, 0.831281) = Angle: 1.17878
```

Now it logs something like:
```
[INFO] [rviz2]: Setting estimate pose: Frame:map, Position(0.672111, -0.269852, 0), Orientation(0, 0, -0.964214, 0.265125) = Angle: -2.60493
[INFO] [rviz2]: Setting goal pose: Frame:map, Position(0.259397, 0.284402, 0), Orientation(0, 0, -0.98341, 0.181399) = Angle: -2.77678
```

