### PR TITLE
Update includes after rcutils/get_env.h deprecation

### DIFF
--- a/rviz_visual_testing_framework/src/internal/visual_test.cpp
+++ b/rviz_visual_testing_framework/src/internal/visual_test.cpp
@@ -38,7 +38,7 @@
 
 #include <QDir>  // NOLINT
 
-#include "rcutils/get_env.h"
+#include "rcutils/env.h"
 
 VisualTest::VisualTest(
   rviz_common::VisualizerApp * vapp,


### PR DESCRIPTION
https://github.com/ros2/rcutils/pull/340 deprecates `rcutils/get_env.h`. This PR doesn't need to wait until the `rcutils` PR is merged, though.