### PR TITLE
Fix possible nullptr access in robot_joint.cpp.

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.cpp
@@ -217,11 +217,15 @@ void RobotJoint::calculateJointCheckboxesRecursive(
   int & links_with_geom_checked,
   int & links_with_geom_unchecked)
 {
+  links_with_geom = 0;
   links_with_geom_checked = 0;
   links_with_geom_unchecked = 0;
 
   RobotLink * link = robot_->getLink(child_link_name_);
-  if (link && link->hasGeometry()) {
+  if (link == nullptr) {
+    return;
+  }
+  if (link->hasGeometry()) {
     bool checked = link->getLinkProperty()->getValue().toBool();
     links_with_geom_checked += checked ? 1 : 0;
     links_with_geom_unchecked += checked ? 0 : 1;
@@ -267,11 +271,15 @@ void RobotJoint::getChildLinkState(
   int & links_with_geom_unchecked,
   bool recursive) const
 {
+  links_with_geom = 0;
   links_with_geom_checked = 0;
   links_with_geom_unchecked = 0;
 
   RobotLink * link = robot_->getLink(child_link_name_);
-  if (link && link->hasGeometry()) {
+  if (link == nullptr) {
+    return;
+  }
+  if (link->hasGeometry()) {
     bool checked = link->getLinkProperty()->getValue().toBool();
     links_with_geom_checked += checked ? 1 : 0;
     links_with_geom_unchecked += checked ? 0 : 1;


### PR DESCRIPTION
As pointed out by clang static analysis, the checks here
are not sufficient to prevent a nullptr access in the
unlikely case that a link is nullptr.  Revamp the code
so that we get out early if a link is nullptr.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>