### PR TITLE
[backport] [foxy] Prevent rviz_rendering::AssimpLoader from loading materials twice (#622)

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -255,8 +255,9 @@ std::vector<Ogre::MaterialPtr> AssimpLoader::loadMaterials(
   for (uint32_t i = 0; i < scene->mNumMaterials; i++) {
     std::string material_name;
     material_name = resource_path + "Material" + std::to_string(i);
-    Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(
+    auto result = Ogre::MaterialManager::getSingleton().createOrRetrieve(
       material_name, ROS_PACKAGE_NAME, true);
+    Ogre::MaterialPtr mat = std::static_pointer_cast<Ogre::Material>(result.first);
     material_table_out.push_back(mat);
 
     aiMaterial * ai_material = scene->mMaterials[i];


### PR DESCRIPTION
Backport #622.

Foxy CI (up to `rviz2`, `rviz_rendering`, and `rviz_rendering_tests`):

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13142)](http://ci.ros2.org/job/ci_linux/13142/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8073)](http://ci.ros2.org/job/ci_linux-aarch64/8073/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10851)](http://ci.ros2.org/job/ci_osx/10851/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13137)](http://ci.ros2.org/job/ci_windows/13137/)
