### PR TITLE
Fix render window disappearing after saving an image

### DIFF
--- a/rviz_common/src/rviz_common/screenshot_dialog.cpp
+++ b/rviz_common/src/rviz_common/screenshot_dialog.cpp
@@ -126,7 +126,12 @@ void ScreenshotDialog::takeScreenshotNow()
   if (save_full_window_) {
     screenshot_ = screen->grabWindow(main_window_->winId());
   } else {
+    // There is a known issue in Qt where calling winId() on an OpenGL window
+    // (OGRE being a wrapper for OpenGL) can result in rendering 'glitches" (See
+    // https://doc.qt.io/qt-5/qopenglwidget.html). As a work-around, we can raise
+    // the main window, causing the render window to re-render its graphics display.
     screenshot_ = screen->grabWindow(render_window_->winId());
+    main_window_->raise();
   }
   image_widget_->setImage(screenshot_);
 }


### PR DESCRIPTION
This PR works around a known issue in Qt where calling winId() on an OpenGL window
(OGRE being a wrapper for OpenGL) results in rendering 'glitches" (See
https://doc.qt.io/qt-5/qopenglwidget.html). In this case, the contents of the rendering
window disappeared entirely. There does not seem to be a portable, alternative method
to get the window handle. Instead, as a work-around, the code in this PR raises the main
window, causing the render window to re-render its graphics display.

Fixes #606

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>