### PR TITLE
Fix map after upgrade

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
@@ -79,7 +79,7 @@ public:
   void setVisible(bool visible);
 
   RVIZ_DEFAULT_PLUGINS_PUBLIC
-  void resetTexture();
+  void resetOldTexture();
 
   RVIZ_DEFAULT_PLUGINS_PUBLIC
   void setRenderQueueGroup(uint8_t group);
@@ -110,6 +110,7 @@ private:
   Ogre::SceneNode * scene_node_;
   Ogre::ManualObject * manual_object_;
   Ogre::TexturePtr texture_;
+  Ogre::TexturePtr old_texture_;
   Ogre::MaterialPtr material_;
   size_t x_, y_, width_, height_;
 };

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -544,10 +544,10 @@ void MapDisplay::transformMap()
     scene_node_->setVisible(false);
   } else {
     setTransformOk();
-  }
 
-  scene_node_->setPosition(position);
-  scene_node_->setOrientation(orientation);
+    scene_node_->setPosition(position);
+    scene_node_->setOrientation(orientation);
+  }
 }
 
 void MapDisplay::fixedFrameChanged()

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -30,12 +30,11 @@
 
 #include "rviz_default_plugins/displays/map/map_display.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <OgreManualObject.h>
-#include <OgreMaterialManager.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 #include <OgreTextureManager.h>
@@ -44,10 +43,8 @@
 
 #include "rclcpp/time.hpp"
 
-#include "rviz_rendering/custom_parameter_indices.hpp"
 #include "rviz_rendering/material_manager.hpp"
 #include "rviz_rendering/objects/grid.hpp"
-#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/logging.hpp"
 #include "rviz_common/msg_conversions.hpp"
 #include "rviz_common/properties/enum_property.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -500,6 +500,7 @@ void MapDisplay::updateSwatches() const
     tex_unit->setTextureName(swatch->getTextureName());
     tex_unit->setTextureFiltering(Ogre::TFO_NONE);
     swatch->setVisible(true);
+    swatch->resetOldTexture();
   }
 }
 
@@ -515,7 +516,7 @@ void MapDisplay::updatePalette()
     } else {
       palette_tex_unit = pass->createTextureUnitState();
     }
-    palette_tex_unit->setTextureName(palette_textures_[palette_index]->getName());
+    palette_tex_unit->setTexture(palette_textures_[palette_index]);
     palette_tex_unit->setTextureFiltering(Ogre::TFO_NONE);
   }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
@@ -30,6 +30,7 @@
 
 #include "rviz_default_plugins/displays/map/swatch.hpp"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
@@ -141,6 +141,7 @@ void Swatch::updateData(const nav_msgs::msg::OccupancyGrid & map)
   Ogre::DataStreamPtr pixel_stream(new Ogre::MemoryDataStream(pixels.data(), pixels_size));
 
   resetTexture(pixel_stream);
+  resetOldTexture();
 }
 
 void Swatch::setVisible(bool visible)
@@ -150,11 +151,11 @@ void Swatch::setVisible(bool visible)
   }
 }
 
-void Swatch::resetTexture()
+void Swatch::resetOldTexture()
 {
-  if (texture_) {
-    Ogre::TextureManager::getSingleton().remove(texture_);
-    texture_.reset();
+  if (old_texture_) {
+    Ogre::TextureManager::getSingleton().remove(old_texture_);
+    old_texture_.reset();
   }
 }
 
@@ -190,10 +191,7 @@ std::string Swatch::getTextureName()
 
 void Swatch::resetTexture(Ogre::DataStreamPtr & pixel_stream)
 {
-  if (texture_) {
-    Ogre::TextureManager::getSingleton().remove(texture_);
-    texture_.reset();
-  }
+  old_texture_ = texture_;
 
   texture_ = Ogre::TextureManager::getSingleton().loadRawData(
     "MapTexture" + std::to_string(texture_count_++),

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
@@ -30,7 +30,6 @@
 
 #include "rviz_default_plugins/displays/map/swatch.hpp"
 
-#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -39,9 +38,9 @@
 #include <OgreRenderable.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreTextureManager.h>
-#include <OgreTechnique.h>
 #include <OgreSharedPtr.h>
+#include <OgreTechnique.h>
+#include <OgreTextureManager.h>
 
 #include "rviz_rendering/custom_parameter_indices.hpp"
 

--- a/rviz_rendering/ogre_media/materials/scripts/indexed_8bit_image.material
+++ b/rviz_rendering/ogre_media/materials/scripts/indexed_8bit_image.material
@@ -11,6 +11,14 @@ material rviz/Indexed8BitImage
         param_named eight_bit_image int 0
         param_named palette int 1
       }
+      texture_unit
+      {
+        texture no_image.png 2d
+      }
+      texture_unit
+      {
+        texture test_20x20.png 1d
+      }
     }
   }
 }


### PR DESCRIPTION
Fix #453 

This fixes the visual test after the latest upgrade and should therefore fix map rendering in general. Now, I only see one instance of 
```
[rviz_common:error] Vertex Program:rviz/glsl120/indexed_8bit_image.vert Fragment Program:rviz/glsl120/indexed_8bit_image.frag GLSL link result : active samplers with a different type refer to the same texture image unit, at /home/martin/gitRepos/ros/rviz_ws/src/rviz_rendering/src/rviz_rendering/ogre_logging.cpp:69
```
in the log, but I also see this way before the upgrade was done, so it's a different issue altogether. 