### PR TITLE
[Eloquent backport]: Allow the MapDisplay "Update Topic" to be changed. (#517)

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -77,12 +77,11 @@ MapDisplay::MapDisplay()
   update_topic_property_ = new rviz_common::properties::RosTopicProperty(
     "Update Topic", "",
     "", "Topic where updates to this map display are received. "
-    "Currently, this topic is read-only and will automatically be determined by the map topic. "
-    "If the map is received on 'map_topic', the display assumes to receive updates on "
-    "'map_topic_updates'.", this);
-  // Set the property to read only for now. Since it is not connected to any slot,
-  // we don't want to update it.
-  update_topic_property_->setReadOnly(true);
+    "This topic is automatically determined by the map topic. "
+    "If the map is received on 'map_topic', the display assumes updates are received on "
+    "'map_topic_updates'."
+    "This can be overridden in the UI by clicking on the topic and setting the desired topic.",
+    this, SLOT(updateMapUpdateTopic()));
 
   update_profile_property_ = new rviz_common::properties::QosProfileProperty(
     update_topic_property_, update_profile_);


### PR DESCRIPTION
The major reason for this is so that the "Update Topic"
(and more importantly the QoS profile) is saved when clicking
"Save Config" in RViz2.  The more minor reason is that a user
*might* want to use a different topic for this.  We still
auto-populate this field with <topic_name>_updates by default,
but the user can now override it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>