### PR TITLE
Add linters and use ament_lint_auto

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -83,15 +83,8 @@ install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
-  # TODO(wjwwood): replace this with ament_lint_auto() and/or add the copyright linter back
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  ament_cppcheck()
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
   add_subdirectory(test)
 endif()

--- a/rviz2/package.xml
+++ b/rviz2/package.xml
@@ -29,10 +29,13 @@
   <depend>rviz_common</depend>
   <depend>rviz_ogre_vendor</depend>
 
+  <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>sensor_msgs</test_depend>

--- a/rviz2/package.xml
+++ b/rviz2/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rviz2</name>
   <version>8.2.0</version>
@@ -8,16 +12,16 @@
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
   <license>BSD</license>
 
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
+
   <author>Dave Hershberger</author>
   <author>David Gossow</author>
   <author>D. Hood</author>
   <author>Josh Faust</author>
   <author email="scott@openrobotics.org">Scott K Logan</author>
   <author email="william@openrobotics.org">William Woodall</author>
-
-  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
-  <url type="repository">https://github.com/ros2/rviz</url>
-  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -1,3 +1,4 @@
+# lint_cmake: -readability/wonkycase
 cmake_minimum_required(VERSION 3.5)
 
 project(rviz_assimp_vendor)
@@ -77,6 +78,11 @@ if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 4.1.0)
     set(ENV_VAR_VALUE "opt/rviz_assimp_vendor/lib")
   endif()
   ament_environment_hooks(env_hook/rviz_assimp_vendor_library_path.dsv.in)
+endif()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package(

--- a/rviz_assimp_vendor/package.xml
+++ b/rviz_assimp_vendor/package.xml
@@ -22,6 +22,10 @@
 
   <depend>assimp</depend>
 
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -313,19 +313,11 @@ install(
 )
 
 if(BUILD_TESTING)
-  # TODO(wjwwood): replace this with ament_lint_auto() and/or add the copyright linter back
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
-
-  ament_cppcheck()
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
 
   qt5_wrap_cpp(rviz_common_test_moc_files test/mock_display.hpp)
   qt5_wrap_cpp(rviz_common_test_moc_files test/mock_property_change_receiver.hpp)

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -46,12 +46,15 @@
   <depend>urdf</depend>
   <depend>yaml_cpp_vendor</depend>
 
+  <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rviz_common</name>
   <version>8.2.0</version>
@@ -8,14 +12,14 @@
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
   <license>BSD</license>
 
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
+
   <author>Dave Hershberger</author>
   <author>David Gossow</author>
   <author>Josh Faust</author>
   <author email="william@openrobotics.org">William Woodall</author>
-
-  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
-  <url type="repository">https://github.com/ros2/rviz</url>
-  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -294,15 +294,8 @@ install(
 )
 
 if(BUILD_TESTING)
-  # TODO(wjwwood): replace this with ament_lint_auto() and/or add the copyright linter back
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  ament_cppcheck()
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_gmock REQUIRED)

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rviz_default_plugins</name>
   <version>8.2.0</version>
@@ -8,14 +12,14 @@
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
   <license>BSD</license>
 
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
+
   <author>Dave Hershberger</author>
   <author>David Gossow</author>
   <author>Josh Faust</author>
   <author email="william@openrobotics.org">William Woodall</author>
-
-  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
-  <url type="repository">https://github.com/ros2/rviz</url>
-  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -46,13 +46,16 @@
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
 
+  <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_index_cpp</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>rviz_rendering_tests</test_depend>
   <test_depend>rviz_visual_testing_framework</test_depend>
 

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -225,6 +225,11 @@ else()
 endif()
 ament_environment_hooks(env_hook/rviz_ogre_vendor_library_path.dsv.in)
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 ament_package(
   CONFIG_EXTRAS "rviz_ogre_vendor-extras.cmake.in"
 )

--- a/rviz_ogre_vendor/package.xml
+++ b/rviz_ogre_vendor/package.xml
@@ -31,6 +31,9 @@
   <depend>libxrandr</depend>
   <depend>opengl</depend>
 
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -154,15 +154,8 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ogre_media"
   USE_SOURCE_PERMISSIONS)
 
 if(BUILD_TESTING)
-  # TODO(wjwwood): replace this with ament_lint_auto() and/or add the copyright linter back
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  ament_cppcheck()
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rviz_rendering</name>
   <version>8.2.0</version>
@@ -8,14 +12,14 @@
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
   <license>BSD</license>
 
+  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
+
   <author>Dave Hershberger</author>
   <author>David Gossow</author>
   <author>Josh Faust</author>
   <author email="william@openrobotics.org">William Woodall</author>
-
-  <url type="website">https://github.com/ros2/rviz/blob/ros2/README.md</url>
-  <url type="repository">https://github.com/ros2/rviz</url>
-  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -42,12 +42,15 @@
   <exec_depend>rviz_assimp_vendor</exec_depend>
   <exec_depend>rviz_ogre_vendor</exec_depend>
 
+  <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>rviz_assimp_vendor</test_depend>
 
   <export>

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -47,15 +47,8 @@ if(BUILD_TESTING)
     DESTINATION "share/rviz_rendering_tests"
     USE_SOURCE_PERMISSIONS)
 
-  # TODO(Martin-Idel-SI): replace this with ament_lint_auto() and/or add the copyright linter back
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  ament_cppcheck()
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_gmock REQUIRED)

--- a/rviz_rendering_tests/package.xml
+++ b/rviz_rendering_tests/package.xml
@@ -3,39 +3,39 @@
   href="http://download.ros.org/schema/package_format2.xsd"
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
-    <name>rviz_rendering_tests</name>
-    <version>8.2.0</version>
-    <description>
-        Example plugin for RViz - documents and tests RViz plugin development
-    </description>
-    <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
-    <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
-    <license>BSD</license>
+  <name>rviz_rendering_tests</name>
+  <version>8.2.0</version>
+  <description>
+    Example plugin for RViz - documents and tests RViz plugin development
+  </description>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
+  <license>BSD</license>
 
-    <url type="repository">https://github.com/ros2/rviz</url>
-    <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
+  <url type="repository">https://github.com/ros2/rviz</url>
+  <url type="bugtracker">https://github.com/ros2/rviz/issues</url>
 
-    <author email="william@openrobotics.org">William Woodall</author>
+  <author email="william@openrobotics.org">William Woodall</author>
 
-    <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-    <build_depend>qtbase5-dev</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
 
-    <depend>rviz_rendering</depend>
-    <depend>resource_retriever</depend>
+  <depend>rviz_rendering</depend>
+  <depend>resource_retriever</depend>
 
-    <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
-    <test_depend>ament_cmake_cppcheck</test_depend>
-    <test_depend>ament_cmake_cpplint</test_depend>
-    <test_depend>ament_cmake_gmock</test_depend>
-    <test_depend>ament_cmake_gtest</test_depend>
-    <test_depend>ament_cmake_lint_cmake</test_depend>
-    <test_depend>ament_cmake_uncrustify</test_depend>
-    <test_depend>ament_cmake_xmllint</test_depend>
-    <test_depend>ament_lint_auto</test_depend>
-    <test_depend>ament_index_cpp</test_depend>
+  <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
 
-    <export>
-        <build_type>ament_cmake</build_type>
-    </export>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/rviz_rendering_tests/package.xml
+++ b/rviz_rendering_tests/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
     <name>rviz_rendering_tests</name>
     <version>8.2.0</version>

--- a/rviz_rendering_tests/package.xml
+++ b/rviz_rendering_tests/package.xml
@@ -20,12 +20,15 @@
     <depend>rviz_rendering</depend>
     <depend>resource_retriever</depend>
 
+    <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
     <test_depend>ament_cmake_cppcheck</test_depend>
     <test_depend>ament_cmake_cpplint</test_depend>
     <test_depend>ament_cmake_gmock</test_depend>
     <test_depend>ament_cmake_gtest</test_depend>
     <test_depend>ament_cmake_lint_cmake</test_depend>
     <test_depend>ament_cmake_uncrustify</test_depend>
+    <test_depend>ament_cmake_xmllint</test_depend>
+    <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_index_cpp</test_depend>
 
     <export>

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -111,15 +111,8 @@ install(
 )
 
 if(BUILD_TESTING)
-  # TODO(wjwwood): replace this with ament_lint_auto() and/or add the copyright linter back
-  find_package(ament_cmake_cppcheck REQUIRED)
-  find_package(ament_cmake_cpplint REQUIRED)
-  find_package(ament_cmake_lint_cmake REQUIRED)
-  find_package(ament_cmake_uncrustify REQUIRED)
-  ament_cppcheck()
-  ament_cpplint()
-  ament_lint_cmake()
-  ament_uncrustify()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_package()

--- a/rviz_visual_testing_framework/package.xml
+++ b/rviz_visual_testing_framework/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format2.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rviz_visual_testing_framework</name>
   <version>8.2.0</version>
@@ -8,12 +12,12 @@
   <maintainer email="michael.jeronimo@openrobotics.org">Michael Jeronimo</maintainer>
   <license>BSD</license>
 
-  <author>Alessandro Bottero</author>
-  <author email="william@openrobotics.org">William Woodall</author>
-
   <url type="website">http://ros.org/wiki/rviz2</url>
   <url type="repository">https://github.com/ros-visualization/rviz</url>
   <url type="bugtracker">https://github.com/ros-visualization/rviz/issues</url>
+
+  <author>Alessandro Bottero</author>
+  <author email="william@openrobotics.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/rviz_visual_testing_framework/package.xml
+++ b/rviz_visual_testing_framework/package.xml
@@ -22,11 +22,14 @@
   <depend>rviz_common</depend>
   <depend>ament_cmake_gtest</depend>
 
+  <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
I still left TODOs for enabling ament_copyright linter once that is able to handle the copyright notices in RViz.