### PR TITLE
change default goal to goal_pose and not just in default rviz

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/tools/goal_pose/goal_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/goal_pose/goal_tool.cpp
@@ -49,7 +49,7 @@ GoalTool::GoalTool()
 {
   shortcut_key_ = 'g';
 
-  topic_property_ = new rviz_common::properties::StringProperty("Topic", "goal",
+  topic_property_ = new rviz_common::properties::StringProperty("Topic", "goal_pose",
       "The topic on which to publish goals.",
       getPropertyContainer(), SLOT(updateTopic()), this);
 


### PR DESCRIPTION
#455 updated the tool name, registration, default rviz files and documentation.

However the migration guide for Eloquent isn't technically correct (https://index.ros.org/doc/ros2/Releases/Release-Eloquent-Elusor/#rviz). The tool name changed, true, and the topic was changed for the **default.rviz** file. This is also where `/move_base_simple/goal` was defined from `goal`. There never was `/move_base_simple/goal` in the rviz tool file. 

If this is what we're going to say in the migration guide, we should change the actual default hardcoded in the tool to be `goal_pose`, rather than just a configuration change in the `rviz` file. 

I tried to think of a way to explain this better for the migration guide and decided that its just easier to align with it. If that's what people walked away thinking that PR did exactly, I should follow that.