### PR TITLE
Always preserve source permissions in vendor packages

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -54,6 +54,7 @@ macro(build_assimp)
       ${CMAKE_CURRENT_BINARY_DIR}/assimp_install/
     DESTINATION
       ${CMAKE_INSTALL_PREFIX}/opt/rviz_assimp_vendor
+    USE_SOURCE_PERMISSIONS
   )
 endmacro()
 

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -59,6 +59,7 @@ macro(build_freetype)
       ${CMAKE_CURRENT_BINARY_DIR}/freetype_install/
     DESTINATION
       ${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor
+    USE_SOURCE_PERMISSIONS
   )
 endmacro()
 
@@ -97,6 +98,7 @@ macro(build_zlib)
       ${CMAKE_CURRENT_BINARY_DIR}/zlib-install/
     DESTINATION
       ${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor
+    USE_SOURCE_PERMISSIONS
   )
 endmacro()
 
@@ -198,6 +200,7 @@ macro(build_ogre)
       ${CMAKE_CURRENT_BINARY_DIR}/ogre_install/
     DESTINATION
       ${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor
+    USE_SOURCE_PERMISSIONS
   )
 endmacro()
 


### PR DESCRIPTION
In vendor packages where we're installing an executable, we use USE_SOURCE_PERMISSIONS to make sure that the executable permissions on the binaries are maintained when the external project's staging directory is recursively installed to the final installation directory.

In most of our vendor packages, we aren't using that flag where we don't expect an executable binary to be installed. However, for reasons I won't go into here, some systems use executable permissions on shared object libraries as well. The linker seems to handle this on our behalf, but we're losing the permissions during the recursive copy operation if we don't use this flag.

Unfortunately, this flag is missing in needed in nearly all of the ROS 2 vendor packages. It doesn't seem to cause a fatal problem in using the packages, but affects processes like symbol extraction during RPM builds.

This particular change fixes the symbol extraction for `rviz_ogre_vendor`, which slashes the installed size of the package by around 200 MiB, which currently makes up about 1/3 of the content of `/opt/ros/rolling` for the `desktop` variant.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13637)](http://ci.ros2.org/job/ci_linux/13637/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8517)](http://ci.ros2.org/job/ci_linux-aarch64/8517/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11351)](http://ci.ros2.org/job/ci_osx/11351/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13698)](http://ci.ros2.org/job/ci_windows/13698/)