### PR TITLE
Use eigen3_cmake_module

### DIFF
--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -39,13 +39,9 @@ find_package(rviz_assimp_vendor REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
 find_package(ament_index_cpp REQUIRED)
+find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(resource_retriever REQUIRED)
-
-# Handle FindEigen3 module's differing definitions
-if(NOT DEFINED EIGEN3_INCLUDE_DIRS AND DEFINED EIGEN3_INCLUDE_DIR)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
-endif()
 
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
 if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
@@ -120,7 +116,7 @@ target_include_directories(rviz_rendering
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     ${OGRE_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS}
+    ${Eigen3_INCLUDE_DIRS}
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -132,6 +128,7 @@ ament_target_dependencies(rviz_rendering
 )
 ament_export_dependencies(
   rviz_ogre_vendor
+  eigen3_cmake_module
   Eigen3
   resource_retriever
   ament_index_cpp)

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -16,6 +16,7 @@
   <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <build_depend>ament_index_cpp</build_depend>
   <build_depend>eigen</build_depend>
@@ -29,7 +30,6 @@
   <build_export_depend>rviz_ogre_vendor</build_export_depend>
 
   <exec_depend>ament_index_cpp</exec_depend>
-  <exec_depend>eigen</exec_depend>
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -18,6 +18,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+
   <build_depend>ament_index_cpp</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>qtbase5-dev</build_depend>


### PR DESCRIPTION
This adds a dependency on `eigen3_cmake_module`, which sets standard cmake variables when finding `Eigen3`.

~~Requires ros2/eigen3_cmake_module#1~~
~~Requires ros2/eigen3_cmake_module#3~~