### PR TITLE
use rcutils_get_env.

### DIFF
--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -24,6 +24,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
+find_package(rcutils REQUIRED)
+
 find_package(rviz_common REQUIRED)
 
 find_package(rviz_ogre_vendor REQUIRED)

--- a/rviz_visual_testing_framework/package.xml
+++ b/rviz_visual_testing_framework/package.xml
@@ -23,6 +23,7 @@
 
   <build_depend>qtbase5-dev</build_depend>
 
+  <depend>rcutils</depend>
   <depend>rviz_common</depend>
   <depend>ament_cmake_gtest</depend>
 

--- a/rviz_visual_testing_framework/src/internal/visual_test.cpp
+++ b/rviz_visual_testing_framework/src/internal/visual_test.cpp
@@ -38,6 +38,8 @@
 
 #include <QDir>  // NOLINT
 
+#include "rcutils/get_env.h"
+
 VisualTest::VisualTest(
   rviz_common::VisualizerApp * vapp,
   std::shared_ptr<Executor> executor,
@@ -182,23 +184,12 @@ void VisualTest::reset()
 
 bool VisualTest::generateReferenceImages()
 {
-#ifdef _WIN32
-  char * buffer = nullptr;
-  size_t size = 0;
-  if (_dupenv_s(&buffer, &size, "GenerateReferenceImages") == 0 && buffer != nullptr) {
-    std::string generate_references(buffer);
-    free(buffer);
-
-    return generate_references == "True";
-  }
-
-  return false;
-#else
-  if (!std::getenv("GenerateReferenceImages")) {
+  const char * env_var_value = NULL;
+  const char * ret_str = rcutils_get_env("GenerateReferenceImages", &env_var_value);
+  if (NULL != ret_str || *env_var_value == '\0') {
     return false;
   }
+  std::string generate_references(env_var_value);
 
-  std::string generate_references = std::getenv("GenerateReferenceImages");
   return generate_references == "True";
-#endif
 }


### PR DESCRIPTION
close https://github.com/ros2/ros2/issues/856

Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>

- Note

all rviz related tests are pass,

```
> colcon test --packages-select rviz_visual_testing_framework rviz2 rviz_assimp_vendor rviz_common rviz_default_plugins rviz_ogre_vendor rviz_rendering rviz_rendering_tests
```