### PR TITLE
Suppress warnings when building with older Qt versions.

### DIFF
--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
@@ -98,10 +98,10 @@ public:
   rviz_common::ViewportMouseEvent generateMouseWheelEvent(int delta)
   {
     auto point = QPointF();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     auto global_point = QPointF();
     auto pixel_delta = QPoint();
     auto angle_delta = QPoint(delta, 0);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     auto mouseEvent = new QWheelEvent(
       point,
       global_point,


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>