### PR TITLE
Putting glsl 1.50 resources back in RenderSystem

### DIFF
--- a/rviz_rendering/include/rviz_rendering/render_system.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_system.hpp
@@ -80,6 +80,7 @@ public:
   getGlVersion();
 
   /// return GLSL Version as integer, e.g. 150 for GLSL 1.50
+  RVIZ_RENDERING_PUBLIC
   int
   getGlslVersion();
 

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -335,14 +335,12 @@ RenderSystem::setupResources()
   // Unfortunately, Ogre doesn't have a notion of glsl versions so we can't go
   // the 'official' way of defining multiple schemes per material and let Ogre
   // decide which one to use.
-  // TODO(wjwwood): figure out why includes don't work on 150
-  // if (getGlslVersion() >= 150) {
-  //   Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
-  //     rviz_path + "/ogre_media/materials/glsl150", "FileSystem", "rviz_rendering");
-  //   Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
-  //     rviz_path + "/ogre_media/materials/scripts150", "FileSystem", "rviz_rendering");
-  // } else if (getGlslVersion() >= 120) {
-  if (getGlslVersion() >= 120) {
+  if (getGlslVersion() >= 150) {
+    Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
+      rviz_path + "/ogre_media/materials/glsl150", "FileSystem", "rviz_rendering");
+    Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
+      rviz_path + "/ogre_media/materials/scripts150", "FileSystem", "rviz_rendering");
+  } else if (getGlslVersion() >= 120) {
     Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
       rviz_path + "/ogre_media/materials/scripts120", "FileSystem", "rviz_rendering");
   } else {

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
@@ -83,13 +83,26 @@ TEST_F(PointCloudRenderableTestFixture, renderable_contains_a_correctly_filled_b
   size_t vertex_size = renderable_->getBuffer()->getVertexSize();
   size_t number_of_vertices = renderable_->getBuffer()->getNumVertices();
 
-  size_t size_of_single_vertex = 3 * 8 + 4;  // three floats + 4 bytes for color
-  size_t vertices_added = 3 * 1;  // three vertices per point
+  size_t size_of_single_vertex {0};
+  size_t vertices_added {0};
+
+  int glsl_version = testing_environment_->getGlslVersion();
+  if (glsl_version >= 150) {
+    size_of_single_vertex = 3 * 4 + 4;  // position + color
+    vertices_added = 1;
+    ASSERT_THAT(
+      renderable_->getRenderOperation()->operationType,
+      Eq(Ogre::RenderOperation::OT_POINT_LIST));
+  } else if (glsl_version >= 120) {
+    size_of_single_vertex = 3 * 4 + 3 * 4 + 4;  // position + texture coordinates + color
+    vertices_added = 3 * 1;  // three vertices per point
+    ASSERT_THAT(
+      renderable_->getRenderOperation()->operationType,
+      Eq(Ogre::RenderOperation::OT_TRIANGLE_LIST));
+  }
 
   ASSERT_THAT(vertex_size, Eq(size_of_single_vertex));
   ASSERT_THAT(number_of_vertices, Eq(vertices_added));
-  ASSERT_THAT(
-    renderable_->getRenderOperation()->operationType, Eq(Ogre::RenderOperation::OT_TRIANGLE_LIST));
 }
 
 TEST_F(

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
@@ -245,6 +245,7 @@ TEST_F(PointCloudTestFixture, setRenderMode_changes_material) {
 TEST_F(
   PointCloudTestFixture,
   setRenderMode_regenerates_renderables_with_different_size_when_geometry_support_changes) {
+  int glsl_version = testing_environment_->getGlslVersion();
   auto point_cloud = std::make_shared<rviz_rendering::PointCloud>();
   point_cloud->addPoints(singlePointArray.begin(), singlePointArray.end());
 
@@ -260,7 +261,12 @@ TEST_F(
 
   renderables = point_cloud->getRenderables();
   for (auto const & renderable : renderables) {
-    size_t number_of_vertices_per_box = 6 * 3 * 2;  // six sides with two triangles each
+    size_t number_of_vertices_per_box {0};
+    if (glsl_version >= 150) {
+      number_of_vertices_per_box = 1;
+    } else if (glsl_version >= 120) {
+      number_of_vertices_per_box = 6 * 3 * 2;  // six sides with two triangles each
+    }
     ASSERT_THAT(renderable->getBuffer()->getNumVertices(), Eq(number_of_vertices_per_box));
   }
 }
@@ -278,9 +284,15 @@ TEST_F(PointCloudTestFixture, addPoints_adds_new_renderable_whenever_it_is_calle
 
 
 TEST_F(PointCloudTestFixture, addPoints_adds_vertices_with_correct_geometry_when_called) {
+  int glsl_version = testing_environment_->getGlslVersion();
   auto point_cloud = std::make_shared<rviz_rendering::PointCloud>();
   point_cloud->setRenderMode(rviz_rendering::PointCloud::RM_FLAT_SQUARES);
-  size_t number_of_vertices_per_flat_square = 3 * 2;  // two triangles for one square
+  size_t number_of_vertices_per_flat_square = {0};
+  if (glsl_version >= 150) {
+    number_of_vertices_per_flat_square = 1;
+  } else if (glsl_version >= 120) {
+    number_of_vertices_per_flat_square = 3 * 2;  // two triangles for one square
+  }
 
   point_cloud->addPoints(singlePointArray.begin(), singlePointArray.end());
 

--- a/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
+++ b/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
@@ -53,4 +53,9 @@ void OgreTestingEnvironment::setUpRenderSystem()
   RenderSystem::get();
 }
 
+int OgreTestingEnvironment::getGlslVersion()
+{
+  return RenderSystem::get()->getGlslVersion();
+}
+
 }  // end namespace rviz_rendering

--- a/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
+++ b/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
@@ -53,7 +53,7 @@ void OgreTestingEnvironment::setUpRenderSystem()
   RenderSystem::get();
 }
 
-int OgreTestingEnvironment::getGlslVersion()
+int OgreTestingEnvironment::getGlslVersion() const
 {
   return RenderSystem::get()->getGlslVersion();
 }

--- a/rviz_rendering/test/rviz_rendering/ogre_testing_environment.hpp
+++ b/rviz_rendering/test/rviz_rendering/ogre_testing_environment.hpp
@@ -44,6 +44,8 @@ public:
   void setUpOgreTestEnvironment(bool debug = false);
 
   void setUpRenderSystem();
+
+  int getGlslVersion();
 };
 
 }  // namespace rviz_rendering

--- a/rviz_rendering/test/rviz_rendering/ogre_testing_environment.hpp
+++ b/rviz_rendering/test/rviz_rendering/ogre_testing_environment.hpp
@@ -45,7 +45,7 @@ public:
 
   void setUpRenderSystem();
 
-  int getGlslVersion();
+  int getGlslVersion() const;
 };
 
 }  // namespace rviz_rendering


### PR DESCRIPTION
GLSL version 1.50 resources were left commented out in `RenderSystem` class which resulted in performance hit in pointcloud rendering. #46 mentions this but was left behind for a long time now (2017). 

I tested putting back 1.50 locally and it worked fine on ubuntu 20.04. Therefore I think it is safe to assume that this is no longer an issue.

Presented PR puts back glsl 1.50 resources and updates corresponding unit tests. This improves pointcloud rendering a lot (on my machine it is about 200% for 21mln pointcloud while rendering with primitives).

This may also fix #662