### PR TITLE
[eloquent backport] Remove uncessary call to render scene (#490)

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
@@ -247,23 +247,10 @@ Dimensions SelectionRenderer::getRenderDimensions(
 void SelectionRenderer::renderToTexture(
   Ogre::RenderTexture * render_texture, Ogre::Viewport * window_viewport)
 {
+  (void)window_viewport;
   // update & force ogre to render the scene
   Ogre::MaterialManager::getSingleton().addListener(this);
-
   render_texture->update();
-
-  // For some reason we need to pretend to render the main window in
-  // order to get the picking render to show up in the pixelbox below.
-  // If we don't do this, it will show up there the *next* time we
-  // pick something, but not this time.  This object as a
-  // render queue listener tells the scene manager to skip every
-  // render step, so nothing actually gets drawn.
-  //
-  // TODO(unknown): find out what part of _renderScene() actually makes this work.
-  scene_manager_->addRenderQueueListener(this);
-  scene_manager_->_renderScene(window_viewport->getCamera(), window_viewport, false);
-  scene_manager_->removeRenderQueueListener(this);
-
   Ogre::MaterialManager::getSingleton().removeListener(this);
 }
 


### PR DESCRIPTION
Backport #490 to Eloquent

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9817)](http://ci.ros2.org/job/ci_linux/9817/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5442)](http://ci.ros2.org/job/ci_linux-aarch64/5442/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7985)](http://ci.ros2.org/job/ci_osx/7985/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9680)](http://ci.ros2.org/job/ci_windows/9680/)