### PR TITLE
Add support for namespace-scoped DELETEALL action in Marker displays. 

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -204,7 +204,11 @@ void MarkerCommon::processMessage(const visualization_msgs::msg::Marker::ConstSh
       break;
 
     case visualization_msgs::msg::Marker::DELETEALL:
-      deleteAllMarkers();
+      if (!message->ns.empty()) {
+        deleteMarkersInNamespace(message->ns);
+      } else {
+        deleteAllMarkers();
+      }
       break;
 
     default:

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_common_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_common_test.cpp
@@ -87,6 +87,20 @@ visualization_msgs::msg::Marker::SharedPtr createSharedPtrMessage(
   return std::make_shared<visualization_msgs::msg::Marker>(marker);
 }
 
+visualization_msgs::msg::Marker::SharedPtr createSharedPtrMessage(
+  int32_t action, int32_t type, const std::string & ns)
+{
+  auto marker = createSharedPtrMessage(action, type);
+  marker->ns = ns;
+  return marker;
+}
+
+visualization_msgs::msg::Marker::SharedPtr createSharedPtrMessage(
+  int32_t action, const std::string & ns)
+{
+  return createSharedPtrMessage(action, -1, ns);
+}
+
 TEST_F(MarkerCommonFixture, processMessage_creates_correct_marker_on_add_type) {
   mockValidTransform();
 
@@ -120,6 +134,30 @@ TEST_F(MarkerCommonFixture, processMessage_deletes_correct_marker_on_delete_type
       visualization_msgs::msg::Marker::DELETE,
       visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
       0));
+
+  ASSERT_FALSE(rviz_default_plugins::findOneMovableText(scene_manager_->getRootSceneNode()));
+  ASSERT_TRUE(rviz_default_plugins::findOnePointCloud(scene_manager_->getRootSceneNode()));
+}
+
+TEST_F(MarkerCommonFixture, processMessage_with_scoped_deleteall_deletes_correct_markers) {
+  mockValidTransform();
+
+  common_->processMessage(
+    createSharedPtrMessage(
+      visualization_msgs::msg::Marker::ADD,
+      visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
+      "ns_a"));
+
+  common_->processMessage(
+    createSharedPtrMessage(
+      visualization_msgs::msg::Marker::ADD,
+      visualization_msgs::msg::Marker::POINTS,
+      "ns_b"));
+
+  common_->processMessage(
+    createSharedPtrMessage(
+      visualization_msgs::msg::Marker::DELETEALL,
+      "ns_a"));
 
   ASSERT_FALSE(rviz_default_plugins::findOneMovableText(scene_manager_->getRootSceneNode()));
   ASSERT_TRUE(rviz_default_plugins::findOnePointCloud(scene_manager_->getRootSceneNode()));


### PR DESCRIPTION
Closes #684. Besides the integration test included in this patch, I've manually tested this works as intended in a local build.

CI up to `rviz_default_plugins`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14609)](http://ci.ros2.org/job/ci_linux/14609/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9364)](http://ci.ros2.org/job/ci_linux-aarch64/9364/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12275)](http://ci.ros2.org/job/ci_osx/12275/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14743)](http://ci.ros2.org/job/ci_windows/14743/)
