### PR TITLE
use reference in range loops to avoid copy

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
@@ -498,7 +498,7 @@ void InteractiveMarker::updateControls(
 
   // Maintain a set of old controls to delete
   std::set<std::string> old_names_to_delete;
-  for (const auto name_control_pair : controls_) {
+  for (const auto & name_control_pair : controls_) {
     old_names_to_delete.insert(name_control_pair.first);
   }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
@@ -195,7 +195,7 @@ void InteractiveMarkerDisplay::update(float wall_dt, float ros_dt)
 
   interactive_marker_client_->update();
 
-  for (const auto name_marker_pair : interactive_markers_map_) {
+  for (const auto & name_marker_pair : interactive_markers_map_) {
     name_marker_pair.second->update();
   }
 }
@@ -358,7 +358,7 @@ void InteractiveMarkerDisplay::updateShowDescriptions()
 {
   bool show = show_descriptions_property_->getBool();
 
-  for (const auto name_marker_pair : interactive_markers_map_) {
+  for (const auto & name_marker_pair : interactive_markers_map_) {
     name_marker_pair.second->setShowDescription(show);
   }
 }
@@ -367,7 +367,7 @@ void InteractiveMarkerDisplay::updateShowAxes()
 {
   bool show = show_axes_property_->getBool();
 
-  for (const auto name_marker_pair : interactive_markers_map_) {
+  for (const auto & name_marker_pair : interactive_markers_map_) {
     name_marker_pair.second->setShowAxes(show);
   }
 }
@@ -376,7 +376,7 @@ void InteractiveMarkerDisplay::updateShowVisualAids()
 {
   bool show = show_visual_aids_property_->getBool();
 
-  for (const auto name_marker_pair : interactive_markers_map_) {
+  for (const auto & name_marker_pair : interactive_markers_map_) {
     name_marker_pair.second->setShowVisualAids(show);
   }
 }


### PR DESCRIPTION
Before: https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/484/clang/folder.-1662385032/
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11500)](https://ci.ros2.org/job/ci_linux/11500/)
* unrelated compiler warnings remaining
* the tests are never run with `clang+libcxx` so there is no baseline what to expect - since the PR build passed green I assume it is expected