### PR TITLE
Add an override flag to force vendored build

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rviz_assimp_vendor)
 
+option(FORCE_BUILD_VENDOR_PKG
+  "Build assimp from source, even if system-installed package is available"
+  OFF)
+
 find_package(ament_cmake REQUIRED)
 
 set(PACKAGE_VERSION "1.0.0")
@@ -61,7 +65,7 @@ set(ON 1)
 
 find_package(assimp QUIET)
 
-if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 4.1.0)
+if(FORCE_BUILD_VENDOR_PKG OR NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 4.1.0)
   build_assimp()
 
   if(WIN32)


### PR DESCRIPTION
Nearly all of the other vendor packages in the critical path to the desktop variant support this flag, which can be very useful in testing.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13585)](http://ci.ros2.org/job/ci_linux/13585/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8473)](http://ci.ros2.org/job/ci_linux-aarch64/8473/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11303)](http://ci.ros2.org/job/ci_osx/11303/) <-- Test failures are in the [nightly build, too](https://ci.ros2.org/view/nightly/job/nightly_osx_repeated/2238/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13647)](http://ci.ros2.org/job/ci_windows/13647/)

With the new flag specified:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13586)](http://ci.ros2.org/job/ci_linux/13586/)