### PR TITLE
add missing export of urdf

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -288,6 +288,7 @@ ament_export_dependencies(
   tf2
   tf2_geometry_msgs
   tf2_ros
+  urdf
   yaml_cpp_vendor
 )
 ament_export_include_directories(include)


### PR DESCRIPTION
Related to ros2/ros2#904.

Usage https://github.com/ros2/rviz/blob/41d9b2bb708ccab61d34a83b03e18ac9540fe1d0/rviz_common/CMakeLists.txt#L271