### PR TITLE
Don't try to moc generate env_config.hpp file.

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -70,7 +70,6 @@ configure_file(src/rviz_common/env_config.cpp.in ${ENV_CONFIG_CPP} @ONLY)
 
 # These need to be added in the add_library() call
 set(rviz_common_headers_to_moc
-  ${ENV_CONFIG_HPP}
   src/rviz_common/add_display_dialog.hpp
   src/rviz_common/help_panel.hpp
   include/rviz_common/properties/enum_property.hpp
@@ -206,7 +205,6 @@ set(rviz_common_source_files
   src/rviz_common/interaction/selection_renderer.cpp
   src/rviz_common/interaction/view_picker.cpp
   src/rviz_common/splash_screen.cpp
-  # src/rviz_common/time_panel.cpp
   src/rviz_common/transformation/identity_frame_transformer.cpp
   src/rviz_common/tool_manager.cpp
   src/rviz_common/tool_properties_panel.cpp


### PR DESCRIPTION
This removes one more warning from rviz_common builds.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>