### PR TITLE
👩‍🌾 [backport] [foxy] Make the types explicit in quaternion_helper.hpp. (#625)

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/quaternion_helper.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/quaternion_helper.hpp
@@ -30,7 +30,6 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__ODOMETRY__QUATERNION_HELPER_HPP_
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__ODOMETRY__QUATERNION_HELPER_HPP_
 
-#include <algorithm>
 #include <cmath>
 
 #include <OgreQuaternion.h>
@@ -40,10 +39,11 @@ namespace rviz_default_plugins
 
 float ogreQuaternionAngularDistance(Ogre::Quaternion first, Ogre::Quaternion second)
 {
-  auto product = first * Ogre::Quaternion(second.w, -second.x, -second.y, -second.z);
-  auto imaginary_norm = sqrt(pow(product.x, 2) + pow(product.y, 2) + pow(product.z, 2));
+  Ogre::Quaternion product = first * Ogre::Quaternion(second.w, -second.x, -second.y, -second.z);
+  float imaginary_norm =
+    sqrtf(powf(product.x, 2.0f) + powf(product.y, 2.0f) + powf(product.z, 2.0f));
 
-  return 2 * atan2(imaginary_norm, sqrt(pow(product.w, 2)));
+  return 2.0f * atan2f(imaginary_norm, sqrtf(powf(product.w, 2.0f)));
 }
 
 }  // namespace rviz_default_plugins


### PR DESCRIPTION
Backport #625 

CI building up to `rviz_default_plugins` and testing only `rviz_default_plugins`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14424)](http://ci.ros2.org/job/ci_linux/14424/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9196)](http://ci.ros2.org/job/ci_linux-aarch64/9196/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12097)](http://ci.ros2.org/job/ci_osx/12097/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14525)](http://ci.ros2.org/job/ci_windows/14525/)

---

Windows started complaining that there was possible loss of
precision.  That came about because we were using the 'double'
versions of cmath functions (sqrt, pow, etc).  However, it
turns out that Ogre only deals with floats by default anyway
(and we don't change the default when we vendor it), so switch
all calculations to floats.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

---

https://github.com/osrf/buildfarmer/issues/181