### PR TITLE
Do not select interactive markers when mousing over them

### DIFF
--- a/rviz_common/include/rviz_common/interaction/selection_manager.hpp
+++ b/rviz_common/include/rviz_common/interaction/selection_manager.hpp
@@ -99,6 +99,15 @@ public:
     int y2,
     SelectType type) override;
 
+  /// Get all objects in a bounding box.
+  void pick(
+    rviz_rendering::RenderWindow * window,
+    int x1,
+    int y1,
+    int x2,
+    int y2,
+    M_Picked & results) override;
+
   void update() override;
 
   const M_Picked & getSelection() const override;
@@ -141,20 +150,6 @@ private Q_SLOTS:
   void updateProperties();
 
 private:
-  /**
-   * \return handles of all objects in the given bounding box
-   * \param single_render_pass only perform one rendering pass
-   *   (point cloud selecting won't work)
-   */
-  void pick(
-    rviz_rendering::RenderWindow * window,
-    int x1,
-    int y1,
-    int x2,
-    int y2,
-    M_Picked & results,
-    bool single_render_pass = false);
-
   /// Set the list of currently selected objects.
   void setSelection(const M_Picked & objs);
 

--- a/rviz_common/include/rviz_common/interaction/selection_manager_iface.hpp
+++ b/rviz_common/include/rviz_common/interaction/selection_manager_iface.hpp
@@ -87,6 +87,18 @@ public:
   virtual void select(
     rviz_rendering::RenderWindow * window, int x1, int y1, int x2, int y2, SelectType type) = 0;
 
+  /// Get all objects in a bounding box.
+  /**
+   * \return handles of all objects in the given bounding box
+   */
+  virtual void pick(
+    rviz_rendering::RenderWindow * window,
+    int x1,
+    int y1,
+    int x2,
+    int y2,
+    M_Picked & results) = 0;
+
   virtual void update() = 0;
 
   virtual const M_Picked & getSelection() const = 0;

--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -585,8 +585,7 @@ void SelectionManager::pick(
   int y1,
   int x2,
   int y2,
-  M_Picked & results,
-  bool single_render_pass)
+  M_Picked & results)
 {
   auto handler_lock = handler_manager_->lock(std::defer_lock);
   std::lock(selection_mutex_, handler_lock);
@@ -619,7 +618,7 @@ void SelectionManager::pick(
         std::pair<M_Picked::iterator, bool> insert_result =
           results.insert(std::make_pair(handle, Picked(handle)));
         if (insert_result.second) {
-          if (handler->needsAdditionalRenderPass(1) && !single_render_pass) {
+          if (handler->needsAdditionalRenderPass(1)) {
             need_additional.insert(handle);
             need_additional_render = true;
           }

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/interaction/interaction_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/interaction/interaction_tool.cpp
@@ -88,17 +88,16 @@ void InteractionTool::deactivate()
 
 void InteractionTool::updateFocus(const rviz_common::ViewportMouseEvent & event)
 {
+  rviz_common::interaction::M_Picked results;
   const auto selection_manager = context_->getSelectionManager();
-  // Select exactly 1 pixel
-  selection_manager->select(
+  // Pick exactly 1 pixel
+  selection_manager->pick(
     event.panel->getRenderWindow(),
     event.x,
     event.y,
     event.x + 1,
     event.y + 1,
-    rviz_common::interaction::SelectionManagerIface::SelectType::Replace);
-
-  const rviz_common::interaction::M_Picked results = selection_manager->getSelection();
+    results);
 
   last_selection_frame_count_ = context_->getFrameCount();
 

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_selection_manager.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_selection_manager.hpp
@@ -54,6 +54,7 @@ public:
   MOCK_METHOD5(highlight, void(rviz_rendering::RenderWindow *, int, int, int, int));
   MOCK_METHOD0(removeHighlight, void());
   MOCK_METHOD6(select, void(rviz_rendering::RenderWindow *, int, int, int, int, SelectType));
+  MOCK_METHOD6(pick, void(rviz_rendering::RenderWindow *, int, int, int, int, M_Picked &));
 
   MOCK_METHOD0(update, void());
   MOCK_CONST_METHOD0(getSelection, const M_Picked & ());


### PR DESCRIPTION
Follow-up from #423.

These changes remove an undesired selection of interactive markers when mousing over them. The selection was causing the markers to be highlighted with a bounding box.

* Expose selection manager's "pick" method
The method is useful for getting objects in a bounding box without actually selecting them.
The last argument, single_render_pass, was not being used and so it has been removed.
* Use pick method instead of select
This removes a visual bounding box (highlight) appearing over interactive markers.

---

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7962)](http://ci.ros2.org/job/ci_linux/7962/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3992)](http://ci.ros2.org/job/ci_linux-aarch64/3992/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6486)](http://ci.ros2.org/job/ci_osx/6486/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7818)](http://ci.ros2.org/job/ci_windows/7818/)