### PR TITLE
Add dependency for building on the buildfarm

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -226,6 +226,11 @@ target_include_directories(rviz_default_plugins PUBLIC
   ${TinyXML_INCLUDE_DIRS}
 )
 
+target_link_libraries(rviz_default_plugins PUBLIC
+  rviz_ogre_vendor::OgreMain
+  rviz_ogre_vendor::OgreOverlay
+)
+
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(rviz_default_plugins PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
@@ -236,6 +241,7 @@ target_compile_definitions(rviz_default_plugins PUBLIC "PLUGINLIB__DISABLE_BOOST
 pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 
 ament_target_dependencies(rviz_default_plugins
+  PUBLIC
   geometry_msgs
   interactive_markers
   laser_geometry
@@ -263,6 +269,7 @@ ament_export_dependencies(
   map_msgs
   nav_msgs
   rclcpp
+  rviz_ogre_vendor
   tf2
   tf2_geometry_msgs
   tf2_ros

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -269,6 +269,7 @@ ament_export_dependencies(
   map_msgs
   nav_msgs
   rclcpp
+  resource_retriever
   rviz_ogre_vendor
   tf2
   tf2_geometry_msgs
@@ -592,7 +593,9 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET robot_test)
     target_include_directories(robot_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(robot_test ${TEST_LINK_LIBRARIES})
+    # TODO(clalancette): Figure out why putting resource_retriever in the
+    # TEST_TARGET_DEPENDENCIES doesn't work.
+    target_link_libraries(robot_test resource_retriever::resource_retriever ${TEST_LINK_LIBRARIES})
     ament_target_dependencies(robot_test ${TEST_TARGET_DEPENDENCIES})
   endif()
 

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -18,11 +18,15 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>qtbase5-dev</build_depend>
+  <build_depend>rviz_ogre_vendor</build_depend>
+
+  <build_export_depend>rviz_ogre_vendor</build_export_depend>
 
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
+  <exec_depend>rviz_ogre_vendor</exec_depend>
 
   <depend>geometry_msgs</depend>
   <depend>interactive_markers</depend>


### PR DESCRIPTION
There are three changes in here:

1.  Add a direct Ogre dependency.  rviz_default_plugins definitely has a direct dependency on Ogre, so it should link in the correct things and export the dependency.
1.  Add a resource_retriever dependency for export.  This is because rviz_default_plugins again depends directly on it.
1.  Add a `target_link_libraries` on `resource_retriever::resource_retriever`.  In theory this shouldn't be necessary, but it won't link without it right now.  This is a workaround for now to get the buildfarm turning over.