### PR TITLE
Glsl override for nouveau

### DIFF
--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -240,12 +240,14 @@ RenderSystem::detectGlVersion()
       break;
   }
 
+  #ifdef __linux__
   // TODO(pijaro): Nouveanu driver doesn't support glsl150 even if it "should", figure out why.
   // We fix version to 120 since this is the one we are currently using in materials.
   std::string vendor_name = (const char *)glGetString(GL_VENDOR);
   if (vendor_name == "nouveau" && glsl_version_ > 120) {
     glsl_version_ = 120;
   }
+  #endif
 
   RVIZ_RENDERING_LOG_INFO_STREAM(
     "OpenGl version: " << gl_version_ / 100.0 << " (GLSL " << glsl_version_ / 100.0 << ")"

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -241,10 +241,10 @@ RenderSystem::detectGlVersion()
   }
 
   #ifdef __linux__
-  // TODO(pijaro): Nouveanu driver doesn't support glsl150 even if it "should", figure out why.
+  // TODO(pijaro): Nouveanu and Intel drivers don't support glsl150 even if they "should".
   // We fix version to 120 since this is the one we are currently using in materials.
   std::string vendor_name = (const char *)glGetString(GL_VENDOR);
-  if (vendor_name == "nouveau" && glsl_version_ > 120) {
+  if ((vendor_name == "nouveau" || vendor_name == "Intel") && glsl_version_ > 120) {
     glsl_version_ = 120;
   }
   #endif

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -239,6 +239,14 @@ RenderSystem::detectGlVersion()
       }
       break;
   }
+
+  // TODO(pijaro): Nouveanu driver doesn't support glsl150 even if it "should", figure out why.
+  // We fix version to 120 since this is the one we are currently using in materials.
+  std::string vendor_name = (const char *)glGetString(GL_VENDOR);
+  if (vendor_name == "nouveau" && glsl_version_ > 120) {
+    glsl_version_ = 120;
+  }
+
   RVIZ_RENDERING_LOG_INFO_STREAM(
     "OpenGl version: " << gl_version_ / 100.0 << " (GLSL " << glsl_version_ / 100.0 << ")"
   );


### PR DESCRIPTION
There is an issue with Nouveau drivers with glsl150 shaders (introduced in PR #668). 

It looks like Nouveau can't use GLSL 1.50 programs, even if the driver reports that it supports even newer version of GLSL.

Proposed piece of code is a workaround for Nouveau driver users in linux. It sets the rviz glsl version to 1.20 which works fine (but is slower than 1.50).