### PR TITLE
Remove the word "Alpha" from the splash screen.

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -57,8 +57,9 @@ configure_file(src/rviz_common/env_config.hpp ${ENV_CONFIG_HPP} @ONLY)
 
 # TODO(jsquare): Adopt parameters given here
 set(ENV_CONFIG_CPP ${CMAKE_CURRENT_BINARY_DIR}/src/rviz_common/env_config.cpp)
-set(RVIZ_VERSION "Alpha")
-set(ROS_DISTRO "ROS 2.0")
+ament_package_xml()
+set(RVIZ_VERSION "${rviz_common_VERSION}")
+set(ROS_DISTRO "ROS 2")
 set(OGRE_PLUGIN_PATH "rviz_ogre_vendor")
 configure_file(src/rviz_common/env_config.cpp.in ${ENV_CONFIG_CPP} @ONLY)
 


### PR DESCRIPTION
I think we can safely say rviz2 is no longer alpha.  This
change adds in the current version from the package.xml, though
this is likely to lag behind when a new release is made.  I'm
not quite sure how to improve that.

While we are in here, also switch from the "ROS 2.0" nomenclature
to just "ROS 2".

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>