### PR TITLE
Do not use assume every RenderPanel has a ViewController.

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
@@ -521,7 +521,7 @@ Ogre::Ray InteractiveMarkerControl::getMouseRayInReferenceFrame(
   float width = viewport->getActualWidth() - 1;
   float height = viewport->getActualHeight() - 1;
 
-  Ogre::Ray mouse_ray = event.panel->getViewController()->getCamera()->getCameraToViewportRay(
+  Ogre::Ray mouse_ray = viewport->getCamera()->getCameraToViewportRay(
     (x + .5) / width, (y + .5) / height);
 
   // convert ray into reference frame
@@ -574,8 +574,10 @@ void InteractiveMarkerControl::rotateXYRelative(const rviz_common::ViewportMouse
   Ogre::Radian rx(dx * MOUSE_SCALE);
   Ogre::Radian ry(dy * MOUSE_SCALE);
 
-  Ogre::Quaternion up_rot(rx, event.panel->getViewController()->getCamera()->getRealUp());
-  Ogre::Quaternion right_rot(ry, event.panel->getViewController()->getCamera()->getRealRight());
+  auto viewport =
+    rviz_rendering::RenderWindowOgreAdapter::getOgreViewport(event.panel->getRenderWindow());
+  Ogre::Quaternion up_rot(rx, viewport->getCamera()->getRealUp());
+  Ogre::Quaternion right_rot(ry, viewport->getCamera()->getRealRight());
 
   parent_->setPose(parent_->getPosition(), up_rot * right_rot * parent_->getOrientation(), name_);
 }
@@ -596,7 +598,9 @@ void InteractiveMarkerControl::rotateZRelative(const rviz_common::ViewportMouseE
   static const double MOUSE_SCALE = 2 * 3.14 / 300;  // 300 pixels = 360deg
   Ogre::Radian rx(dx * MOUSE_SCALE);
 
-  Ogre::Quaternion rot(rx, event.panel->getViewController()->getCamera()->getRealDirection());
+  auto viewport =
+    rviz_rendering::RenderWindowOgreAdapter::getOgreViewport(event.panel->getRenderWindow());
+  Ogre::Quaternion rot(rx, viewport->getCamera()->getRealDirection());
 
   parent_->setPose(parent_->getPosition(), rot * parent_->getOrientation(), name_);
 }
@@ -639,8 +643,10 @@ void InteractiveMarkerControl::moveViewPlane(
   Ogre::Ray & mouse_ray, const rviz_common::ViewportMouseEvent & event)
 {
   // find plane on which mouse is moving
+  auto viewport =
+    rviz_rendering::RenderWindowOgreAdapter::getOgreViewport(event.panel->getRenderWindow());
   Ogre::Plane plane(
-    event.panel->getViewController()->getCamera()->getRealDirection(),
+    viewport->getCamera()->getRealDirection(),
     grab_point_in_reference_frame_);
 
   // find intersection of mouse with the plane


### PR DESCRIPTION
This pull request gets the current `Ogre::Viewport` from the panel's `RenderWindow` instead of assuming it'll have an `rviz_common::ViewController` (which it doesn't if the panel is that of a `rviz_default_plugins::Camera` display.

With this patch,  interactive markers work (and do not make `rviz` crash) when a user attempts to interact with marker controls via camera feed (which, to my surprise, is supported on ROS 1).


CI up to `rviz2`, `rviz_default_plugins`, and `rviz_rendering_tests`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12792)](http://ci.ros2.org/job/ci_linux/12792/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7751)](http://ci.ros2.org/job/ci_linux-aarch64/7751/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10506)](http://ci.ros2.org/job/ci_osx/10506/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12739)](http://ci.ros2.org/job/ci_windows/12739/)

