### PR TITLE
fix deprecation warnings with new Qt

### DIFF
--- a/rviz_common/src/rviz_common/loading_dialog.cpp
+++ b/rviz_common/src/rviz_common/loading_dialog.cpp
@@ -53,7 +53,6 @@ void LoadingDialog::showMessage(const QString & message)
   label_->setText(message);
   QApplication::processEvents();
   QWidget::repaint();
-  QApplication::flush();
 }
 
 }  // namespace rviz_common

--- a/rviz_common/src/rviz_common/screenshot_dialog.cpp
+++ b/rviz_common/src/rviz_common/screenshot_dialog.cpp
@@ -42,8 +42,10 @@
 #include <QMessageBox>  // NOLINT: cpplint is unable to handle the include order here
 // Included so we know that QPushButton inherits QAbstractButton
 #include <QPushButton>  // NOLINT: cpplint is unable to handle the include order here
+#include <QScreen>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here
+#include <QWindow>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "./scaled_image_widget.hpp"
 
@@ -120,9 +122,9 @@ void ScreenshotDialog::onTimeout()
 void ScreenshotDialog::takeScreenshotNow()
 {
   if (save_full_window_) {
-    screenshot_ = QPixmap::grabWindow(main_window_->winId());
+    screenshot_ = main_window_->windowHandle()->screen()->grabWindow(main_window_->winId());
   } else {
-    screenshot_ = QPixmap::grabWindow(render_window_->winId());
+    screenshot_ = render_window_->windowHandle()->screen()->grabWindow(render_window_->winId());
   }
   image_widget_->setImage(screenshot_);
 }

--- a/rviz_common/src/rviz_common/screenshot_dialog.cpp
+++ b/rviz_common/src/rviz_common/screenshot_dialog.cpp
@@ -121,10 +121,11 @@ void ScreenshotDialog::onTimeout()
 
 void ScreenshotDialog::takeScreenshotNow()
 {
+  QScreen * screen = main_window_->windowHandle()->screen();
   if (save_full_window_) {
-    screenshot_ = main_window_->windowHandle()->screen()->grabWindow(main_window_->winId());
+    screenshot_ = screen->grabWindow(main_window_->winId());
   } else {
-    screenshot_ = render_window_->windowHandle()->screen()->grabWindow(render_window_->winId());
+    screenshot_ = screen->grabWindow(render_window_->winId());
   }
   image_widget_->setImage(screenshot_);
 }


### PR DESCRIPTION
This fixes compiler warnings after upgrading to the new Qt on our macOS machines:

https://ci.ros2.org/view/All/job/test_packaging_osx/1/warnings11Result/

I think we should also backport this for dashing, but we could choose to wait for the next patch release if we're ok ignoring these warnings. @nuclearsandwich do you have an opinion?