### PR TITLE
Ensure the section handler is not null before using it.

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -267,7 +267,9 @@ void PointCloudCommon::updateBillboardSize()
   }
   for (auto & cloud_info : cloud_infos_) {
     cloud_info->cloud_->setDimensions(size, size, size);
-    cloud_info->selection_handler_->setBoxSize(getSelectionBoxSize());
+    if (cloud_info->selection_handler_) {
+      cloud_info->selection_handler_->setBoxSize(getSelectionBoxSize());
+    }
   }
   context_->queueRender();
 }


### PR DESCRIPTION
The selection checkbox creates or releases the selection handler.
Since it may or may not be presently allocated, it needs to be
checked before use.

Fixes #669

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>