### PR TITLE
[backport] [dashing] Prevent rviz_rendering::AssimpLoader from loading materials twice (#622)

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -254,8 +254,9 @@ std::vector<Ogre::MaterialPtr> AssimpLoader::loadMaterials(
   for (uint32_t i = 0; i < scene->mNumMaterials; i++) {
     std::string material_name;
     material_name = resource_path + "Material" + std::to_string(i);
-    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
+    auto result = Ogre::MaterialManager::getSingleton().createOrRetrieve(
       material_name, ROS_PACKAGE_NAME, true);
+    Ogre::MaterialPtr mat = std::static_pointer_cast<Ogre::Material>(result.first);
     material_table_out.push_back(mat);
 
     aiMaterial * ai_material = scene->mMaterials[i];

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -256,7 +256,7 @@ std::vector<Ogre::MaterialPtr> AssimpLoader::loadMaterials(
     material_name = resource_path + "Material" + std::to_string(i);
     auto result = Ogre::MaterialManager::getSingleton().createOrRetrieve(
       material_name, ROS_PACKAGE_NAME, true);
-    Ogre::MaterialPtr mat = std::static_pointer_cast<Ogre::Material>(result.first);
+    Ogre::MaterialPtr mat = Ogre::static_pointer_cast<Ogre::Material>(result.first);
     material_table_out.push_back(mat);
 
     aiMaterial * ai_material = scene->mMaterials[i];


### PR DESCRIPTION
Backport #622.

Dashing CI (up to `rviz2`, `rviz_rendering`, and `rviz_rendering_tests`):

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13214)](http://ci.ros2.org/job/ci_linux/13214/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8143)](http://ci.ros2.org/job/ci_linux-aarch64/8143/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10928)](http://ci.ros2.org/job/ci_osx/10928/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13229)](http://ci.ros2.org/job/ci_windows/13229/)
