### PR TITLE
Fix map display for moving TF frame

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -573,10 +573,11 @@ void MapDisplay::transformMap()
 
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
-  if (!context_->getFrameManager()->transform(frame_, transform_time, current_map_.info.origin,
-    position, orientation) &&
-    !context_->getFrameManager()->transform(frame_, context_->getClock()->now(),
-    current_map_.info.origin, position, orientation))
+  if (!context_->getFrameManager()->transform(
+      frame_, transform_time, current_map_.info.origin, position, orientation) &&
+    !context_->getFrameManager()->transform(
+      frame_, rclcpp::Time(0, 0, context_->getClock()->get_clock_type()),
+      current_map_.info.origin, position, orientation))
   {
     setMissingTransformToFixedFrame(frame_);
     scene_node_->setVisible(false);


### PR DESCRIPTION
Instead of the current time, use Time(0) to get the latest available transform as a fallback.
This is the same logic that is applied in RViz from ROS 1.

Resolves #332

Although we are using TF message_filters to deliver the map to the display, the display itself is doing a transformation:

https://github.com/ros2/rviz/blob/045227a9fc251ab9e5af763bddc1f203aff6feac/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp#L576-L579

And even though it is using the current time (just a few lines before), it is off by less than a second causing the extrapolation exception. I noticed the ROS 1 implementation is slightly different, defaulting to the latest available transform by passing Time(0) (the related PR is https://github.com/ros-visualization/rviz/pull/1066):

      if (!context_->getFrameManager()->transform(frame_, transform_time, current_map_.info.origin, position, orientation) &&
          !context_->getFrameManager()->transform(frame_, ros::Time(0), current_map_.info.origin, position, orientation))

https://github.com/ayrton04/rviz/blob/8f482f494ee4031ed04b3065a9755710b61176bf/src/rviz/default_plugin/map_display.cpp#L719-L720
