### PR TITLE
Add missing virtual destructors

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 # Tests currently only run on OS X @ OSRF jenkins

--- a/rviz_default_plugins/include/rviz_default_plugins/robot/link_updater.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/link_updater.hpp
@@ -52,6 +52,9 @@ using rviz_common::properties::StatusLevel;
 class RVIZ_DEFAULT_PLUGINS_PUBLIC LinkUpdater
 {
 public:
+
+  virtual ~LinkUpdater() {}
+
   virtual bool getLinkTransforms(
     const std::string & link_name, Ogre::Vector3 & visual_position,
     Ogre::Quaternion & visual_orientation,

--- a/rviz_default_plugins/include/rviz_default_plugins/robot/link_updater.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/link_updater.hpp
@@ -52,7 +52,6 @@ using rviz_common::properties::StatusLevel;
 class RVIZ_DEFAULT_PLUGINS_PUBLIC LinkUpdater
 {
 public:
-
   virtual ~LinkUpdater() {}
 
   virtual bool getLinkTransforms(

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 # Tests currently only run on OS X @ OSRF jenkins

--- a/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
@@ -73,13 +73,6 @@ public:
   RVIZ_RENDERING_PUBLIC
   virtual ~PointCloudRenderable();
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Woverloaded-virtual"
-#endif
-
-// TODO(ivanpauno): Fixme!
-// This is not creating a problem, but hidding a base class virtual method is not a good practice.
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Woverloaded-virtual"
@@ -88,10 +81,6 @@ public:
   Ogre::RenderOperation * getRenderOperation() {return &mRenderOp;}
 #ifndef _WIN32
 # pragma GCC diagnostic pop
-#endif
-
-#ifdef __clang__
-#pragma clang diagnostic pop
 #endif
 
   RVIZ_RENDERING_PUBLIC

--- a/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
@@ -78,8 +78,17 @@ public:
 #pragma clang diagnostic ignored "-Woverloaded-virtual"
 #endif
 
+// TODO(ivanpauno): Fixme!
+// This is not creating a problem, but hidding a base class virtual method is not a good practice.
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
   RVIZ_RENDERING_PUBLIC
   Ogre::RenderOperation * getRenderOperation() {return &mRenderOp;}
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 # Tests currently only run on OS X @ OSRF jenkins

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Same idea as https://github.com/ros2/rclcpp/pull/1149.

There's an "overloaded virtual" warning that I'm ignoring in order to avoid breaking API now.
We should fix that in the future.