### PR TITLE
Silence a dead store warning.

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -477,10 +477,10 @@ void AssimpLoader::declareVertexBufferOrdering(
   if (input_mesh->HasTextureCoords(0)) {
     vertex_decl->addElement(0, offset, Ogre::VET_FLOAT2, Ogre::VES_TEXTURE_COORDINATES, 0);
     offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
-    (void)offset;
   }
 
   // TODO(anyone): vertex colors
+  (void)offset;
 }
 
 Ogre::HardwareVertexBufferSharedPtr

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -477,6 +477,7 @@ void AssimpLoader::declareVertexBufferOrdering(
   if (input_mesh->HasTextureCoords(0)) {
     vertex_decl->addElement(0, offset, Ogre::VET_FLOAT2, Ogre::VES_TEXTURE_COORDINATES, 0);
     offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+    (void)offset;
   }
 
   // TODO(anyone): vertex colors


### PR DESCRIPTION
clang static analysis points out that the value stored into
offset is never read near the end of declareVertexBufferOrdering.
While that is technically correct, removing the store is
dangerous; any code that is later added will have to remember
to store it again.  Instead of removing the store, just put
'(void)offset;' at the end to tell clang not to warn about it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>