### PR TITLE
Ensure rviz_common::MessageFilterDisplay processes messages in the main thread

### DIFF
--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -132,7 +132,7 @@ protected:
       tf_filter_->connectInput(*subscription_);
       tf_filter_->registerCallback(
         std::bind(
-          &MessageFilterDisplay<MessageType>::incomingMessage, this,
+          &MessageFilterDisplay<MessageType>::messageTaken, this,
           std::placeholders::_1));
       setStatus(properties::StatusProperty::Ok, "Topic", "OK");
     } catch (rclcpp::exceptions::InvalidTopicNameError & e) {
@@ -186,17 +186,21 @@ protected:
     reset();
   }
 
-  /// Incoming message callback.
-  /**
-   * Checks if the message pointer
-   * is valid, increments messages_received_, then calls
-   * processMessage().
-   */
-  void incomingMessage(const typename MessageType::ConstSharedPtr msg)
+  void messageTaken(typename MessageType::ConstSharedPtr msg)
   {
     if (!msg) {
       return;
     }
+
+    // Do not process message right away, tf2_ros::MessageFilter may be
+    // calling back from tf2_ros::TransformListener dedicated thread.
+    // Use type erased signal/slot machinery to ensure messages are
+    // processed in the main thread.
+    Q_EMIT typeErasedMessageTaken(std::static_pointer_cast<const void>(msg));
+  }
+
+  void processTypeErasedMessage(std::shared_ptr<const void> type_erased_msg) override {
+    auto msg = std::static_pointer_cast<const MessageType>(type_erased_msg);
 
     ++messages_received_;
     setStatus(

--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -199,7 +199,8 @@ protected:
     Q_EMIT typeErasedMessageTaken(std::static_pointer_cast<const void>(msg));
   }
 
-  void processTypeErasedMessage(std::shared_ptr<const void> type_erased_msg) override {
+  void processTypeErasedMessage(std::shared_ptr<const void> type_erased_msg) override
+  {
     auto msg = std::static_pointer_cast<const MessageType>(type_erased_msg);
 
     ++messages_received_;

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -109,11 +109,13 @@ public:
       this,
       SLOT(processTypeErasedMessage(std::shared_ptr<const void>)));
   }
+
 Q_SIGNALS:
   void typeErasedMessageTaken(std::shared_ptr<const void> type_erased_message);
 
 protected Q_SLOTS:
-  virtual void processTypeErasedMessage(std::shared_ptr<const void> type_erased_message) {
+  virtual void processTypeErasedMessage(std::shared_ptr<const void> type_erased_message)
+  {
     (void)type_erased_message;
   }
 

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -51,6 +51,12 @@
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
 #include "rviz_common/visibility_control.hpp"
 
+// Required, in combination with
+// `qRegisterMetaType<std::shared_ptr<const void>>` so that this
+// type can be queued by Qt slots.
+// See: http://doc.qt.io/qt-5/qmetatype.html#qRegisterMetaType-1
+Q_DECLARE_METATYPE(std::shared_ptr<const void>)
+
 namespace rviz_common
 {
 
@@ -66,6 +72,8 @@ public:
   : rviz_ros_node_(),
     qos_profile(5)
   {
+    qRegisterMetaType<std::shared_ptr<const void>>();
+
     topic_property_ = new properties::RosTopicProperty(
       "Topic", "",
       "", "", this, SLOT(updateTopic()));
@@ -92,9 +100,23 @@ public:
         this->qos_profile = profile;
         updateTopic();
       });
+
+    // Useful to _ROSTopicDisplay subclasses to ensure GUI updates
+    // are performed by the main thread only.
+    connect(
+      this,
+      SIGNAL(typeErasedMessageTaken(std::shared_ptr<const void>)),
+      this,
+      SLOT(processTypeErasedMessage(std::shared_ptr<const void>)));
   }
+Q_SIGNALS:
+  void typeErasedMessageTaken(std::shared_ptr<const void> type_erased_message);
 
 protected Q_SLOTS:
+  virtual void processTypeErasedMessage(std::shared_ptr<const void> type_erased_message) {
+    (void)type_erased_message;
+  }
+
   virtual void transformerChangedCallback()
   {
   }

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -107,7 +107,9 @@ public:
       this,
       SIGNAL(typeErasedMessageTaken(std::shared_ptr<const void>)),
       this,
-      SLOT(processTypeErasedMessage(std::shared_ptr<const void>)));
+      SLOT(processTypeErasedMessage(std::shared_ptr<const void>)),
+      // Force queued connections regardless of QObject thread affinity
+      Qt::QueuedConnection);
   }
 
 Q_SIGNALS:


### PR DESCRIPTION
Since `tf2_ros::MessageFilter` callback is called from `tf2_ros::TransformListener` dedicated thread, concurrency issues will arise if a derived display (like `rviz_defaults_plugins::Polygon`) attempts to modify the UI from `rviz_common::MessageFilterDisplay::processMessage()`.

CI up to `rviz_default_plugins` and `rviz_common`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12918)](http://ci.ros2.org/job/ci_linux/12918/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7871)](http://ci.ros2.org/job/ci_linux-aarch64/7871/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10634)](http://ci.ros2.org/job/ci_osx/10634/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12867)](http://ci.ros2.org/job/ci_windows/12867/)

Unfortunately, I do not have a regression test nor a reliable repro for the segfaults this causes. Below you'll find the partial backtrace that led me here.

<details>
<summary>Backtrace</summary>

#0  0x00007ffff214f649 in ?? () from /usr/lib/x86_64-linux-gnu/libGLdispatch.so.0
#1  0x00007fffdc2d484e in Ogre::GLHardwareVertexBuffer::GLHardwareVertexBuffer(Ogre::HardwareBufferManagerBase*, unsigned long, unsigned long, Ogre::HardwareBuffer::Usage, bool) () from /opt/ros/foxy/opt/rviz_ogre_vendor/lib/OGRE/RenderSystem_GL.so.1.12.1
#2  0x00007fffdc2cb907 in Ogre::GLHardwareBufferManager::createVertexBuffer(unsigned long, unsigned long, Ogre::HardwareBuffer::Usage, bool) ()
   from /opt/ros/foxy/opt/rviz_ogre_vendor/lib/OGRE/RenderSystem_GL.so.1.12.1
#3  0x00007ffff670f775 in Ogre::ManualObject::end() () from /opt/ros/foxy/opt/rviz_ogre_vendor/lib/libOgreMain.so.1.12.1
#4  0x00007fffc7e4ba3a in rviz_default_plugins::displays::PolygonDisplay::processMessage(std::shared_ptr<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > const>) () from /opt/ros/foxy/lib/librviz_default_plugins.so
#5  0x00007fffc7c7ffb5 in rviz_common::MessageFilterDisplay<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > >::incomingMessage(std::shared_ptr<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > const>) () from /opt/ros/foxy/lib/librviz_default_plugins.so
#6  0x00007fffc7c8022e in std::_Function_handler<void (std::shared_ptr<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > const> const&), std::_Bind<void (rviz_common::MessageFilterDisplay<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > >::*(rviz_common::MessageFilterDisplay<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > >*, std::_Placeholder<1>))(std::shared_ptr<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > const>)> >::_M_invoke(std::_Any_data const&, std::shared_ptr<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > const> const&) ()
   from /opt/ros/foxy/lib/librviz_default_plugins.so
#7  0x00007fffc7c904a4 in message_filters::CallbackHelper1T<std::shared_ptr<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > const> const&, geometry_msgs::msg::PolygonStamped_<std::allocator<void> > >::call(message_filters::MessageEvent<geometry_msgs::msg::PolygonStamped_<std::allocator<void> > const> const&, bool) () from /opt/ros/foxy/lib/librviz_default_plugins.so
#8  0x00007fffc7c8b6cb in tf2_ros::MessageFilter<geometry_msgs::msg::PolygonStamped_<std::allocator<void> >, rviz_common::transformation::FrameTransformer>::transformReadyCallback(std::shared_future<geometry_msgs::msg::TransformStamped_<std::allocator<void> > > const&, unsigned long) ()
   from /opt/ros/foxy/lib/librviz_default_plugins.so
#9  0x00007fffc7660430 in ?? () from /opt/ros/foxy/lib/libtf2_ros.so
#10 0x00007fffdc0224b1 in tf2::BufferCore::testTransformableRequests() () from /opt/ros/foxy/lib/libtf2.so
#11 0x00007fffdc023d34 in tf2::BufferCore::setTransformImpl(tf2::Transform const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) ()
   from /opt/ros/foxy/lib/libtf2.so
#12 0x00007fffdc02576d in tf2::BufferCore::setTransform(geometry_msgs::msg::TransformStamped_<std::allocator<void> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) () from /opt/ros/foxy/lib/libtf2.so
#13 0x00007fffc7666826 in tf2_ros::TransformListener::subscription_callback(std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >, bool) ()
   from /opt/ros/foxy/lib/libtf2_ros.so
#14 0x00007fffc7ea643d in std::_Function_handler<void (std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >), std::_Bind<void (tf2_ros::TransformListener::*(tf2_ros::TransformListener*, std::_Placeholder<1>, bool))(std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >, bool)> >::_M_invoke(std::_Any_data const&, std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >&&) ()
   from /opt/ros/foxy/lib/librviz_default_plugins.so
--Type <RET> for more, q to quit, c to continue without paging--
#15 0x00007fffc7eabc81 in rclcpp::AnySubscriptionCallback<tf2_msgs::msg::TFMessage_<std::allocator<void> >, std::allocator<void> >::dispatch(std::shared_ptr<tf2_msgs::msg::TFMessage_<std::allocator<void> > >, rclcpp::MessageInfo const&) () from /opt/ros/foxy/lib/librviz_default_plugins.so
#16 0x00007fffc7eac4ef in rclcpp::Subscription<tf2_msgs::msg::TFMessage_<std::allocator<void> >, std::allocator<void>, rclcpp::message_memory_strategy::MessageMemoryStrategy<tf2_msgs::msg::TFMessage_<std::allocator<void> >, std::allocator<void> > >::handle_message(std::shared_ptr<void>&, rclcpp::MessageInfo const&) () from /opt/ros/foxy/lib/librviz_default_plugins.so
#17 0x00007ffff70e728c in ?? () from /opt/ros/foxy/lib/librclcpp.so
#18 0x00007ffff70e7b4b in rclcpp::Executor::execute_subscription(std::shared_ptr<rclcpp::SubscriptionBase>) () from /opt/ros/foxy/lib/librclcpp.so
#19 0x00007ffff70e830a in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&) () from /opt/ros/foxy/lib/librclcpp.so
#20 0x00007ffff70ecb0c in rclcpp::executors::SingleThreadedExecutor::spin() () from /opt/ros/foxy/lib/librclcpp.so
#21 0x00007fffc7666a72 in ?? () from /opt/ros/foxy/lib/libtf2_ros.so
#22 0x00007ffff6eedcb4 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#23 0x00007ffff598c609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#24 0x00007ffff6d2c103 in clone () from /usr/lib/x86_64-linux-gnu/libc.so.6
</details>

You can see on frame `#4` that the crash occurs within `rviz_default_plugins::Polygon` implementation, which in frame `#21` we see it's being called from `tf2_ros` dedicated thread implementation.