### PR TITLE
Switch to CMake Patch module

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(rviz_ogre_vendor)
 
@@ -150,6 +150,7 @@ macro(build_ogre)
     list(APPEND extra_cmake_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
   endif()
 
+  find_package(Patch REQUIRED)
   include(ExternalProject)
   ExternalProject_Add(ogre-v1.12.1
     URL https://github.com/OGRECave/ogre/archive/v1.12.1.zip
@@ -177,7 +178,7 @@ macro(build_ogre)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> patch${CMAKE_EXECUTABLE_SUFFIX} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff
     COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.1-prefix/src/ogre-v1.12.1/CMake/Packages/FindFreetype.cmake
   )


### PR DESCRIPTION
As of CMake 3.10, there is a `FindPatch.cmake` module built in.
Note that, on Windows, this prefers `patch` distributed with Git instead of via the "GNU Patch for Windows" Chocolatey package, so admin privilege is not required to build this package anymore.