### PR TITLE
Add visualization_frame to the public API

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -123,7 +123,7 @@ set(rviz_common_headers_to_moc
   include/rviz_common/view_controller.hpp
   include/rviz_common/view_manager.hpp
   src/rviz_common/views_panel.hpp
-  src/rviz_common/visualization_frame.hpp
+  include/rviz_common/visualization_frame.hpp
   src/rviz_common/widget_geometry_change_detector.hpp
   include/rviz_common/ros_topic_display.hpp
 )

--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -215,6 +215,14 @@ public:
   void
   setHideButtonVisibility(bool visible);
 
+  /// Add a panel by a given name and class name.
+  QDockWidget *
+  addPanelByName(
+      const QString & name,
+      const QString & class_lookup_name,
+      Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
+      bool floating = true);
+
 public Q_SLOTS:
   /// Notification that something would change in the display config if saved.
   void
@@ -413,14 +421,6 @@ protected:
   /// Called by markRecentConfig().
   void
   updateRecentConfigMenu();
-
-  /// Add a panel by a given name and class name.
-  QDockWidget *
-  addPanelByName(
-    const QString & name,
-    const QString & class_lookup_name,
-    Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
-    bool floating = true);
 
   /// Loads custom panels from the given Config object.
   void

--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -218,10 +218,10 @@ public:
   /// Add a panel by a given name and class name.
   QDockWidget *
   addPanelByName(
-      const QString & name,
-      const QString & class_lookup_name,
-      Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
-      bool floating = true);
+    const QString & name,
+    const QString & class_lookup_name,
+    Qt::DockWidgetArea area = Qt::LeftDockWidgetArea,
+    bool floating = true);
 
 public Q_SLOTS:
   /// Notification that something would change in the display config if saved.

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -29,7 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "visualization_frame.hpp"
+#include "rviz_common/visualization_frame.hpp"
 
 #include <exception>
 #include <fstream>

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -47,7 +47,7 @@
 #include "rviz_common/logging.hpp"
 #include "rviz_rendering/ogre_logging.hpp"
 
-#include "./visualization_frame.hpp"
+#include "rviz_common/visualization_frame.hpp"
 #include "rviz_common/visualization_manager.hpp"
 
 // TODO(wjwwood): figure out a non-depricated way to do this


### PR DESCRIPTION
[moveit_task_constructor_visualization](https://github.com/ros-planning/moveit_task_constructor/) package uses the `VisualizationFrame` to make sure all the displays share a singleton panel, this class was public in ROS1