### PR TITLE
Remove uncessary call to render scene

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
@@ -247,6 +247,7 @@ Dimensions SelectionRenderer::getRenderDimensions(
 void SelectionRenderer::renderToTexture(
   Ogre::RenderTexture * render_texture, Ogre::Viewport * window_viewport)
 {
+  (void)window_viewport;
   // update & force ogre to render the scene
   Ogre::MaterialManager::getSingleton().addListener(this);
   render_texture->update();

--- a/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
@@ -249,21 +249,7 @@ void SelectionRenderer::renderToTexture(
 {
   // update & force ogre to render the scene
   Ogre::MaterialManager::getSingleton().addListener(this);
-
   render_texture->update();
-
-  // For some reason we need to pretend to render the main window in
-  // order to get the picking render to show up in the pixelbox below.
-  // If we don't do this, it will show up there the *next* time we
-  // pick something, but not this time.  This object as a
-  // render queue listener tells the scene manager to skip every
-  // render step, so nothing actually gets drawn.
-  //
-  // TODO(unknown): find out what part of _renderScene() actually makes this work.
-  scene_manager_->addRenderQueueListener(this);
-  scene_manager_->_renderScene(window_viewport->getCamera(), window_viewport, false);
-  scene_manager_->removeRenderQueueListener(this);
-
   Ogre::MaterialManager::getSingleton().removeListener(this);
 }
 


### PR DESCRIPTION
Fixes #486.

At least the call seems unncessary. I haven't noticed any changes in selection render behavior
with or without the change. But, making the call causes an assertion to fail within Ogre when
a selection tool is moused-over an image display (see #486 for details).

The hack was originally added in

https://github.com/ros-visualization/rviz/commit/7feb02d6adf2d3a02343fd43b4b386f515591ab4

but it's not clear if the original buggy behavior still exists without it. There's been a lot
of refactoring since then. I've played around with selecting things and haven't noticed any
flickering or discoloration after removing the hack.