### PR TITLE
Prevent rviz_rendering::AssimpLoader from loading materials twice.

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -255,8 +255,9 @@ std::vector<Ogre::MaterialPtr> AssimpLoader::loadMaterials(
   for (uint32_t i = 0; i < scene->mNumMaterials; i++) {
     std::string material_name;
     material_name = resource_path + "Material" + std::to_string(i);
-    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
+    auto result = Ogre::MaterialManager::getSingleton().createOrRetrieve(
       material_name, ROS_PACKAGE_NAME, true);
+    Ogre::MaterialPtr mat = std::static_pointer_cast<Ogre::Material>(result.first);
     material_table_out.push_back(mat);
 
     aiMaterial * ai_material = scene->mMaterials[i];


### PR DESCRIPTION
Retrieve material if it already exists. Assumes resource path uniqueness.

I still don't grok why this isn't a problem in `rviz` (similar code [here](https://github.com/ros-visualization/rviz/blob/3cdc03a5186a53f644c5abd55b9971457bdffa1c/src/rviz/mesh_loader.cpp#L461-L467)). But without this patch, resetting `rviz2` whenever a mesh marker is being displayed causes it to crash.

CI up to `rviz_rendering` and `rviz_rendering_tests`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12962)](http://ci.ros2.org/job/ci_linux/12962/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7911)](http://ci.ros2.org/job/ci_linux-aarch64/7911/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10680)](http://ci.ros2.org/job/ci_osx/10680/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12911)](http://ci.ros2.org/job/ci_windows/12911/)
