### PR TITLE
rewrite hack to avoid CMake warning with assimp 5.0.1 and older, apply cross platform

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -52,77 +52,12 @@ macro(build_assimp)
   )
 endmacro()
 
-# Copy and fix the assimp config files on Ubuntu, in order to suppress a warning.
-# This should be removed once upstream is updated to assimp-0.5.1, see:
+# Override ON so that the following CMake logic in assimp 5.0.1 and older
+# doesn't result in a CMake warning: if(ON)
 #   https://github.com/ros2/rviz/issues/524
 #   https://bugs.launchpad.net/ubuntu/+source/assimp/+bug/1869405
-### BEGIN HACKS
-set(IS_UBUNTU_FOCAL FALSE)
-if(UNIX AND NOT APPLE)
-  find_program(LSB_RELEASE_EXEC lsb_release)
-  if(EXISTS "${LSB_RELEASE_EXEC}")
-    execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
-        OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    execute_process(COMMAND ${LSB_RELEASE_EXEC} -sr
-      OUTPUT_VARIABLE LSB_RELEASE_RELEASE_SHORT
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  else()
-    set(LSB_RELEASE_ID_SHORT "Unknown")
-    set(LSB_RELEASE_RELEASE_SHORT "Unknown")
-  endif()
+set(ON 1)
 
-  if(${LSB_RELEASE_ID_SHORT} STREQUAL "Ubuntu" AND ${LSB_RELEASE_RELEASE_SHORT} STREQUAL "20.04")
-    set(IS_UBUNTU_FOCAL TRUE)
-  endif()
-endif()
-
-if(IS_UBUNTU_FOCAL)
-  file(GLOB_RECURSE assimp_target_files "/usr/lib/*/cmake/assimp-5.0/assimpTargets.cmake")
-  list(LENGTH assimp_target_files assimp_target_files_len)
-  if(assimp_target_files_len EQUAL 0)
-    message(FATAL_ERROR "failed to find assimpTargets.cmake as expected")
-  endif()
-  if(NOT assimp_target_files_len EQUAL 1)
-    message(FATAL_ERROR "found multiple assimpTargets.cmake files, unexpectedly")
-  endif()
-  list(GET assimp_target_files 0 assimp_target_file)
-
-  get_filename_component(assimp_target_dir "${assimp_target_file}" DIRECTORY)
-  set(new_assimp_target_dir "${CMAKE_CURRENT_BINARY_DIR}/assimp-0.5")
-
-  file(READ "${assimp_target_dir}/assimpTargets.cmake" assimp_targets_content)
-  string(REPLACE
-    "if(ON)"
-    "set(WORKAROUND ON)\nif(WORKAROUND)"
-    assimp_targets_content
-    ${assimp_targets_content})
-  file(WRITE "${new_assimp_target_dir}/assimpTargets.cmake" "${assimp_targets_content}")
-  file(READ "${assimp_target_dir}/assimpTargets-release.cmake" assimp_targets_content)
-  string(REPLACE
-    "if(ON)"
-    "set(WORKAROUND ON)\nif(WORKAROUND)"
-    assimp_targets_content
-    ${assimp_targets_content})
-  file(WRITE "${new_assimp_target_dir}/assimpTargets-release.cmake" "${assimp_targets_content}")
-  file(
-    COPY "${assimp_target_dir}/assimp-config.cmake"
-    DESTINATION "${new_assimp_target_dir}")
-  file(
-    COPY "${assimp_target_dir}/assimp-config-version.cmake"
-    DESTINATION "${new_assimp_target_dir}")
-  set(assimp_DIR "${new_assimp_target_dir}")
-
-  install(
-    DIRECTORY
-      ${new_assimp_target_dir}/
-    DESTINATION
-      ${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor_custom_config
-  )
-endif()
-### END HACKS
 find_package(assimp QUIET)
 
 if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 4.1.0)

--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -1,29 +1,8 @@
-# Use custom CMake config files for assimp on Ubuntu to work around a cmake warning.
-# This should be removed once upstream is updated to assimp-0.5.1, see:
+# Override ON so that the following CMake logic in assimp 5.0.1 and older
+# doesn't result in a CMake warning: if(ON)
 #   https://github.com/ros2/rviz/issues/524
 #   https://bugs.launchpad.net/ubuntu/+source/assimp/+bug/1869405
-### BEGIN HACKS
-set(IS_UBUNTU FALSE)
-if(UNIX AND NOT APPLE)
-  find_program(LSB_RELEASE_EXEC lsb_release)
-  if(EXISTS "${LSB_RELEASE_EXEC}")
-    execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
-        OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-  else()
-    set(LSB_RELEASE_ID_SHORT "Unknown")
-  endif()
-
-  if(${LSB_RELEASE_ID_SHORT} STREQUAL "Ubuntu")
-    set(IS_UBUNTU TRUE)
-  endif()
-endif()
-
-if(IS_UBUNTU)
-  set(assimp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_assimp_vendor_custom_config")
-endif()
-### END HACKS
+set(ON 1)
 
 find_package(assimp QUIET)
 


### PR DESCRIPTION
This addresses the remaining CMake warning on macOS from https://github.com/ros2/rviz/issues/524#issuecomment-638376917.

macOS CI of `rviz_assimp_vendor`:
Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9110)](https://ci.ros2.org/job/ci_osx/9110/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9122)](https://ci.ros2.org/job/ci_osx/9122/)

CI builds testing all packages including and above `rviz_assimp_vendor`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11179)](http://ci.ros2.org/job/ci_linux/11179/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6457)](http://ci.ros2.org/job/ci_linux-aarch64/6457/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9123)](http://ci.ros2.org/job/ci_osx/9123/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11092)](http://ci.ros2.org/job/ci_windows/11092/)

macOS packaging passing without a CMake warning: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=77)](https://ci.ros2.org/job/ci_packaging_osx/77/)