### PR TITLE
Fixed segfault when quickly adding image displays

### DIFF
--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -83,6 +83,7 @@ RenderWindowImpl::RenderWindowImpl(QWindow * parent)
 //   enableStereo(true);
 
   // setCameraAspectRatio();
+  eventTimePoint = std::chrono::system_clock::now();
 }
 
 RenderWindowImpl::~RenderWindowImpl()
@@ -258,6 +259,17 @@ RenderWindowImpl::initialize()
 void
 RenderWindowImpl::resize(size_t width, size_t height)
 {
+  // Check how fast we are calling this method
+  auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now() - eventTimePoint).count();
+  eventTimePoint = std::chrono::system_clock::now();
+  // if the time between call is less than 100 milliseconds then we return
+  // otherwise this may generate a crash. Review this issue:
+  // https://github.com/ros2/rviz/issues/202
+  if (diff < 100) {
+    return;
+  }
+
   if (ogre_render_window_) {
     this->setCameraAspectRatio();
     ogre_render_window_->resize(

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
@@ -213,8 +213,10 @@ protected:
   std::vector<Ogre::RenderTargetListener *> pending_listeners_;
   std::vector<uint32_t> pending_visibility_masks_;
 
-  /// \brief timepoint to check the speed of the events received
-  std::chrono::time_point<std::chrono::system_clock> eventTimePoint;
+  /// \brief time point to check the speed of the events received
+  std::chrono::time_point<std::chrono::system_clock> eventTimePoint_;
+  /// \brief time point to check the time since the app was started
+  static std::chrono::time_point<std::chrono::system_clock> timeFromStart_;
 };
 
 }  // namespace rviz_rendering

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
@@ -31,6 +31,7 @@
 #ifndef RVIZ_RENDERING__OGRE_RENDER_WINDOW_IMPL_HPP_
 #define RVIZ_RENDERING__OGRE_RENDER_WINDOW_IMPL_HPP_
 
+#include <chrono>
 #include <functional>
 #include <vector>
 
@@ -211,6 +212,9 @@ protected:
   setupSceneCallback setup_scene_callback_;
   std::vector<Ogre::RenderTargetListener *> pending_listeners_;
   std::vector<uint32_t> pending_visibility_masks_;
+
+  /// \brief timepoint to check the speed of the events received
+  std::chrono::time_point<std::chrono::system_clock> eventTimePoint;
 };
 
 }  // namespace rviz_rendering


### PR DESCRIPTION
This PR fixes this issue https://github.com/ros2/rviz/issues/202. If we call this method many times may generate a crash. I have added a timer to check this.

Signed-off-by: ahcorde <ahcorde@gmail.com>

