### PR TITLE
avoid absolute OGRE path in exported targets

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -219,7 +219,6 @@ add_library(rviz_default_plugins SHARED
 target_include_directories(rviz_default_plugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-  ${OGRE_INCLUDE_DIRS}
   ${Qt5Widgets_INCLUDE_DIRS}
 )
 

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -110,7 +110,6 @@ target_include_directories(rviz_rendering
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
-    ${OGRE_INCLUDE_DIRS}
     ${Eigen3_INCLUDE_DIRS}
 )
 # Causes the visibility macros to use dllexport rather than dllimport,


### PR DESCRIPTION
Fixes one more parts of https://github.com/ros2/rviz/issues/556#issuecomment-638586174.

Both targets already link against `rviz_ogre_vendor::OgreMain` / `rviz_ogre_vendor::OgreOverlay` which provide the necessary include directory.