### PR TITLE
Fix the order of destructors

### DIFF
--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -56,8 +56,7 @@ public:
   typedef MessageFilterDisplay<MessageType> MFDClass;
 
   MessageFilterDisplay()
-  : subscription_(),
-    tf_filter_(),
+  : tf_filter_(nullptr),
     messages_received_(0)
   {
     // TODO(Martin-Idel-SI): We need a way to extract the MessageType from the template to set a
@@ -152,12 +151,8 @@ protected:
 
   virtual void unsubscribe()
   {
-    if (tf_filter_) {
-      tf_filter_.reset();
-    }
-    if (subscription_) {
-      subscription_.reset();
-    }
+    tf_filter_.reset();
+    subscription_.reset();
   }
 
   void onEnable() override

--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -56,7 +56,8 @@ public:
   typedef MessageFilterDisplay<MessageType> MFDClass;
 
   MessageFilterDisplay()
-  : tf_filter_(nullptr),
+  : subscription_(),
+    tf_filter_(),
     messages_received_(0)
   {
     // TODO(Martin-Idel-SI): We need a way to extract the MessageType from the template to set a
@@ -151,8 +152,12 @@ protected:
 
   virtual void unsubscribe()
   {
-    subscription_.reset();
-    tf_filter_.reset();
+    if (tf_filter_) {
+      tf_filter_.reset();
+    }
+    if (subscription_) {
+      subscription_.reset();
+    }
   }
 
   void onEnable() override


### PR DESCRIPTION
In current code, nullptr is called on destructor of `MessageFilterDisplay`.
This causes segfault on OS X (with Clang++) (e.g. #557 #568 )

I only tested on OS X, so I don't know this fix is acceptable on Ubuntu and g++.
Can anyone test on Ubuntu?