### PR TITLE
Remove rviz_default_plugins dependency on TinyXML

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -69,8 +69,6 @@ find_package(resource_retriever REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(tinyxml_vendor REQUIRED)
-find_package(TinyXML REQUIRED)  # provided by tinyxml_vendor
 find_package(urdf REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
@@ -239,7 +237,6 @@ target_include_directories(rviz_default_plugins PUBLIC
   ${OGRE_INCLUDE_DIRS}
   ${Qt5Widgets_INCLUDE_DIRS}
   ${resource_retriever_INCLUDE_DIRS}
-  ${TinyXML_INCLUDE_DIRS}
   ${urdf_INCLUDE_DIRS}
   ${visualization_msgs_INCLUDE_DIRS}
 )

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -37,8 +37,6 @@
 
 #include <QFile>  // NOLINT cpplint cannot handle include order here
 
-// TODO(Martin-Idel-SI): Upgrade to tinyxml2 once supported by urdf
-#include <tinyxml.h>  // NOLINT cpplint cannot handle include order here
 #include "urdf/model.h"
 
 #include "tf2_ros/transform_listener.h"
@@ -250,16 +248,8 @@ void RobotModelDisplay::load_urdf_from_string(const std::string & robot_descript
 
 void RobotModelDisplay::display_urdf_content()
 {
-  TiXmlDocument doc;
-  doc.Parse(robot_description_.c_str());
-  if (!doc.RootElement() ) {
-    clear();
-    setStatus(StatusProperty::Error, "URDF", "URDF failed XML parse");
-    return;
-  }
-
   urdf::Model descr;
-  if (!descr.initXml(doc.RootElement())) {
+  if (!descr.initString(robot_description_)) {
     clear();
     setStatus(StatusProperty::Error, "URDF", "URDF failed Model parse");
     return;


### PR DESCRIPTION
This clears the way for urdf to switch to TinyXML2
Note that internally, urdf was converting the passed XML to a string and reparsing it in the implementation of `urdf::model::initXml`