### PR TITLE
Switch back to patch instead of git apply.

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -173,7 +173,7 @@ macro(build_ogre)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch${CMAKE_EXECUTABLE_SUFFIX} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff
     COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.1-prefix/src/ogre-v1.12.1/CMake/Packages/FindFreetype.cmake
   )

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -1808,9 +1808,9 @@ index 071039a86..efe8859fc 100644
 +
  
  #endif 
-diff -urp ogre-1.12.1.orig/PlugIns/OctreeZone/CMakeLists.txt ogre-1.12.1/PlugIns/OctreeZone/CMakeLists.txt
---- ogre-1.12.1.orig/PlugIns/OctreeZone/CMakeLists.txt	2019-06-24 23:04:20.000000000 +0000
-+++ ogre-1.12.1/PlugIns/OctreeZone/CMakeLists.txt	2019-10-04 16:58:03.669588969 +0000
+diff --git a/PlugIns/OctreeZone/CMakeLists.txt b/PlugIns/OctreeZone/CMakeLists.txt
+--- a/PlugIns/OctreeZone/CMakeLists.txt	2019-06-24 23:04:20.000000000 +0000
++++ b/PlugIns/OctreeZone/CMakeLists.txt	2019-10-04 16:58:03.669588969 +0000
 @@ -23,6 +23,11 @@ generate_export_header(Plugin_OctreeZone
      EXPORT_MACRO_NAME _OgreOctreeZonePluginExport
      EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreOctreeZonePrerequisites.h)
@@ -1823,3 +1823,27 @@ diff -urp ogre-1.12.1.orig/PlugIns/OctreeZone/CMakeLists.txt ogre-1.12.1/PlugIns
  ogre_config_framework(Plugin_OctreeZone)
 
  ogre_config_plugin(Plugin_OctreeZone)
+diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
+--- a/OgreMain/include/OgreTimer.h	2019-06-24 16:04:20.000000000 -0700
++++ b/OgreMain/include/OgreTimer.h	2019-10-10 12:33:07.243621900 -0700
+@@ -28,6 +28,10 @@ THE SOFTWARE.
+ 
+ #ifndef __OGRE_TIMER_H__
+ #define __OGRE_TIMER_H__
++#ifdef _WIN32
++#pragma warning(push)
++#pragma warning(disable:4251)
++#endif
+ 
+ #include "OgrePrerequisites.h"
+ #include <chrono>
+@@ -59,4 +63,9 @@ namespace Ogre
+         uint64_t getMicrosecondsCPU();
+     };
+ }
++
++#ifdef _WIN32
++#pragma warning(pop)
++#endif
++
+ #endif

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -1827,13 +1827,14 @@ diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
 --- a/OgreMain/include/OgreTimer.h	2019-06-24 16:04:20.000000000 -0700
 +++ b/OgreMain/include/OgreTimer.h	2019-10-10 12:33:07.243621900 -0700
 @@ -28,6 +28,10 @@ THE SOFTWARE.
+
  #ifndef __OGRE_TIMER_H__
  #define __OGRE_TIMER_H__
-
 +#ifdef _WIN32
 +#pragma warning(push)
 +#pragma warning(disable:4251)
 +#endif
+
  #include "OgrePrerequisites.h"
  #include <chrono>
 

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -47,32 +47,6 @@ index 5b9cababd..dda7a57b3 100644
 +#endif
 +
  #endif
-diff --git a/OgreMain/include/Ogre.h b/OgreMain/include/Ogre.h
-index 515178aa0..5ad6463dd 100644
---- a/OgreMain/include/Ogre.h
-+++ b/OgreMain/include/Ogre.h
-@@ -27,6 +27,11 @@ THE SOFTWARE.
- */
- #ifndef _Ogre_H__
- #define _Ogre_H__
-+#ifdef _WIN32
-+#pragma warning(push)
-+#pragma warning(disable:4251)
-+#endif
-+
- // This file includes all the other files which you will need to build a client application
- #include "OgrePrerequisites.h"
- 
-@@ -130,5 +135,9 @@ THE SOFTWARE.
- #include "OgreViewport.h"
- #include "OgreComponents.h"
- // .... more to come
-+#ifdef _WIN32
-+#pragma warning(pop)
-+#endif
-+
- 
- #endif
 diff --git a/OgreMain/include/OgreAnimable.h b/OgreMain/include/OgreAnimable.h
 index 755e76d00..38c86cfea 100644
 --- a/OgreMain/include/OgreAnimable.h
@@ -1840,12 +1814,12 @@ diff -urp ogre-1.12.1.orig/PlugIns/OctreeZone/CMakeLists.txt ogre-1.12.1/PlugIns
 @@ -23,6 +23,11 @@ generate_export_header(Plugin_OctreeZone
      EXPORT_MACRO_NAME _OgreOctreeZonePluginExport
      EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreOctreeZonePrerequisites.h)
- 
+
 +if (UNIX)
 +  set_property(TARGET Plugin_OctreeZone APPEND PROPERTY
 +    INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}/OGRE)
 +endif ()
 +
  ogre_config_framework(Plugin_OctreeZone)
- 
+
  ogre_config_plugin(Plugin_OctreeZone)

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -1827,24 +1827,22 @@ diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
 --- a/OgreMain/include/OgreTimer.h	2019-06-24 16:04:20.000000000 -0700
 +++ b/OgreMain/include/OgreTimer.h	2019-10-10 12:33:07.243621900 -0700
 @@ -28,6 +28,10 @@ THE SOFTWARE.
-
+ 
  #ifndef __OGRE_TIMER_H__
  #define __OGRE_TIMER_H__
 +#ifdef _WIN32
 +#pragma warning(push)
 +#pragma warning(disable:4251)
 +#endif
-
+ 
  #include "OgrePrerequisites.h"
  #include <chrono>
-
-@@ -59,4 +63,9 @@ namespace Ogre
+@@ -59,4 +63,7 @@ namespace Ogre
          uint64_t getMicrosecondsCPU();
      };
  }
-+
 +#ifdef _WIN32
 +#pragma warning(pop)
 +#endif
-+
  #endif
+

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -1827,16 +1827,16 @@ diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
 --- a/OgreMain/include/OgreTimer.h	2019-06-24 16:04:20.000000000 -0700
 +++ b/OgreMain/include/OgreTimer.h	2019-10-10 12:33:07.243621900 -0700
 @@ -28,6 +28,10 @@ THE SOFTWARE.
- 
  #ifndef __OGRE_TIMER_H__
  #define __OGRE_TIMER_H__
+
 +#ifdef _WIN32
 +#pragma warning(push)
 +#pragma warning(disable:4251)
 +#endif
- 
  #include "OgrePrerequisites.h"
  #include <chrono>
+
 @@ -59,4 +63,9 @@ namespace Ogre
          uint64_t getMicrosecondsCPU();
      };


### PR DESCRIPTION
There were two problems with the fix for the ogre vendor patch:

1.  The downloaded ogre sources is not a git repository
2.  The fix used Unix line endings instead of DOS ones

It seems that newer versions of git do not allow you to call
'git apply' on a directory that is not a git repository.  Worse,
'git apply' silently fails to apply the patch in that case
(actually, in all cases).  So switch back to using patch, which
does properly throw errors and does properly work in a non-git
repository.  Patch fails to apply mixed Unix-style and DOS-style
line endings, so also fix the patch up to use only DOS.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Reviewers note: the final hunk of change to `pragma-patch.diff` seems like a no-op, but it subtly changes things so that we use CR/LF at the end of lines so Windows is happier with it.

This should fix all of the compile warnings we are getting from the Windows nightly jobs, like: https://ci.ros2.org/view/nightly/job/nightly_win_deb/1401/warnings43Result/