### PR TITLE
Pass through CMAKE_{C,CXX}_FLAGS to OGRE build

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -102,7 +102,8 @@ endmacro()
 
 macro(build_ogre)
   set(extra_cmake_args)
-  set(OGRE_CXX_FLAGS)
+  set(OGRE_C_FLAGS ${CMAKE_C_FLAGS})
+  set(OGRE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
   # standard library is important for linking, but the other cxx flags are not
   if(CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -stdlib=libc++")
@@ -113,19 +114,20 @@ macro(build_ogre)
   endif()
 
   if(WIN32)
+    set(OGRE_C_FLAGS "${OGRE_C_FLAGS} /w /EHsc")
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} /w /EHsc")
-    list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=/w /EHsc")
   elseif(APPLE)
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -std=c++14 -stdlib=libc++ -w")
     list(APPEND extra_cmake_args "-DCMAKE_OSX_ARCHITECTURES='x86_64'")
   else()  # Linux
+    set(OGRE_C_FLAGS "${OGRE_C_FLAGS} -w")
     # include Clang -Wno-everything to disable warnings in that build. GCC doesn't mind it
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -std=c++14 -w -Wno-everything")
-    list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=-w")
   endif()
   list(APPEND extra_cmake_args "-DOGRE_BUILD_RENDERSYSTEM_GL:BOOL=TRUE")
   list(APPEND extra_cmake_args "-DOGRE_BUILD_RENDERSYSTEM_D3D11:BOOL=OFF")
   list(APPEND extra_cmake_args "-DOGRE_BUILD_RENDERSYSTEM_D3D9:BOOL=OFF")
+  list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=${OGRE_C_FLAGS}")
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${OGRE_CXX_FLAGS}")
 
   # Uncomment this line to enable the GL3PLUS render engine


### PR DESCRIPTION
The compile flags passed to the vendor package's CMake build are only used for compiler tests, and aren't being forwarded on to the actual OGRE build. This seems to be OK on our currently supported platforms, but makes it impossible to pass compile flags via colcon arguments and is currently breaking RPM builds, where certain flags must be specified.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11636)](http://ci.ros2.org/job/ci_linux/11636/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6765)](http://ci.ros2.org/job/ci_linux-aarch64/6765/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9521)](http://ci.ros2.org/job/ci_osx/9521/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11619)](http://ci.ros2.org/job/ci_windows/11619/)