### PR TITLE
Reduce compilation memory

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -327,11 +327,6 @@ if(BUILD_TESTING)
   )
   ament_include_directories_order(TEST_INCLUDE_DIRS ${TEST_INCLUDE_DIRS})
 
-  set(TEST_LINK_LIBRARIES
-    rviz_default_plugins
-    Qt5::Widgets
-  )
-
   set(TEST_TARGET_DEPENDENCIES
     map_msgs
     nav_msgs
@@ -341,10 +336,26 @@ if(BUILD_TESTING)
     visualization_msgs
   )
 
+  # display_test_fixture.cpp is a piece of code that is used by every test.
+  # Instead of recompiling it for every test, just compile it once as a library
+  # and reuse it.  Note that we need to call ament_find_gmock() by hand here to
+  # find GMOCK_INCLUDE_DIRS so we can compile this file.
+  ament_find_gmock()
+  add_library(display_test_fixture SHARED
+    test/rviz_default_plugins/displays/display_test_fixture.cpp
+  )
+  target_include_directories(display_test_fixture PRIVATE ${GMOCK_INCLUDE_DIRS} ${TEST_INCLUDE_DIRS})
+  ament_target_dependencies(display_test_fixture ${TEST_TARGET_DEPENDENCIES} rviz_rendering rviz_common)
+
+  set(TEST_LINK_LIBRARIES
+    display_test_fixture
+    rviz_default_plugins
+    Qt5::Widgets
+  )
+
   ament_add_gmock(fps_view_controller_test
     test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET fps_view_controller_test)
@@ -355,7 +366,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(frame_info_test
     test/rviz_default_plugins/displays/tf/frame_info_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_info_test)
@@ -366,7 +376,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(grid_cells_display_test
     test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET grid_cells_display_test)
     target_include_directories(grid_cells_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -392,7 +401,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker/markers/text_view_facing_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/triangle_list_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/displays/marker/marker_messages.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
@@ -405,7 +413,6 @@ if(BUILD_TESTING)
   ament_add_gmock(marker_common_test
     test/rviz_default_plugins/displays/marker/marker_common_test.cpp
     test/rviz_default_plugins/displays/marker/marker_messages.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_common_test)
@@ -416,7 +423,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(map_display_test
     test/rviz_default_plugins/displays/map/map_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET map_display_test)
@@ -427,7 +433,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(measure_tool_test
     test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET measure_tool_test)
@@ -438,7 +443,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(odometry_display_test
     test/rviz_default_plugins/displays/odometry/odometry_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_display_test)
@@ -459,7 +463,6 @@ if(BUILD_TESTING)
   ament_add_gmock(orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET orbit_view_controller_test)
@@ -471,7 +474,6 @@ if(BUILD_TESTING)
   ament_add_gmock(ortho_view_controller_test
     test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ortho_view_controller_test)
@@ -491,7 +493,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(path_display_test
     test/rviz_default_plugins/displays/path/path_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET path_display_test)
@@ -515,7 +516,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/pointcloud_messages.hpp
     test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_common_test)
@@ -526,7 +526,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud_scalar_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_scalar_display_test)
     target_include_directories(point_cloud_scalar_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -552,7 +551,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_display_test
     test/rviz_default_plugins/displays/point/point_stamped_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_display_test)
@@ -563,7 +561,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(pose_array_display_test
     test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_array_display_test)
@@ -574,7 +571,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(pose_tool_test
     test/rviz_default_plugins/tools/pose/pose_tool_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_tool_test)
@@ -585,7 +581,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(range_display_test
     test/rviz_default_plugins/displays/range/range_display_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET range_display_test)
@@ -624,7 +619,6 @@ if(BUILD_TESTING)
   ament_add_gmock(xy_orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection_helper.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET xy_orbit_view_controller_test)
@@ -644,7 +638,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(transformer_guard_test
     test/rviz_default_plugins/transformation/transformer_guard_test.cpp
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET transformer_guard_test)
     target_include_directories(transformer_guard_test PUBLIC ${TEST_INCLUDE_DIRS})

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -74,7 +74,6 @@ find_package(TinyXML REQUIRED)  # provided by tinyxml_vendor
 find_package(urdf REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
-# These need to be added in the add_library() call so AUTOMOC detects them.
 set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/displays/axes/axes_display.hpp
   include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -327,19 +326,16 @@ if(BUILD_TESTING)
     visualization_msgs
   )
 
-  # None of the tests are Qt files, so we can save a bit of time by not letting
-  # AUTOMOC run on every one of them and generate an empty file.
-  set(CMAKE_AUTOMOC OFF)
-
   # display_test_fixture.cpp is a piece of code that is used by every test.
   # Instead of recompiling it for every test, just compile it once as a library
   # and reuse it.  Note that we need to call ament_find_gmock() by hand here to
-  # find GMOCK_INCLUDE_DIRS so we can compile this file.
+  # find GMOCK_INCLUDE_DIRS and GMOCK_LIBRARIES so we can compile this file.
   ament_find_gmock()
-  add_library(display_test_fixture SHARED
+  add_library(display_test_fixture
     test/rviz_default_plugins/displays/display_test_fixture.cpp
   )
   target_include_directories(display_test_fixture PRIVATE ${GMOCK_INCLUDE_DIRS} ${TEST_INCLUDE_DIRS})
+  target_link_libraries(display_test_fixture ${GMOCK_LIBRARIES})
   ament_target_dependencies(display_test_fixture ${TEST_TARGET_DEPENDENCIES} rviz_rendering rviz_common)
 
   set(TEST_LINK_LIBRARIES

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -46,9 +46,9 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 
-# Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
+# We specifically don't turn on CMAKE_AUTOMOC, since it generates one huge
+# mocs_compilation.cpp file that takes a lot of memory to compile.  Instead
+# we create individual moc files that can be compiled separately.
 
 find_package(ament_cmake REQUIRED)
 
@@ -86,29 +86,19 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
   include/rviz_default_plugins/displays/map/map_display.hpp
   include/rviz_default_plugins/displays/marker/marker_common.hpp
-  include/rviz_default_plugins/displays/marker/marker_display.hpp
-  include/rviz_default_plugins/displays/marker_array/marker_array_display.hpp
   include/rviz_default_plugins/displays/odometry/odometry_display.hpp
   include/rviz_default_plugins/transformation/transformer_guard.hpp
   include/rviz_default_plugins/displays/interactive_markers/integer_action.hpp
   include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
-  include/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.hpp
   include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
   include/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp
   include/rviz_default_plugins/displays/path/path_display.hpp
   include/rviz_default_plugins/displays/point/point_stamped_display.hpp
   include/rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp
-  include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
-  include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
   include/rviz_default_plugins/displays/pointcloud/point_cloud_transformer.hpp
-  include/rviz_default_plugins/displays/pointcloud/point_cloud_transformer_factory.hpp
-  include/rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp
-  include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
   include/rviz_default_plugins/displays/pointcloud/transformers/axis_color_pc_transformer.hpp
   include/rviz_default_plugins/displays/pointcloud/transformers/flat_color_pc_transformer.hpp
   include/rviz_default_plugins/displays/pointcloud/transformers/intensity_pc_transformer.hpp
-  include/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.hpp
-  include/rviz_default_plugins/displays/pointcloud/transformers/rgbf32_pc_transformer.hpp
   include/rviz_default_plugins/displays/polygon/polygon_display.hpp
   include/rviz_default_plugins/displays/pose/pose_display.hpp
   include/rviz_default_plugins/displays/pose_array/pose_array_display.hpp
@@ -127,15 +117,16 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/tools/measure/measure_tool.hpp
   include/rviz_default_plugins/tools/goal_pose/goal_tool.hpp
   include/rviz_default_plugins/tools/interaction/interaction_tool.hpp
-  include/rviz_default_plugins/tools/pose/pose_tool.hpp
   include/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.hpp
   include/rviz_default_plugins/tools/point/point_tool.hpp
-  include/rviz_default_plugins/transformation/tf_frame_transformer.hpp
-  include/rviz_default_plugins/transformation/tf_wrapper.hpp
   include/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp
   include/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp
   include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
 )
+
+foreach(header "${rviz_default_plugins_headers_to_moc}")
+  qt5_wrap_cpp(rviz_default_plugins_moc_files "${header}")
+endforeach()
 
 set(rviz_default_plugins_source_files
   src/rviz_default_plugins/displays/axes/axes_display.cpp
@@ -224,7 +215,7 @@ set(rviz_default_plugins_source_files
 )
 
 add_library(rviz_default_plugins SHARED
-  ${rviz_default_plugins_headers_to_moc}
+  ${rviz_default_plugins_moc_files}
   ${rviz_default_plugins_source_files}
 )
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -336,6 +336,10 @@ if(BUILD_TESTING)
     visualization_msgs
   )
 
+  # None of the tests are Qt files, so we can save a bit of time by not letting
+  # AUTOMOC run on every one of them and generate an empty file.
+  set(CMAKE_AUTOMOC OFF)
+
   # display_test_fixture.cpp is a piece of code that is used by every test.
   # Instead of recompiling it for every test, just compile it once as a library
   # and reuse it.  Note that we need to call ament_find_gmock() by hand here to

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
@@ -41,6 +41,7 @@
 #include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/transformation/frame_transformer.hpp"
 
+#include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_default_plugins/transformation/transformer_guard.hpp"
 #include "rviz_default_plugins/transformation/tf_wrapper.hpp"
 #include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
@@ -56,7 +57,6 @@ class IntProperty;
 }  // namespace rviz_common
 namespace rviz_default_plugins
 {
-class PointCloudCommon;
 namespace displays
 {
 /** @brief Visualizes a laser scan, received as a sensor_msgs::LaserScan. */

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/flat_arrows_array.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/flat_arrows_array.cpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "include/rviz_default_plugins/displays/pose_array/flat_arrows_array.hpp"
+#include "rviz_default_plugins/displays/pose_array/flat_arrows_array.hpp"
 
 #include <vector>
 #include <string>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_covariance/pose_with_cov_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_covariance/pose_with_cov_selection_handler.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "src/rviz_default_plugins/displays/pose_covariance/pose_with_cov_selection_handler.hpp"
+#include "pose_with_cov_selection_handler.hpp"
 
 #include <memory>
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_info.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_info.cpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "include/rviz_default_plugins/displays/tf/frame_info.hpp"
+#include "rviz_default_plugins/displays/tf/frame_info.hpp"
 
 #include <algorithm>
 
@@ -40,7 +40,7 @@
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/properties/vector_property.hpp"
 #include "rviz_common/properties/quaternion_property.hpp"
-#include "include/rviz_default_plugins/displays/tf/frame_selection_handler.hpp"
+#include "rviz_default_plugins/displays/tf/frame_selection_handler.hpp"
 
 namespace rviz_default_plugins
 {

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
@@ -38,7 +38,7 @@
 
 #include "test/rviz_rendering/ogre_testing_environment.hpp"
 
-#include "include/rviz_default_plugins/displays/image/ros_image_texture.hpp"
+#include "rviz_default_plugins/displays/image/ros_image_texture.hpp"
 
 using namespace rviz_default_plugins::displays;  // NOLINT
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
@@ -32,7 +32,7 @@
 #include <vector>
 
 #include "rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp"
-#include "test/rviz_default_plugins/pointcloud_messages.hpp"
+#include "../../pointcloud_messages.hpp"
 
 using namespace ::testing;  // NOLINT
 using namespace rviz_default_plugins::displays;  // NOLINT

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
@@ -34,7 +34,7 @@
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/property.hpp"
-#include "test/rviz_default_plugins/pointcloud_messages.hpp"
+#include "../../../pointcloud_messages.hpp"
 
 #include "rviz_default_plugins/displays/pointcloud/transformers/axis_color_pc_transformer.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
@@ -34,7 +34,7 @@
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/property.hpp"
-#include "test/rviz_default_plugins/pointcloud_messages.hpp"
+#include "../../../pointcloud_messages.hpp"
 
 #include "rviz_default_plugins/displays/pointcloud/transformers/flat_color_pc_transformer.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
@@ -33,7 +33,7 @@
 
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here
 
-#include "test/rviz_default_plugins/pointcloud_messages.hpp"
+#include "../../../pointcloud_messages.hpp"
 
 #include "rviz_default_plugins/displays/pointcloud/transformers/intensity_pc_transformer.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgb8_pc_transformer_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgb8_pc_transformer_test.cpp
@@ -32,7 +32,7 @@
 #include <memory>
 #include <vector>
 
-#include "test/rviz_default_plugins/pointcloud_messages.hpp"
+#include "../../../pointcloud_messages.hpp"
 
 #include "rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgbf32_pc_transformer_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgbf32_pc_transformer_test.cpp
@@ -32,7 +32,7 @@
 #include <memory>
 #include <vector>
 
-#include "test/rviz_default_plugins/pointcloud_messages.hpp"
+#include "../../../pointcloud_messages.hpp"
 
 #include "rviz_default_plugins/displays/pointcloud/transformers/rgbf32_pc_transformer.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/xyz_pc_transformer_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/xyz_pc_transformer_test.cpp
@@ -32,7 +32,7 @@
 #include <memory>
 #include <vector>
 
-#include "test/rviz_default_plugins/pointcloud_messages.hpp"
+#include "../../../pointcloud_messages.hpp"
 
 #include "../../../scene_graph_introspection_helper.hpp"
 


### PR DESCRIPTION
As pointed out in https://github.com/ros2/rviz/issues/539 , it can take a lot of memory to compile rviz_default_plugins.  This PR aims to reduce the maximum amount of memory necessary to compile by doing two major things:

1.  Only compiling display_test_fixture.cpp one time for the tests.  Previously, each test compiled its own copy, and since it takes ~1GB of memory to compile each time, this can push up the maximum consumption if we have many threads compiling.  This PR changes that file to be a library, and then all of the tests link that library in.
1.  Split up the compilation of the MOC QT5 stuff.  Previously we were using CMAKE_AUTOMOC, which takes all of the MOC stuff and combines it into one large file.  When trying to compile that, it can take upwards for 2.5GB of memory, and we can run out of memory if we are compiling it alongside other things.  This PR changes that to generate one MOC per header file, and then compiling those MOC files separately.

The rest of the changes are to support the above.

I've done some basic testing of RViz2 locally with these changes, both the tests and RViz2 itself.  I believe this will close #539 .