### PR TITLE
Add get3DPatch to ViewPicker public API

### DIFF
--- a/rviz_common/include/rviz_common/interaction/view_picker.hpp
+++ b/rviz_common/include/rviz_common/interaction/view_picker.hpp
@@ -98,11 +98,6 @@ public:
     int y,
     Ogre::Vector3 & result_point) override;
 
-private:
-  void setDepthTextureSize(unsigned width, unsigned height);
-
-  void capTextureSize(unsigned int & width, unsigned int & height);
-
   /// Gets the 3D points in a box around a point in a view port.
   /**
    * \param[in] viewport Rendering area clicked on.
@@ -125,7 +120,12 @@ private:
     unsigned width,
     unsigned height,
     bool skip_missing,
-    std::vector<Ogre::Vector3> & result_points);
+    std::vector<Ogre::Vector3> & result_points) override;
+
+private:
+  void setDepthTextureSize(unsigned width, unsigned height);
+
+  void capTextureSize(unsigned int & width, unsigned int & height);
 
   /**
    * \param[in] panel Rendering area clicked on.

--- a/rviz_common/include/rviz_common/interaction/view_picker_iface.hpp
+++ b/rviz_common/include/rviz_common/interaction/view_picker_iface.hpp
@@ -31,9 +31,11 @@
 #ifndef RVIZ_COMMON__INTERACTION__VIEW_PICKER_IFACE_HPP_
 #define RVIZ_COMMON__INTERACTION__VIEW_PICKER_IFACE_HPP_
 
-#include "rviz_common/visibility_control.hpp"
+#include <vector>
 
 #include <OgreVector3.h>
+
+#include "rviz_common/visibility_control.hpp"
 
 namespace Ogre
 {
@@ -65,6 +67,19 @@ public:
     int x,
     int y,
     Ogre::Vector3 & result_point) = 0;
+
+  /// Return true if the point at x,y in the viewport is showing an object, false otherwise.
+  /**
+   * Gets the 3D points in a box around a point in a view port.
+   */
+  virtual bool get3DPatch(
+    RenderPanel * panel,
+    int x,
+    int y,
+    unsigned width,
+    unsigned height,
+    bool skip_missing,
+    std::vector<Ogre::Vector3> & result_points) = 0;
 };
 
 }  // namespace interaction

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_selection_manager.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_selection_manager.hpp
@@ -63,6 +63,9 @@ public:
   MOCK_METHOD1(setTextureSize, void(unsigned int));
 
   MOCK_METHOD4(get3DPoint, bool(Ogre::Viewport *, int, int, Ogre::Vector3 &));
+  MOCK_METHOD7(
+    get3DPatch, bool(Ogre::Viewport *, int, int, unsigned, unsigned,
+    bool, std::vector<Ogre::Vector3>&));
   MOCK_METHOD0(getPropertyModel, rviz_common::properties::PropertyTreeModel *());
 };
 

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_view_picker.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_view_picker.hpp
@@ -73,6 +73,22 @@ public:
     return false;
   }
 
+  bool get3DPatch(
+    rviz_common::RenderPanel * panel, int x, int y, unsigned width, unsigned height,
+    bool skip_missing, std::vector<Ogre::Vector3> & result_points) override
+  {
+    (void) panel;
+    (void) skip_missing;
+
+    for (const auto & object : view_objects) {
+      if (object.x == x && object.y == y) {
+        result_points = std::vector<Ogre::Vector3>(width * height, object.position);
+        return true;
+      }
+    }
+    return false;
+  }
+
   void registerObject(const Visible3DObject & object)
   {
     view_objects.push_back(object);


### PR DESCRIPTION
`ViewPicker::get3DPatch` is currently a private member function of the ViewPicker class. It would be very useful to make it public, since this lets us develop plugins that can use the orientations of mesh surfaces and point clouds in the 3D scene. This change moves it from the private API to the public API.

~~Additionally, the method in which OGRE packs depth pixel data has changed in the version currently used by RViz2. In ROS Melodic RViz each `uint32` pixel was represented by 4 sequential `uint8` elements in an array, but only the first 3 elements  actually contained useful data and the 4th element was discarded. In the current version (I'm testing with Foxy right now) it looks like each depth pixel is now represented by just 3 sequential `uint8` elements, without the 4th "empty" index. This means that the previous method of accessing the data for each pixel by index relative to the start of the array no longer works correctly and returns mangled or misaligned data for all pixels after the first. A change to the data pointer indexing method in the `ViewPicker::getPatchDepthImage` function was needed to correctly calculate distances from the scene camera when getting patches containing more than one pixel.~~

~~The data indexing bug did not cause problems previously because it does not affect the depth value for the first pixel in the array. `ViewPicker::getPatchDepthImage` is only used by `ViewPicker::get3DPatch`, which is itself only used by `ViewPicker::get3DPoint` to get a single-pixel patch. This issue is also somewhat challenging to demonstrate, since I think the current RViz test suite only uses mock versions of these functions.~~

https://github.com/ros2/rviz/pull/661 now contains the pixel byte indexing fix described above which was originally part of this PR.

Signed-off-by: Joe Schornak <joe.schornak@gmail.com>