### PR TITLE
Remove automoc completely.

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -13,10 +13,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-# Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
 find_package(rviz_common REQUIRED)
 
 find_package(rviz_ogre_vendor REQUIRED)

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -85,7 +85,6 @@ set(rviz_common_headers_to_moc
   src/rviz_common/displays_panel.hpp
   src/rviz_common/failed_panel.hpp
   src/rviz_common/frame_manager.hpp
-  include/rviz_common/transformation/frame_transformer.hpp
   include/rviz_common/frame_manager_iface.hpp
   src/rviz_common/loading_dialog.hpp
   src/rviz_common/new_object_dialog.hpp
@@ -102,8 +101,6 @@ set(rviz_common_headers_to_moc
   include/rviz_common/properties/editable_enum_property.hpp
   include/rviz_common/properties/float_edit.hpp
   include/rviz_common/properties/float_property.hpp
-  include/rviz_common/properties/grouped_checkbox_property.hpp
-  include/rviz_common/properties/grouped_checkbox_property_group.hpp
   include/rviz_common/properties/int_property.hpp
   include/rviz_common/properties/line_edit_with_button.hpp
   include/rviz_common/properties/property.hpp
@@ -122,10 +119,7 @@ set(rviz_common_headers_to_moc
   src/rviz_common/screenshot_dialog.hpp
   include/rviz_common/interaction/selection_manager.hpp
   include/rviz_common/interaction/selection_manager_iface.hpp
-  include/rviz_common/interaction/selection_renderer.hpp
   src/rviz_common/splash_screen.hpp
-  # src/rviz_common/time_panel.hpp
-  src/rviz_common/transformation/identity_frame_transformer.hpp
   include/rviz_common/tool.hpp
   src/rviz_common/tool_manager.hpp
   src/rviz_common/tool_properties_panel.hpp
@@ -137,10 +131,7 @@ set(rviz_common_headers_to_moc
   src/rviz_common/visualization_frame.hpp
   src/rviz_common/visualization_manager.hpp
   src/rviz_common/widget_geometry_change_detector.hpp
-  include/rviz_common/window_manager_interface.hpp
-  include/rviz_common/validate_floats.hpp
   include/rviz_common/ros_topic_display.hpp
-  include/rviz_common/message_filter_display.hpp
 )
 
 foreach(header "${rviz_common_headers_to_moc}")
@@ -347,9 +338,11 @@ if(BUILD_TESTING)
   qt5_wrap_cpp(rviz_common_test_moc_files test/mock_display.hpp)
   qt5_wrap_cpp(rviz_common_test_moc_files test/mock_property_change_receiver.hpp)
 
+  qt5_wrap_cpp(rviz_common_test_frame_manager_moc src/rviz_common/frame_manager.hpp)
   ament_add_gmock(frame_manager_test
     test/frame_manager_test.cpp
     src/rviz_common/frame_manager.cpp
+    ${rviz_common_test_frame_manager_moc}
   )
   if(TARGET frame_manager_test)
     target_link_libraries(frame_manager_test

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -36,10 +36,6 @@ find_package(ament_cmake REQUIRED)
 # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
 find_package(rviz_ogre_vendor REQUIRED)
 
-# Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
 find_package(geometry_msgs REQUIRED)
@@ -72,7 +68,7 @@ set(ROS_DISTRO "ROS 2.0")
 set(OGRE_PLUGIN_PATH "rviz_ogre_vendor")
 configure_file(src/rviz_common/env_config.cpp.in ${ENV_CONFIG_CPP} @ONLY)
 
-# These need to be added in the add_library() call so AUTOMOC detects them.
+# These need to be added in the add_library() call
 set(rviz_common_headers_to_moc
   ${ENV_CONFIG_HPP}
   src/rviz_common/add_display_dialog.hpp
@@ -146,6 +142,10 @@ set(rviz_common_headers_to_moc
   include/rviz_common/ros_topic_display.hpp
   include/rviz_common/message_filter_display.hpp
 )
+
+foreach(header "${rviz_common_headers_to_moc}")
+  qt5_wrap_cpp(rviz_common_moc_files "${header}")
+endforeach()
 
 set(rviz_common_source_files
   ${ENV_CONFIG_CPP}
@@ -236,7 +236,7 @@ set(rviz_common_source_files
 )
 
 add_library(rviz_common SHARED
-  ${rviz_common_headers_to_moc}
+  ${rviz_common_moc_files}
   ${rviz_common_source_files}
 )
 
@@ -344,6 +344,9 @@ if(BUILD_TESTING)
   ament_lint_cmake()
   ament_uncrustify()
 
+  qt5_wrap_cpp(rviz_common_test_moc_files test/mock_display.hpp)
+  qt5_wrap_cpp(rviz_common_test_moc_files test/mock_property_change_receiver.hpp)
+
   ament_add_gmock(frame_manager_test
     test/frame_manager_test.cpp
     src/rviz_common/frame_manager.cpp
@@ -379,7 +382,9 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gtest(rviz_common_property_test
+    ${rviz_common_test_moc_files}
     test/property_test.cpp
+    test/mock_display.cpp
     test/mock_property_change_receiver.cpp
   )
   if(TARGET rviz_common_property_test)
@@ -438,9 +443,11 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gtest(rviz_common_display_test
+    ${rviz_common_test_moc_files}
     test/display_test.cpp
     test/mock_display.cpp
     test/mock_display_group.cpp
+    test/mock_property_change_receiver.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET rviz_common_display_test)
     target_link_libraries(rviz_common_display_test rviz_common Qt5::Widgets)

--- a/rviz_common/src/rviz_common/bit_allocator.cpp
+++ b/rviz_common/src/rviz_common/bit_allocator.cpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "include/rviz_common/bit_allocator.hpp"
+#include "rviz_common/bit_allocator.hpp"
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "include/rviz_common/display_group.hpp"
+#include "rviz_common/display_group.hpp"
 
 #include <cstdio>  // for debug-write printf
 #include <map>

--- a/rviz_common/src/rviz_common/properties/display_group_visibility_property.cpp
+++ b/rviz_common/src/rviz_common/properties/display_group_visibility_property.cpp
@@ -35,7 +35,7 @@
 
 #include <map>
 
-#include "include/rviz_common/properties/display_group_visibility_property.hpp"
+#include "rviz_common/properties/display_group_visibility_property.hpp"
 
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_common/src/rviz_common/properties/display_visibility_property.cpp
+++ b/rviz_common/src/rviz_common/properties/display_visibility_property.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "include/rviz_common/properties/display_visibility_property.hpp"
+#include "rviz_common/properties/display_visibility_property.hpp"
 
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_common/test/mock_display_group.hpp
+++ b/rviz_common/test/mock_display_group.hpp
@@ -30,7 +30,7 @@
 #ifndef MOCK_DISPLAY_GROUP_HPP_
 #define MOCK_DISPLAY_GROUP_HPP_
 
-#include "include/rviz_common/display_group.hpp"
+#include "rviz_common/display_group.hpp"
 
 using namespace rviz_common;  // NOLINT
 

--- a/rviz_common/test/transformation/identity_frame_transformer_test.cpp
+++ b/rviz_common/test/transformation/identity_frame_transformer_test.cpp
@@ -33,7 +33,7 @@
 #include <memory>
 #include <string>
 
-#include "src/rviz_common/transformation/identity_frame_transformer.hpp"
+#include "../../src/rviz_common/transformation/identity_frame_transformer.hpp"
 #include "transformation_test_helpers.hpp"
 
 using namespace testing;  // NOLINT

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -28,10 +28,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-# Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
 # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
 find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_assimp_vendor REQUIRED)
@@ -65,13 +61,11 @@ if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
   endif()
 endif()
 
-# These need to be added in the add_library() call so AUTOMOC detects them.
-set(headers_with_q_object
-  include/rviz_rendering/render_window.hpp
-)
+# These need to be added in the add_library() call
+qt5_wrap_cpp(rviz_rendering_moc_files include/rviz_rendering/render_window.hpp)
 
 add_library(rviz_rendering SHARED
-  ${headers_with_q_object}
+  ${rviz_rendering_moc_files}
   src/rviz_rendering/apply_visibility_bits.cpp
   src/rviz_rendering/geometry.cpp
   src/rviz_rendering/viewport_projection_finder.cpp

--- a/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
@@ -64,8 +64,8 @@
 
 #include "resource_retriever/retriever.h"
 
-#include "src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp"
-#include "src/rviz_rendering/mesh_loader_helpers/stl_loader.hpp"
+#include "mesh_loader_helpers/assimp_loader.hpp"
+#include "mesh_loader_helpers/stl_loader.hpp"
 #include "rviz_rendering/logging.hpp"
 
 #define ROS_PACKAGE_NAME "rviz_rendering"

--- a/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
@@ -38,7 +38,7 @@
 #include <Ogre.h>
 
 #include "rviz_rendering/objects/covariance_visual.hpp"
-#include "test/rviz_rendering/matcher.hpp"
+#include "../matcher.hpp"
 #include "test/rviz_rendering/ogre_testing_environment.hpp"
 #include "test/rviz_rendering/scene_graph_introspection.hpp"
 

--- a/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
+++ b/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
@@ -30,7 +30,7 @@
 #include "test/rviz_rendering/ogre_testing_environment.hpp"
 
 #include "rviz_rendering/render_window.hpp"
-#include "src/rviz_rendering/render_system.hpp"
+#include "../src/rviz_rendering/render_system.hpp"
 
 namespace rviz_rendering
 {

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -29,10 +29,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
-  # Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
-  set(CMAKE_INCLUDE_CURRENT_DIR ON)
-  set(CMAKE_AUTOMOC ON)
-
   # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
   find_package(rviz_ogre_vendor REQUIRED)
   find_package(Qt5 REQUIRED COMPONENTS Widgets)

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -24,10 +24,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-# Qt5 boilerplate options from http://doc.qt.io/qt-5/cmake-manual.html
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
 find_package(rviz_common REQUIRED)
 
 find_package(rviz_ogre_vendor REQUIRED)


### PR DESCRIPTION
Continuing on from #540, disable automoc in the rest of rviz.  There are 2 main reasons to do this:

1.  Reduce the memory consumption again (though this is a lot less important than it was for rviz_default_plugins).
1.  Get rid of warning messages on macOS of the form:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libgmock_main.a(mocs_compilation.cpp.o) has no symbols
```

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>