### PR TITLE
fix toolbar vanishing when pressing escape

### DIFF
--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -119,6 +119,7 @@ VisualizationFrame::VisualizationFrame(
   loading_(false),
   post_load_timer_(new QTimer(this)),
   frame_count_(0),
+  toolbar_visible_(true),
   rviz_ros_node_(rviz_ros_node)
 {
   setObjectName("VisualizationFrame");
@@ -1205,8 +1206,13 @@ void VisualizationFrame::onDeletePanel()
 
 void VisualizationFrame::setFullScreen(bool full_screen)
 {
+  auto state = windowState();
+  if (full_screen == state.testFlag(Qt::WindowFullScreen)) {
+    return;
+  }
   Q_EMIT (fullScreenChange(full_screen));
 
+  // When switching to fullscreen, remember visibility state of toolbar
   if (full_screen) {
     toolbar_visible_ = toolbar_->isVisible();
   }
@@ -1216,9 +1222,9 @@ void VisualizationFrame::setFullScreen(bool full_screen)
   setHideButtonVisibility(!full_screen);
 
   if (full_screen) {
-    setWindowState(windowState() | Qt::WindowFullScreen);
+    setWindowState(state | Qt::WindowFullScreen);
   } else {
-    setWindowState(windowState() & ~Qt::WindowFullScreen);
+    setWindowState(state & ~Qt::WindowFullScreen);
   }
   show();
 }


### PR DESCRIPTION
Ports the fix from https://github.com/ros-visualization/rviz/pull/1256 

> The fullscreen code does not properly keep track of the toolbar visibility state. This leads to the following undesired behaviour:
> 
> - Pressing esc without ever having entered fullscreen may hides the toolbar because toolbar_visible_ is never set.
> - Pressing esc after having entered fullscreen previously sets the toolbar visibility to what it was the last time fullscreen was entered.
> 
> By only calling setFullScreen(false) after we really were in fullscreen mode, we guarantee that toolbar_visible_ is valid and don't mess with the toolbar visibility otherwise.