### PR TITLE
restore compatibility with older Qt versions

### DIFF
--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
@@ -101,6 +101,7 @@ public:
     auto global_point = QPointF();
     auto pixel_delta = QPoint();
     auto angle_delta = QPoint(delta, 0);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     auto mouseEvent = new QWheelEvent(
       point,
       global_point,
@@ -110,6 +111,10 @@ public:
       Qt::NoModifier,
       Qt::NoScrollPhase,
       false);
+#else
+    auto mouseEvent = new QWheelEvent(
+      point, delta, Qt::NoButton, Qt::NoModifier, Qt::Orientation::Horizontal);
+#endif
     return {render_panel_.get(), mouseEvent, 0, 0};
   }
 


### PR DESCRIPTION
Addressed https://github.com/ros2/rviz/pull/555#issuecomment-638987854

CentOS builds:
* Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=58)](https://ci.ros2.org/job/ci_linux-centos/58/)
* After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-centos&build=60)](https://ci.ros2.org/job/ci_linux-centos/60/)