### PR TITLE
Update deprecated enums in rviz_common

### DIFF
--- a/rviz_common/src/rviz_common/panel_dock_widget.cpp
+++ b/rviz_common/src/rviz_common/panel_dock_widget.cpp
@@ -47,7 +47,7 @@ PanelDockWidget::PanelDockWidget(const QString & name)
   QWidget * title_bar = new QWidget(this);
 
   QPalette pal(palette());
-  pal.setColor(QPalette::Background, QColor(200, 200, 200));
+  pal.setColor(QPalette::Window, QColor(200, 200, 200));
   title_bar->setAutoFillBackground(true);
   title_bar->setPalette(pal);
   title_bar->setContentsMargins(0, 0, 0, 0);

--- a/rviz_common/src/rviz_common/properties/property.cpp
+++ b/rviz_common/src/rviz_common/properties/property.cpp
@@ -251,7 +251,7 @@ void Property::setParent(Property * new_parent)
 
 QVariant Property::getViewData(int column, int role) const
 {
-  if (role == Qt::TextColorRole &&
+  if (role == Qt::ForegroundRole &&
     ( parent_ && parent_->getDisableChildren() ) )
   {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -147,7 +147,7 @@ QString ViewController::formatClassId(const QString & class_id)
 
 QVariant ViewController::getViewData(int column, int role) const
 {
-  if (role == Qt::TextColorRole) {
+  if (role == Qt::ForegroundRole) {
     return QVariant();
   }
 


### PR DESCRIPTION
Several uses of enum values in rviz_common use long-deprecated values (back to 5.9). Compiling with 5.14.1 now produce deprecation warnings. These values have been mapped for awhile to the replacements I dropped in here, so this won't affect functionality.

`QPalette::Background` -> `QPalette::Window`
https://doc.qt.io/qt-5/qpalette.html#ColorRole-enum
`Qt::TextColorRole` -> `Qt::ForegroundRole`
https://doc.qt.io/qt-5/qt.html#ItemDataRole-enum

Addresses issue  #508

Build with warnings:
https://ci.ros2.org/job/ci_windows-container/123/warnings43Result/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9393)](http://ci.ros2.org/job/ci_linux/9393/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5072)](http://ci.ros2.org/job/ci_linux-aarch64/5072/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7687)](http://ci.ros2.org/job/ci_osx/7687/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9311)](http://ci.ros2.org/job/ci_windows/9311/)
* Windows-container [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows-container&build=174)](http://ci.ros2.org/job/ci_windows-container/174/)