### PR TITLE
Solve compiler warning in Focal

### DIFF
--- a/rviz_common/include/rviz_common/config.hpp
+++ b/rviz_common/include/rviz_common/config.hpp
@@ -139,6 +139,9 @@ public:
   /// The converting constructor, makes a Value type Config object with the given value.
   explicit Config(QVariant value);
 
+  Config &
+  operator=(const Config & source);
+
   /// Make this object a deep copy of the source.
   void
   copy(const Config & source);

--- a/rviz_common/src/rviz_common/config.cpp
+++ b/rviz_common/src/rviz_common/config.cpp
@@ -119,6 +119,13 @@ Config::Config(NodePtr node)
 : node_(node)
 {}
 
+Config &
+Config::operator=(const Config & source)
+{
+  node_ = source.node_;
+  return *this;
+}
+
 void Config::copy(const Config & source)  // NOLINT linter wants #include <algorithm>
 {
   if (!source.isValid()) {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request!

Please shortly explain your contribution, and if fixing an issue from the tracker, add a link to the issue.
Note, that we don't accept ABI breaking changes for released versions. Such changes should target the upcoming release branch.
Be sure to go over each item in the list below before submitting your pull request. -->

### Description

Fixes warning in Focal: https://ci.ros2.org/job/ci_linux/9175/warnings23Result/package.-1204707637/

### Checklist

- [ ] If you are addressing rendering issues, please provide:
  - [ ] Images of both, broken and fixed renderings.
  - [ ] Source code to reproduce the issue, e.g. a `YAML` or `rosbag` file with a `MarkerArray` msg.
- [ ] If you are changing GUI, please include screenshots showing how things looked *before* and *after*.
- [ ] Choose the proper target branch: latest release branch, for non-ABI-breaking changes, *future* release branch otherwise.
      Due to the lack of active maintainers, we cannot provide support for older release branches anymore.
- [ ] Did you change how RViz works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/rviz)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-visualization/rviz/pulls) to support the maintainers of RViz. Refer to the [RViz Wiki](https://github.com/ros-visualization/rviz/wiki/Maintainer-Guide#reviewing-pull-requests) for reviewing guidelines.
