### PR TITLE
Use clock from context in markers

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -70,16 +70,6 @@ void MarkerCommon::initialize(rviz_common::DisplayContext * context, Ogre::Scene
   namespace_config_enabled_state_.clear();
 
   marker_factory_->initialize(this, context_, scene_node_);
-
-  // TODO(greimela): Revisit after MessageFilter is available in ROS2
-//  tf_filter_ = new tf::MessageFilter<visualization_msgs::Marker>( *context_->getTFClient(),
-//    fixed_frame_.toStdString(),
-//    queue_size_property_->getInt(),
-//    update_nh_ );
-//
-//  tf_filter_->connectInput(sub_);
-//  tf_filter_->registerCallback(boost::bind(&MarkerCommon::incomingMarker, this, _1));
-//  tf_filter_->registerFailureCallback(boost::bind(&MarkerCommon::failedMarker, this, _1, _2));
 }
 
 void MarkerCommon::load(const rviz_common::Config & config)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -335,7 +335,7 @@ void MarkerCommon::removeExpiredMarkers()
       markers_to_delete.push_back(marker);
     }
   }
-  for(const auto & marker : markers_to_delete) {
+  for (const auto & marker : markers_to_delete) {
     deleteMarker(marker->getID());
   }
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -339,16 +339,14 @@ void MarkerCommon::processNewMessages(const MarkerCommon::V_MarkerMessage & loca
 
 void MarkerCommon::removeExpiredMarkers()
 {
-  auto marker_it = markers_with_expiration_.begin();
-  auto end = markers_with_expiration_.end();
-  for (; marker_it != end; ) {
-    MarkerBasePtr marker = *marker_it;
+  std::vector<MarkerBasePtr> markers_to_delete;
+  for (const auto & marker : markers_with_expiration_) {
     if (marker->expired()) {
-      ++marker_it;
-      deleteMarker(marker->getID());
-    } else {
-      ++marker_it;
+      markers_to_delete.push_back(marker);
     }
+  }
+  for(const auto & marker : markers_to_delete) {
+    deleteMarker(marker->getID());
   }
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_base.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_base.cpp
@@ -81,7 +81,7 @@ void MarkerBase::setMessage(const MarkerConstSharedPtr & message)
   MarkerConstSharedPtr old = message_;
   message_ = message;
 
-  expiration_ = rclcpp::Clock().now() + message->lifetime;
+  expiration_ = context_->getClock()->now() + message->lifetime;
 
   onNewMessage(old, message);
 }
@@ -94,7 +94,7 @@ void MarkerBase::updateFrameLocked()
 
 bool MarkerBase::expired()
 {
-  return rclcpp::Clock().now() >= expiration_;
+  return context_->getClock()->now() >= expiration_;
 }
 
 bool MarkerBase::transform(


### PR DESCRIPTION
Markers currently use their own clock to set marker lifetime. This is definitely unintended as everything within RViz should use the same clock. 

In addition, the deletion method for makers with expired lifetime looks suspicious, so I refactored it to work better. 

This might or might not be enough to fix #464, I couldn't test it right now.