### PR TITLE
avoid qt 5.13 deprecations

### DIFF
--- a/rviz_common/src/rviz_common/loading_dialog.cpp
+++ b/rviz_common/src/rviz_common/loading_dialog.cpp
@@ -53,7 +53,7 @@ void LoadingDialog::showMessage(const QString & message)
   label_->setText(message);
   QApplication::processEvents();
   QWidget::repaint();
-  QApplication::flush();
+  QApplication::sendPostedEvents();
 }
 
 }  // namespace rviz_common

--- a/rviz_common/src/rviz_common/screenshot_dialog.cpp
+++ b/rviz_common/src/rviz_common/screenshot_dialog.cpp
@@ -32,6 +32,7 @@
 
 #include <utility>
 
+#include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
 #include <QCheckBox>  // NOLINT: cpplint is unable to handle the include order here
 #include <QDateTime>  // NOLINT: cpplint is unable to handle the include order here
 #include <QDialogButtonBox>  // NOLINT: cpplint is unable to handle the include order here
@@ -42,8 +43,10 @@
 #include <QMessageBox>  // NOLINT: cpplint is unable to handle the include order here
 // Included so we know that QPushButton inherits QAbstractButton
 #include <QPushButton>  // NOLINT: cpplint is unable to handle the include order here
+#include <QScreen>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here
+#include <QWindow>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "./scaled_image_widget.hpp"
 
@@ -119,10 +122,20 @@ void ScreenshotDialog::onTimeout()
 
 void ScreenshotDialog::takeScreenshotNow()
 {
+  QScreen *screen = QApplication::primaryScreen();
+  if (const QWindow *window = windowHandle()) {
+    screen = window->screen();
+  }
+  if (!screen) {
+    QString error_message = "Unable to fetch primary screen";
+    QMessageBox::critical(this, "Error", error_message);
+    return;
+  }
+
   if (save_full_window_) {
-    screenshot_ = QPixmap::grabWindow(main_window_->winId());
+    screenshot_ = screen->grabWindow(main_window_->winId());
   } else {
-    screenshot_ = QPixmap::grabWindow(render_window_->winId());
+    screenshot_ = screen->grabWindow(render_window_->winId());
   }
   image_widget_->setImage(screenshot_);
 }


### PR DESCRIPTION
`QApplication::flush` is deprecated: https://doc.qt.io/qt-5/qcoreapplication-obsolete.html#flush
`QPixMap::grabWindow` is also deprecated:  https://doc.qt.io/qt-5/qpixmap-obsolete.html#grabWindow

The first one is a straightforward replacement, the second one however needs an initialization of a `QScreen` object with a window ID. 

Signed-off-by: Karsten Knese <karsten@openrobotics.org>