### PR TITLE
Avoid hiding base class getRenderOperation in PointCloudRenderable

### DIFF
--- a/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
@@ -73,15 +73,11 @@ public:
   RVIZ_RENDERING_PUBLIC
   virtual ~PointCloudRenderable();
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
   RVIZ_RENDERING_PUBLIC
   Ogre::RenderOperation * getRenderOperation() {return &mRenderOp;}
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
+
+  // Avoid hidding parent class overload.
+  using Ogre::SimpleRenderable::getRenderOperation;
 
   RVIZ_RENDERING_PUBLIC
   Ogre::HardwareVertexBufferSharedPtr getBuffer();


### PR DESCRIPTION
This avoid hiding the base class [method](https://ogrecave.github.io/ogre/api/latest/class_ogre_1_1_simple_renderable.html#a51c5ae135793c602557d46be10c59b8d) instead of ignoring the warning.

Follow up of https://github.com/ros2/rviz/pull/553.