### PR TITLE
Switch to nullptr everywhere.

### DIFF
--- a/rviz_common/src/rviz_common/config.cpp
+++ b/rviz_common/src/rviz_common/config.cpp
@@ -62,7 +62,7 @@ public:
 Config::Node::Node()
 : type_(Empty)
 {
-  data_.map = NULL;
+  data_.map = nullptr;
 }
 
 Config::Node::~Node()
@@ -79,7 +79,7 @@ void Config::Node::deleteData()
     default:
       break;
   }
-  data_.map = NULL;
+  data_.map = nullptr;
 }
 
 void Config::Node::setType(Config::Type new_type)
@@ -198,7 +198,7 @@ Config Config::mapMakeChild(const QString & key)
 
 Config Config::mapGetChild(const QString & key) const
 {
-  if (node_.get() == NULL || node_->type_ != Map) {
+  if (node_ == nullptr || node_->type_ != Map) {
     return invalidConfig();
   }
   Node::ChildMap::const_iterator iter = node_->data_.map->find(key);
@@ -282,14 +282,14 @@ bool Config::mapGetString(const QString & key, QString * value_out) const
 
 void Config::makeValid()
 {
-  if (node_.get() == NULL) {
+  if (node_ == nullptr) {
     node_.reset(new Node());
   }
 }
 
 bool Config::isValid() const
 {
-  return node_.get() != NULL;
+  return node_ != nullptr;
 }
 
 void Config::setValue(const QVariant & value)
@@ -333,7 +333,7 @@ Config::MapIterator Config::mapIterator() const
   // Create a new (invalid) iterator.
   Config::MapIterator iter;
 
-  if (node_.get() == NULL || node_->type_ != Map) {
+  if (node_ == nullptr || node_->type_ != Map) {
     // Force the node to be invalid, since this node does not have a map.
     iter.node_.reset();
   } else {
@@ -350,7 +350,7 @@ Config::MapIterator::MapIterator()
 
 void Config::MapIterator::advance()
 {
-  if (node_.get() == NULL || node_->type_ != Config::Map) {
+  if (node_ == nullptr || node_->type_ != Config::Map) {
     iterator_valid_ = false;
     return;
   }
@@ -364,7 +364,7 @@ void Config::MapIterator::advance()
 
 bool Config::MapIterator::isValid()
 {
-  if (node_.get() == NULL || node_->type_ != Config::Map) {
+  if (node_ == nullptr || node_->type_ != Config::Map) {
     iterator_valid_ = false;
     return false;
   }
@@ -377,7 +377,7 @@ bool Config::MapIterator::isValid()
 
 void Config::MapIterator::start()
 {
-  if (node_.get() == NULL || node_->type_ != Config::Map) {
+  if (node_ == nullptr || node_->type_ != Config::Map) {
     iterator_valid_ = false;
     return;
   }
@@ -387,7 +387,7 @@ void Config::MapIterator::start()
 
 QString Config::MapIterator::currentKey()
 {
-  if (node_.get() == NULL || node_->type_ != Config::Map || !iterator_valid_) {
+  if (node_ == nullptr || node_->type_ != Config::Map || !iterator_valid_) {
     iterator_valid_ = false;
     return QString();
   }
@@ -396,7 +396,7 @@ QString Config::MapIterator::currentKey()
 
 Config Config::MapIterator::currentChild()
 {
-  if (node_.get() == NULL || node_->type_ != Config::Map || !iterator_valid_) {
+  if (node_ == nullptr || node_->type_ != Config::Map || !iterator_valid_) {
     iterator_valid_ = false;
     return Config();
   }

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -166,8 +166,8 @@ void DisplayGroup::removeAllDisplays()
   for (int i = displays_.size() - 1; i >= 0; i--) {
     Display * child = displays_.takeAt(i);
     Q_EMIT displayRemoved(child);
-    child->setParent(NULL);  // prevent child destructor from calling getParent()->takeChild().
-    child->setModel(NULL);
+    child->setParent(nullptr);  // prevent child destructor from calling getParent()->takeChild().
+    child->setModel(nullptr);
     child_indexes_valid_ = false;
     delete child;
   }
@@ -179,7 +179,7 @@ void DisplayGroup::removeAllDisplays()
 
 Display * DisplayGroup::takeDisplay(Display * child)
 {
-  Display * result = NULL;
+  Display * result = nullptr;
   int num_displays = displays_.size();
   for (int i = 0; i < num_displays; i++) {
     if (displays_.at(i) == child) {
@@ -188,8 +188,8 @@ Display * DisplayGroup::takeDisplay(Display * child)
       }
       result = displays_.takeAt(i);
       Q_EMIT displayRemoved(result);
-      result->setParent(NULL);
-      result->setModel(NULL);
+      result->setParent(nullptr);
+      result->setModel(nullptr);
       child_indexes_valid_ = false;
       if (model_) {
         model_->endRemove();
@@ -206,7 +206,7 @@ Display * DisplayGroup::getDisplayAt(int index) const
   if (0 <= index && index < displays_.size() ) {
     return displays_.at(index);
   }
-  return NULL;
+  return nullptr;
 }
 
 DisplayGroup * DisplayGroup::getGroupAt(int index) const
@@ -307,8 +307,8 @@ Property * DisplayGroup::takeChildAt(int index)
 //  printf("  displaygroup5 displays_.takeAt( %d ) ( index = %d )\n", disp_index, index );
   Display * child = displays_.takeAt(disp_index);
   Q_EMIT displayRemoved(child);
-  child->setModel(NULL);
-  child->setParent(NULL);
+  child->setModel(nullptr);
+  child->setParent(nullptr);
   child_indexes_valid_ = false;
   if (model_) {
     model_->endRemove();

--- a/rviz_common/src/rviz_common/failed_view_controller.cpp
+++ b/rviz_common/src/rviz_common/failed_view_controller.cpp
@@ -69,7 +69,7 @@ void FailedViewController::save(Config config) const
 
 void FailedViewController::onActivate()
 {
-  QWidget * parent = NULL;
+  QWidget * parent = nullptr;
   if (context_->getWindowManager() ) {
     parent = context_->getWindowManager()->getParentWindow();
   }

--- a/rviz_common/src/rviz_common/properties/property.cpp
+++ b/rviz_common/src/rviz_common/properties/property.cpp
@@ -97,7 +97,7 @@ Property::~Property()
   // Destroy my children.
   for (int i = children_.size() - 1; i >= 0; i--) {
     Property * child = children_.takeAt(i);
-    child->setParent(NULL);
+    child->setParent(nullptr);
     delete child;
   }
 }
@@ -118,7 +118,7 @@ void Property::removeChildren(int start_index, int count)
   // Destroy my children.
   for (int i = start_index; i < start_index + count; i++) {
     Property * child = children_.at(i);
-    child->setParent(NULL);   // prevent child destructor from calling getParent()->takeChild().
+    child->setParent(nullptr);   // prevent child destructor from calling getParent()->takeChild().
     delete child;
   }
   children_.erase(children_.begin() + start_index, children_.begin() + start_index + count);
@@ -199,7 +199,7 @@ Property * Property::subProp(const QString & sub_name)
   // Print a useful error message showing the whole ancestry of this
   // property, but don't crash.
   QString ancestry = "";
-  for (Property * prop = this; prop != NULL; prop = prop->getParent() ) {
+  for (Property * prop = this; prop != nullptr; prop = prop->getParent() ) {
     ancestry = "\"" + prop->getName() + "\"->" + ancestry;
   }
   printf(
@@ -220,7 +220,7 @@ Property * Property::childAt(int index) const
   if (0 <= index && index < numChildren() ) {
     return childAtUnchecked(index);
   }
-  return NULL;
+  return nullptr;
 }
 
 Property * Property::childAtUnchecked(int index) const
@@ -324,7 +324,7 @@ bool Property::paint(QPainter * painter, const QStyleOptionViewItem & option) co
 bool Property::isAncestorOf(Property * possible_child) const
 {
   Property * prop = possible_child->getParent();
-  while (prop != NULL && prop != this) {
+  while (prop != nullptr && prop != this) {
     prop = prop->getParent();
   }
   return prop == this;
@@ -337,20 +337,20 @@ Property * Property::takeChild(Property * child)
       return takeChildAt(i);
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 Property * Property::takeChildAt(int index)
 {
   if (index < 0 || index >= children_.size() ) {
-    return NULL;
+    return nullptr;
   }
   if (model_) {
     model_->beginRemove(this, index, 1);
   }
   Property * child = children_.takeAt(index);
-  child->setModel(NULL);
-  child->parent_ = NULL;
+  child->setModel(nullptr);
+  child->parent_ = nullptr;
   child_indexes_valid_ = false;
   if (model_) {
     model_->endRemove();

--- a/rviz_common/src/rviz_common/screenshot_dialog.cpp
+++ b/rviz_common/src/rviz_common/screenshot_dialog.cpp
@@ -55,7 +55,7 @@ namespace rviz_common
 ScreenshotDialog::ScreenshotDialog(
   QWidget * main_window, QWidget * render_window,
   const QString & default_save_dir)
-: QWidget(NULL),    // This should be a top-level window to act like a dialog.
+: QWidget(nullptr),    // This should be a top-level window to act like a dialog.
   main_window_(main_window),
   render_window_(render_window),
   save_full_window_(false),

--- a/rviz_common/src/rviz_common/views_panel.cpp
+++ b/rviz_common/src/rviz_common/views_panel.cpp
@@ -48,7 +48,7 @@ namespace rviz_common
 
 ViewsPanel::ViewsPanel(QWidget * parent)
 : Panel(parent),
-  view_man_(NULL)
+  view_man_(nullptr)
 {
   camera_type_selector_ = new QComboBox;
   properties_view_ = new properties::PropertyTreeWidget();
@@ -120,7 +120,7 @@ void ViewsPanel::setViewManager(ViewManager * view_man)
     connect(camera_type_selector_, SIGNAL(activated(int)), this, SLOT(onTypeSelectorChanged(int)));
     connect(view_man_, SIGNAL(currentChanged()), this, SLOT(onCurrentChanged()));
   } else {
-    properties_view_->setModel(NULL);
+    properties_view_->setModel(nullptr);
   }
   onCurrentChanged();
 }

--- a/rviz_rendering/src/rviz_rendering/objects/shape.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/shape.cpp
@@ -58,7 +58,7 @@ Shape::createEntity(
   Ogre::SceneManager * scene_manager)
 {
   if (type == Mesh) {
-    return NULL;  // the entity is initialized after the vertex data was specified
+    return nullptr;  // the entity is initialized after the vertex data was specified
   }
   std::string mesh_name;
   switch (type) {

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -291,7 +291,7 @@ void RenderWindowImpl::setupStereo()
   rendering_stereo_ = render_stereo;
 
   if (rendering_stereo_) {
-    right_viewport_ = render_window_->addViewport(NULL, 1);
+    right_viewport_ = render_window_->addViewport(nullptr, 1);
 #if OGRE_STEREO_ENABLE
     right_viewport_->setDrawBuffer(Ogre::CBT_BACK_RIGHT);
     viewport_->setDrawBuffer(Ogre::CBT_BACK_LEFT);
@@ -308,7 +308,7 @@ void RenderWindowImpl::setupStereo()
   } else {
     render_window_->removeListener(this);
     render_window_->removeViewport(1);
-    right_viewport_ = NULL;
+    right_viewport_ = nullptr;
 
 #if OGRE_STEREO_ENABLE
     viewport_->setDrawBuffer(Ogre::CBT_BACK);
@@ -317,11 +317,11 @@ void RenderWindowImpl::setupStereo()
     if (left_camera_) {
       left_camera_->getSceneManager()->destroyCamera(left_camera_);
     }
-    left_camera_ = NULL;
+    left_camera_ = nullptr;
     if (right_camera_) {
       right_camera_->getSceneManager()->destroyCamera(right_camera_);
     }
-    right_camera_ = NULL;
+    right_camera_ = nullptr;
   }
 }
 #endif


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a trivial patch to just replace `NULL` -> `nullptr` everywhere.  Just something I noticed while looking into other things here.