### PR TITLE
Fix byte indexing for depth patch pixels in ViewPicker::getPatchDepthImage

### DIFF
--- a/rviz_common/src/rviz_common/interaction/view_picker.cpp
+++ b/rviz_common/src/rviz_common/interaction/view_picker.cpp
@@ -170,10 +170,15 @@ void ViewPicker::getPatchDepthImage(
 
   auto data_ptr = static_cast<uint8_t *>(depth_pixel_box_.data);
 
+  // Assert that depth_pixel_box_ represents each depth pixel using 3 elements of type uint8_t,
+  // and that the series of pixels in depth_pixel_box_.data is a contiguous array of sets of 3.
+  // This ensures that the distance value at each pixel is composed using the correct indices.
+  assert(Ogre::PF_R8G8B8 == depth_pixel_box_.format);
+
   for (uint32_t pixel = 0; pixel < num_pixels; ++pixel) {
-    uint8_t a = data_ptr[4 * pixel];
-    uint8_t b = data_ptr[4 * pixel + 1];
-    uint8_t c = data_ptr[4 * pixel + 2];
+    uint8_t a = data_ptr[3 * pixel];
+    uint8_t b = data_ptr[3 * pixel + 1];
+    uint8_t c = data_ptr[3 * pixel + 2];
 
     int int_depth = (c << 16) | (b << 8) | a;
     float normalized_depth = (static_cast<float>(int_depth)) / static_cast<float>(0xffffff);


### PR DESCRIPTION
Originally in https://github.com/ros2/rviz/pull/657; split off to separate a bugfix from an API change.

The method in which OGRE packs depth pixel data has changed in the version currently used by RViz2. In ROS Melodic RViz each uint32 pixel was represented by 4 sequential uint8 elements in an array, but only the first 3 elements actually contained useful data and the 4th element was discarded. In the current version (I'm testing with Foxy right now) it looks like each depth pixel is now represented by just 3 sequential uint8 elements, without the 4th "empty" index. This means that the previous method of accessing the data for each pixel by index relative to the start of the array no longer works correctly and returns mangled or misaligned data for all pixels after the first. A change to the data pointer indexing method in the ViewPicker::getPatchDepthImage function was needed to correctly calculate distances from the scene camera when getting patches containing more than one pixel. A new assert checks that the depth patch uses the expected data format before accessing pixel data.

The data indexing bug did not cause problems previously because it does not affect the depth value for the first pixel in the array. ViewPicker::getPatchDepthImage is only used by ViewPicker::get3DPatch, which is itself only used by ViewPicker::get3DPoint to get a single-pixel patch. This issue is also somewhat challenging to demonstrate, since I think the current RViz test suite only uses mock versions of these functions.

Signed-off-by: Joe Schornak <joe.schornak@gmail.com>