### PR TITLE
Don't attempt to moc generate files that don't have QOBJECT.

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -80,9 +80,7 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/displays/grid/grid_display.hpp
   include/rviz_default_plugins/displays/grid_cells/grid_cells_display.hpp
   include/rviz_default_plugins/displays/illuminance/illuminance_display.hpp
-  include/rviz_default_plugins/displays/image/get_transport_from_topic.hpp
   include/rviz_default_plugins/displays/image/image_display.hpp
-  include/rviz_default_plugins/displays/image/image_transport_display.hpp
   include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
   include/rviz_default_plugins/displays/map/map_display.hpp
   include/rviz_default_plugins/displays/marker/marker_common.hpp


### PR DESCRIPTION
This avoids a warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This removes a warning seen on Linux that looks like:

```
Note: No relevant classes found. No output generated.
```

for each of the two files.