### PR TITLE
Fix the rviz_ogre_vendor packaging.

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -146,11 +146,6 @@ macro(build_ogre)
     list(APPEND extra_cmake_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
   endif()
 
-  # We need to patch some pragmas because the OgreVector cannot compile without warnings
-  if(WIN32)
-    set(patch_files patch.exe -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff &&)
-  endif()
-
   include(ExternalProject)
   ExternalProject_Add(ogre-v1.12.1
     URL https://github.com/OGRECave/ogre/archive/v1.12.1.zip
@@ -179,7 +174,8 @@ macro(build_ogre)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${patch_files}
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff
+    COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.1-prefix/src/ogre-v1.12.1/CMake/Packages/FindFreetype.cmake
   )
 

--- a/rviz_ogre_vendor/package.xml
+++ b/rviz_ogre_vendor/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>git</build_depend>
   <build_depend>pkg-config</build_depend>
 
   <build_depend>libfreetype6-dev</build_depend>

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -1834,3 +1834,18 @@ index 071039a86..efe8859fc 100644
 +
  
  #endif 
+diff -urp ogre-1.12.1.orig/PlugIns/OctreeZone/CMakeLists.txt ogre-1.12.1/PlugIns/OctreeZone/CMakeLists.txt
+--- ogre-1.12.1.orig/PlugIns/OctreeZone/CMakeLists.txt	2019-06-24 23:04:20.000000000 +0000
++++ ogre-1.12.1/PlugIns/OctreeZone/CMakeLists.txt	2019-10-04 16:58:03.669588969 +0000
+@@ -23,6 +23,11 @@ generate_export_header(Plugin_OctreeZone
+     EXPORT_MACRO_NAME _OgreOctreeZonePluginExport
+     EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreOctreeZonePrerequisites.h)
+ 
++if (UNIX)
++  set_property(TARGET Plugin_OctreeZone APPEND PROPERTY
++    INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}/OGRE)
++endif ()
++
+ ogre_config_framework(Plugin_OctreeZone)
+ 
+ ogre_config_plugin(Plugin_OctreeZone)


### PR DESCRIPTION
We need to:

1.  Apply the patch in all situations; it's fine because it has
compile-time guards for WIN32
2.  Add to the patch so that we put the correct RUNPATH in place
so OctreeZone can find its dependencies.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the packaging problem at http://build.ros2.org/view/Ebin_uB64/job/Ebin_uB64__rviz_ogre_vendor__ubuntu_bionic_amd64__binary/2/ (at least, it does in my local testing).