### PR TITLE
Support loading meshes other than .mesh and .stl with package URIs

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
@@ -94,13 +94,14 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
   } else {
     QFileInfo model_path(QString::fromStdString(resource_path));
     std::string ext = model_path.completeSuffix().toStdString();
+
+    auto res = getResource(resource_path);
+
+    if (res.size == 0) {
+      return Ogre::MeshPtr();
+    }
+
     if (ext == "mesh" || ext == "MESH") {
-      auto res = getResource(resource_path);
-
-      if (res.size == 0) {
-        return Ogre::MeshPtr();
-      }
-
       Ogre::MeshSerializer ser;
       Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));
       Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(
@@ -109,12 +110,6 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
 
       return mesh;
     } else if (ext == "stl" || ext == "STL" || ext == "stlb" || ext == "STLB") {
-      auto res = getResource(resource_path);
-
-      if (res.size == 0) {
-        return Ogre::MeshPtr();
-      }
-
       STLLoader stl_loader;
       if (!stl_loader.load(res.data.get(), res.size, resource_path)) {
         RVIZ_RENDERING_LOG_ERROR_STREAM("Failed to load file [" << resource_path.c_str() << "]");
@@ -125,7 +120,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
     } else {
       AssimpLoader assimp_loader;
 
-      const aiScene * scene = assimp_loader.getScene(resource_path);
+      const aiScene * scene = assimp_loader.getScene(static_cast<void *>(res.data.get()), res.size);
       if (!scene) {
         RVIZ_RENDERING_LOG_ERROR_STREAM(
           "Could not load resource [" << resource_path.c_str() << "]: " <<

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -228,10 +228,10 @@ Ogre::MeshPtr AssimpLoader::meshFromAssimpScene(const std::string & name, const 
   return mesh;
 }
 
-const aiScene * AssimpLoader::getScene(const std::string & resource_path)
+const aiScene * AssimpLoader::getScene(void * buffer, size_t size)
 {
-  return importer_->ReadFile(
-    resource_path,
+  return importer_->ReadFileFromMemory(
+    buffer, size,
     aiProcess_SortByPType | aiProcess_GenNormals | aiProcess_Triangulate |
     aiProcess_GenUVCoords | aiProcess_FlipUVs);
 }

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
@@ -62,7 +62,7 @@ class AssimpLoader
 public:
   AssimpLoader();
   Ogre::MeshPtr meshFromAssimpScene(const std::string & name, const aiScene * scene);
-  const aiScene * getScene(const std::string & resource_path);
+  const aiScene * getScene(void * buffer, size_t size);
   std::string getErrorMessage();
 
 private:


### PR DESCRIPTION
Previously, trying to load a mesh of a different type (e.g. .dae) with a package URI would fail.