### PR TITLE
Set MapDisplay topic durability to transient local

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -115,6 +115,9 @@ MapDisplay::MapDisplay()
 
   transform_timestamp_property_ = new rviz_common::properties::BoolProperty("Use Timestamp", false,
       "Use map header timestamp when transforming", this, SLOT(transformMap()));
+
+  // TODO(jacobperron): Replace this with an RViz property
+  qos_profile.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 }
 
 MapDisplay::~MapDisplay()


### PR DESCRIPTION
Related to #400

I think it would be better if this were replaced with a property so that publishers with different durability still work. I've left a TODO in case we want to merge this as-is and revisit later. This quick fix is also more easily back-ported to Dashing and/or Crystal.