### PR TITLE
fix assert in mesh_loader_test

### DIFF
--- a/rviz_rendering_tests/test/mesh_loader_test.cpp
+++ b/rviz_rendering_tests/test/mesh_loader_test.cpp
@@ -95,8 +95,7 @@ TEST_F(MeshLoaderTestFixture, can_load_stl_files) {
 
   auto mesh = rviz_rendering::loadMeshFromResource(mesh_path);
 
-  double actual_bounding_radius = mesh->getBoundingSphereRadius();
-  double expected_bound_radius = 34.920441;
+  float expected_bound_radius = 34.920441f;
   size_t expected_vertex_count = 35532;
   size_t actual_vertex_count = 0;
   // Meshes are divided and stored in submeshes with at most 2004 vertices each.
@@ -105,7 +104,7 @@ TEST_F(MeshLoaderTestFixture, can_load_stl_files) {
   }
   ASSERT_TRUE(mesh->isManuallyLoaded());
   ASSERT_EQ(mesh_path, mesh->getName());
-  ASSERT_EQ(std::to_string(expected_bound_radius), std::to_string(actual_bounding_radius));
+  ASSERT_FLOAT_EQ(expected_bound_radius, mesh->getBoundingSphereRadius());
   ASSERT_EQ(expected_vertex_count, actual_vertex_count);
 }
 


### PR DESCRIPTION
The test "can_load_stl_files" was asserting on a float comparison by first casting to strings.

I replaced the string cast and assert with ASSERT_FLOAT_EQ. The type of "expected_bound_radius" was also changed to float since "getBoundingSphereRadius" returns a float.