### PR TITLE
Revert "Support loading meshes other than .mesh and .stl with package URIs (#610)"

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
@@ -94,14 +94,13 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
   } else {
     QFileInfo model_path(QString::fromStdString(resource_path));
     std::string ext = model_path.completeSuffix().toStdString();
-
-    auto res = getResource(resource_path);
-
-    if (res.size == 0) {
-      return Ogre::MeshPtr();
-    }
-
     if (ext == "mesh" || ext == "MESH") {
+      auto res = getResource(resource_path);
+
+      if (res.size == 0) {
+        return Ogre::MeshPtr();
+      }
+
       Ogre::MeshSerializer ser;
       Ogre::DataStreamPtr stream(new Ogre::MemoryDataStream(res.data.get(), res.size));
       Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(
@@ -110,6 +109,12 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
 
       return mesh;
     } else if (ext == "stl" || ext == "STL" || ext == "stlb" || ext == "STLB") {
+      auto res = getResource(resource_path);
+
+      if (res.size == 0) {
+        return Ogre::MeshPtr();
+      }
+
       STLLoader stl_loader;
       if (!stl_loader.load(res.data.get(), res.size, resource_path)) {
         RVIZ_RENDERING_LOG_ERROR_STREAM("Failed to load file [" << resource_path.c_str() << "]");
@@ -120,7 +125,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
     } else {
       AssimpLoader assimp_loader;
 
-      const aiScene * scene = assimp_loader.getScene(static_cast<void *>(res.data.get()), res.size);
+      const aiScene * scene = assimp_loader.getScene(resource_path);
       if (!scene) {
         RVIZ_RENDERING_LOG_ERROR_STREAM(
           "Could not load resource [" << resource_path.c_str() << "]: " <<

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -228,10 +228,10 @@ Ogre::MeshPtr AssimpLoader::meshFromAssimpScene(const std::string & name, const 
   return mesh;
 }
 
-const aiScene * AssimpLoader::getScene(void * buffer, size_t size)
+const aiScene * AssimpLoader::getScene(const std::string & resource_path)
 {
-  return importer_->ReadFileFromMemory(
-    buffer, size,
+  return importer_->ReadFile(
+    resource_path,
     aiProcess_SortByPType | aiProcess_GenNormals | aiProcess_Triangulate |
     aiProcess_GenUVCoords | aiProcess_FlipUVs);
 }

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
@@ -62,7 +62,7 @@ class AssimpLoader
 public:
   AssimpLoader();
   Ogre::MeshPtr meshFromAssimpScene(const std::string & name, const aiScene * scene);
-  const aiScene * getScene(void * buffer, size_t size);
+  const aiScene * getScene(const std::string & resource_path);
   std::string getErrorMessage();
 
 private:


### PR DESCRIPTION
This reverts commit a4da1b279367218a6a95a36121528454df4a6af0.

#610 broke loading `.obj` mesh files using package URIs.

Example:

```
$ tree
.
├── mre_pub.py
└── share
    ├── ament_index
    │   └── resource_index
    │       └── packages
    │           └── mre_description
    └── mre_description
        ├── meshes
        │   ├── torus.mtl
        │   └── torus.obj
        ├── mre.urdf
        └── package.xml

```
files: [mre.tar.gz](https://github.com/ros2/rviz/files/5752731/mre.tar.gz)

In one terminal
```console
$ cd mre
$ export AMENT_PREFIX_PATH="$AMENT_PREFIX_PATH:$(pwd)"
$ ./mre_pub.py
```

In another terminal

```console
$ cd mre
$ export AMENT_PREFIX_PATH="$AMENT_PREFIX_PATH:$(pwd)"
$ rviz2
# Now add a RobotModel display, set the topic to /robot_description, and change RViz's frame to `link`
```

On the latest Rolling release I don't see the robot model, and the rviz console shows the following error:

```
QStandardPaths: XDG_RUNTIME_DIR points to non-existing path '/run/user/1000', please create it with 0700 permissions.
Gtk-Message: 17:56:45.650: Failed to load module "canberra-gtk-module"
Gtk-Message: 17:56:45.650: Failed to load module "canberra-gtk-module"
QStandardPaths: XDG_RUNTIME_DIR points to non-existing path '/run/user/1000', please create it with 0700 permissions.
Qt: Session management error: None of the authentication protocols specified are supported
[INFO] [1609293406.146870694] [rviz2]: Stereo is NOT SUPPORTED
[INFO] [1609293406.146964002] [rviz2]: OpenGl version: 4.6 (GLSL 4.6)
[INFO] [1609293406.224437166] [rviz2]: Stereo is NOT SUPPORTED
[ERROR] [1609293427.006568758] [rviz2]: Could not load resource [package://mre_description/meshes/torus.obj]: BLEND: BLENDER magic bytes are missing, couldn't find GZIP header either
[ERROR] [1609293427.006751008] [rviz2]: FileNotFoundException: Cannot locate resource package://mre_description/meshes/torus.obj in resource group OgreAutodetect. in ResourceGroupManager::openResource at /tmp/binarydeb/ros-rolling-rviz-ogre-vendor-8.3.0/obj-x86_64-linux-gnu/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 703)
[ERROR] [1609293427.006982996] [rviz2]: could not load model 'package://mre_description/meshes/torus.obj' for link 'link': FileNotFoundException: Cannot locate resource package://mre_description/meshes/torus.obj in resource group OgreAutodetect. in ResourceGroupManager::openResource at /tmp/binarydeb/ros-rolling-rviz-ogre-vendor-8.3.0/obj-x86_64-linux-gnu/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 703)
[ERROR] [1609293427.007408963] [rviz2]: Could not load resource [package://mre_description/meshes/torus.obj]: BLEND: BLENDER magic bytes are missing, couldn't find GZIP header either
[ERROR] [1609293427.007509128] [rviz2]: FileNotFoundException: Cannot locate resource package://mre_description/meshes/torus.obj in resource group OgreAutodetect. in ResourceGroupManager::openResource at /tmp/binarydeb/ros-rolling-rviz-ogre-vendor-8.3.0/obj-x86_64-linux-gnu/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 703)
[ERROR] [1609293427.007589112] [rviz2]: could not load model 'package://mre_description/meshes/torus.obj' for link 'link': FileNotFoundException: Cannot locate resource package://mre_description/meshes/torus.obj in resource group OgreAutodetect. in ResourceGroupManager::openResource at /tmp/binarydeb/ros-rolling-rviz-ogre-vendor-8.3.0/obj-x86_64-linux-gnu/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreResourceGroupManager.cpp (line 703)
```


