### PR TITLE
Allow to zoom more with orbit controller

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
@@ -72,7 +72,7 @@ OrbitViewController::OrbitViewController()
   distance_property_ = new FloatProperty(
     "Distance", DISTANCE_START,
     "Distance from the focal point.", this);
-  distance_property_->setMin(0.01f);
+  distance_property_->setMin(0.001f);
 
   focal_shape_size_property_ = new FloatProperty(
     "Focal Shape Size", FOCAL_SHAPE_SIZE_START,


### PR DESCRIPTION
Port of https://github.com/ros-visualization/rviz/pull/1373

This allows to zoom more on small objects with the orbit controller.