### PR TITLE
Use RViz node clock in tools

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/tools/goal_pose/goal_tool.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/tools/goal_pose/goal_tool.hpp
@@ -73,6 +73,7 @@ private Q_SLOTS:
 
 private:
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr publisher_;
+  rclcpp::Clock::SharedPtr clock_;
 
   rviz_common::properties::StringProperty * topic_property_;
   rviz_common::properties::QosProfileProperty * qos_profile_property_;

--- a/rviz_default_plugins/include/rviz_default_plugins/tools/point/point_tool.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/tools/point/point_tool.hpp
@@ -85,6 +85,7 @@ protected:
   QCursor std_cursor_;
   QCursor hit_cursor_;
   rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr publisher_;
+  rclcpp::Clock::SharedPtr clock_;
 
   rviz_common::properties::StringProperty * topic_property_;
   rviz_common::properties::BoolProperty * auto_deactivate_property_;

--- a/rviz_default_plugins/include/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.hpp
@@ -73,6 +73,7 @@ private Q_SLOTS:
 
 private:
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr publisher_;
+  rclcpp::Clock::SharedPtr clock_;
 
   rviz_common::properties::StringProperty * topic_property_;
   rviz_common::properties::QosProfileProperty * qos_profile_property_;

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/goal_pose/goal_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/goal_pose/goal_tool.cpp
@@ -71,10 +71,13 @@ void GoalTool::onInitialize()
 
 void GoalTool::updateTopic()
 {
+  rclcpp::Node::SharedPtr raw_node =
+    context_->getRosNodeAbstraction().lock()->get_raw_node();
   // TODO(anhosi, wjwwood): replace with abstraction for publishers once available
-  publisher_ = context_->getRosNodeAbstraction().lock()->get_raw_node()->
+  publisher_ = raw_node->
     template create_publisher<geometry_msgs::msg::PoseStamped>(
     topic_property_->getStdString(), qos_profile_);
+  clock_ = raw_node->get_clock();
 }
 
 void GoalTool::onPoseSet(double x, double y, double theta)
@@ -82,7 +85,7 @@ void GoalTool::onPoseSet(double x, double y, double theta)
   std::string fixed_frame = context_->getFixedFrame().toStdString();
 
   geometry_msgs::msg::PoseStamped goal;
-  goal.header.stamp = rclcpp::Clock().now();
+  goal.header.stamp = clock_->now();
   goal.header.frame_id = fixed_frame;
 
   goal.pose.position.x = x;

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/point/point_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/point/point_tool.cpp
@@ -86,10 +86,13 @@ void PointTool::deactivate() {}
 
 void PointTool::updateTopic()
 {
+  rclcpp::Node::SharedPtr raw_node =
+    context_->getRosNodeAbstraction().lock()->get_raw_node();
   // TODO(anhosi, wjwwood): replace with abstraction for publishers once available
-  publisher_ = context_->getRosNodeAbstraction().lock()->get_raw_node()->
+  publisher_ = raw_node->
     template create_publisher<geometry_msgs::msg::PointStamped>(
     topic_property_->getStdString(), qos_profile_);
+  clock_ = raw_node->get_clock();
 }
 
 void PointTool::updateAutoDeactivate() {}
@@ -134,7 +137,7 @@ void PointTool::publishPosition(const Ogre::Vector3 & position) const
   geometry_msgs::msg::PointStamped point_stamped;
   point_stamped.point = point;
   point_stamped.header.frame_id = context_->getFixedFrame().toStdString();
-  point_stamped.header.stamp = rclcpp::Clock().now();
+  point_stamped.header.stamp = clock_->now();
   publisher_->publish(point_stamped);
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.cpp
@@ -73,9 +73,12 @@ void InitialPoseTool::onInitialize()
 void InitialPoseTool::updateTopic()
 {
   // TODO(anhosi, wjwwood): replace with abstraction for publishers once available
-  publisher_ = context_->getRosNodeAbstraction().lock()->get_raw_node()->
+  rclcpp::Node::SharedPtr raw_node =
+    context_->getRosNodeAbstraction().lock()->get_raw_node();
+  publisher_ = raw_node->
     template create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     topic_property_->getStdString(), qos_profile_);
+  clock_ = raw_node->get_clock();
 }
 
 void InitialPoseTool::onPoseSet(double x, double y, double theta)
@@ -84,7 +87,7 @@ void InitialPoseTool::onPoseSet(double x, double y, double theta)
 
   geometry_msgs::msg::PoseWithCovarianceStamped pose;
   pose.header.frame_id = fixed_frame;
-  pose.header.stamp = rclcpp::Clock().now();
+  pose.header.stamp = clock_->now();
 
   pose.pose.pose.position.x = x;
   pose.pose.pose.position.y = y;


### PR DESCRIPTION
Precisely what the title says. Without this patch, a default clock (i.e. a clock hooked up to system time) is always used, not abiding to `use_sim_time`.

CI up to `rviz_default_plugins`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9647)](http://ci.ros2.org/job/ci_linux/9647/)