### PR TITLE
Set clock type if Marker frame_locked is true

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_base.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_base.cpp
@@ -105,7 +105,7 @@ bool MarkerBase::transform(
 {
   rclcpp::Time stamp = message->header.stamp;
   if (message->frame_locked) {
-    stamp = rclcpp::Time();
+    stamp = rclcpp::Time(0, 0, context_->getClock()->get_clock_type());
   }
 
   if (!context_->getFrameManager()->transform(


### PR DESCRIPTION
Fixes #479

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8729)](http://ci.ros2.org/job/ci_linux/8729/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4560)](http://ci.ros2.org/job/ci_linux-aarch64/4560/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7131)](http://ci.ros2.org/job/ci_osx/7131/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8644)](http://ci.ros2.org/job/ci_windows/8644/)