### PR TITLE
Use git apply Instead of patch

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -141,12 +141,6 @@ macro(build_ogre)
       "-DZLIB_ROOT=${CMAKE_CURRENT_BINARY_DIR}/zlib_install")
   endif()
 
-  if(WIN32)
-    set(patch_exe patch.exe)
-  else()
-    set(patch_exe patch)
-  endif()
-
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
   else()
@@ -179,7 +173,7 @@ macro(build_ogre)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${patch_exe} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/ogre-ca665a6-patch.diff
+      git apply ${CMAKE_CURRENT_SOURCE_DIR}/ogre-ca665a6-patch.diff
   )
 
   if(BUILDING_FREETYPE_LOCALLY)

--- a/rviz_ogre_vendor/package.xml
+++ b/rviz_ogre_vendor/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>pkg-config</build_depend>
-
+  <build_depend>git</build_depend>
   <build_depend>libfreetype6-dev</build_depend>
   <build_export_depend>libfreetype6-dev</build_export_depend>
   <exec_depend>libfreetype6</exec_depend>


### PR DESCRIPTION
Use `git apply` instead of `patch` command for patching to allow building from source on Windows 10 without administrator privileges.

Signed-off-by: Hunter L. Allen <hunterlallen@protonmail.com>

--- 

This relates to ament/uncrustify_vendor#6