### PR TITLE
Fix a memory leak when using the ResourceIOSystem.

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -136,19 +136,9 @@ private:
   uint8_t * pos_;
 };
 
-class ResourceIOSystem : public Assimp::IOSystem
+class ResourceIOSystem final : public Assimp::IOSystem
 {
 public:
-  struct RetrieverResult
-  {
-    RetrieverResult(bool resource_exists, Assimp::IOStream * resource_io_stream)
-    : resource_exists_(resource_exists),
-      resource_io_stream_(resource_io_stream) {}
-
-    bool resource_exists_;
-    Assimp::IOStream * resource_io_stream_;
-  };
-
   ResourceIOSystem() = default;
 
   ~ResourceIOSystem() override = default;
@@ -162,16 +152,18 @@ public:
   // Check whether a specific file exists
   bool Exists(const char * file) const override
   {
-    return checkExistsAndOpen(file).resource_exists_;
+    try {
+      resource_retriever::MemoryResource res = retriever_.get(file);
+    } catch (const resource_retriever::Exception & e) {
+      (void) e;  // do nothing on exception
+      return false;
+    }
+
+    return true;
   }
 
   // ... and finally a method to open a custom stream
   Assimp::IOStream * Open(const char * file, const char * mode = "rb") override
-  {
-    return checkExistsAndOpen(file, mode).resource_io_stream_;
-  }
-
-  RetrieverResult checkExistsAndOpen(const char * file, const char * mode = "rb") const
   {
     (void) mode;
     assert(mode == std::string("r") || mode == std::string("rb"));
@@ -179,12 +171,13 @@ public:
     resource_retriever::MemoryResource res;
     try {
       res = retriever_.get(file);
-    } catch (resource_retriever::Exception & e) {
+    } catch (const resource_retriever::Exception & e) {
       (void) e;  // do nothing on exception
-      return RetrieverResult(false, nullptr);
+      return nullptr;
     }
 
-    return RetrieverResult(true, new ResourceIOStream(res));
+    // This will get freed when 'Close' is called
+    return new ResourceIOStream(res);
   }
 
   void Close(Assimp::IOStream * stream) override


### PR DESCRIPTION
clang static analysis pointed out that when using the "Exists"
method of the ResourceIOSystem, we would leak the newly
created ResourceIOStream.  While I was in there looking at it,
I noticed that the way it went about things was unnecessarily
complicated by the additional structure and 'checkExistsAndOpen'
method.  Instead, just open code the small amount of code
necessary to determine if the file exists (for Exists), and
to actually open the file (for Open).  This simplifies the
code and fixes the memory leak.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>