### PR TITLE
add qt6 & arm64 compatability

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -17,24 +17,24 @@ find_package(rviz_common REQUIRED)
 
 find_package(rviz_ogre_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
-if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
-  get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)
+if(Qt6_FOUND AND WIN32 AND TARGET Qt6::qmake AND NOT TARGET Qt6::windeployqt)
+  get_target_property(_Qt6_qmake_location Qt6::qmake IMPORTED_LOCATION)
 
   execute_process(
-    COMMAND "${_qt5_qmake_location}" -query QT_INSTALL_PREFIX
+    COMMAND "${_Qt6_qmake_location}" -query QT_INSTALL_PREFIX
     RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE qt5_install_prefix
+    OUTPUT_VARIABLE Qt6_install_prefix
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-  set(imported_location "${qt5_install_prefix}/bin/windeployqt.exe")
+  set(imported_location "${Qt6_install_prefix}/bin/windeployqt.exe")
 
   if(EXISTS ${imported_location})
-    add_executable(Qt5::windeployqt IMPORTED)
+    add_executable(Qt6::windeployqt IMPORTED)
 
-    set_target_properties(Qt5::windeployqt PROPERTIES
+    set_target_properties(Qt6::windeployqt PROPERTIES
       IMPORTED_LOCATION ${imported_location}
     )
   endif()
@@ -47,21 +47,21 @@ target_link_libraries(${PROJECT_NAME}
   rviz_common::rviz_common
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
-  Qt5::Widgets
+  Qt6::Widgets
 )
 
 # TODO(wjwwood): find a way to make this optional or to run without "deploying" the
 #                necessary dlls and stuff to the bin folder.
 #                see:
 # https://stackoverflow.com/questions/41193584/deploy-all-qt-dependencies-when-building#41199492
-if(TARGET Qt5::windeployqt)
+if(TARGET Qt6::windeployqt)
   # execute windeployqt in a tmp directory after build
   add_custom_command(TARGET ${PROJECT_NAME}
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
-    COMMAND set PATH=%PATH%$<SEMICOLON>${qt5_install_prefix}/bin
+    COMMAND set PATH=%PATH%$<SEMICOLON>${Qt6_install_prefix}/bin
     COMMAND
-    Qt5::windeployqt
+    Qt6::windeployqt
     --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/$<TARGET_FILE_NAME:${PROJECT_NAME}>"
   )

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(ament_cmake REQUIRED)
 # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
 find_package(rviz_ogre_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 find_package(geometry_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -129,7 +129,7 @@ set(rviz_common_headers_to_moc
 )
 
 foreach(header "${rviz_common_headers_to_moc}")
-  qt5_wrap_cpp(rviz_common_moc_files "${header}")
+  Qt6_wrap_cpp(rviz_common_moc_files "${header}")
 endforeach()
 
 set(rviz_common_source_files
@@ -236,7 +236,7 @@ target_link_libraries(rviz_common
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
   rviz_rendering::rviz_rendering
-  Qt5::Widgets
+  Qt6::Widgets
 )
 
 ament_target_dependencies(rviz_common
@@ -319,10 +319,10 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
 
-  qt5_wrap_cpp(rviz_common_test_moc_files test/mock_display.hpp)
-  qt5_wrap_cpp(rviz_common_test_moc_files test/mock_property_change_receiver.hpp)
+  Qt6_wrap_cpp(rviz_common_test_moc_files test/mock_display.hpp)
+  Qt6_wrap_cpp(rviz_common_test_moc_files test/mock_property_change_receiver.hpp)
 
-  qt5_wrap_cpp(rviz_common_test_frame_manager_moc src/rviz_common/frame_manager.hpp)
+  Qt6_wrap_cpp(rviz_common_test_frame_manager_moc src/rviz_common/frame_manager.hpp)
 
   ament_add_gmock(display_factory_test
     test/display_factory_test.cpp
@@ -331,7 +331,7 @@ if(BUILD_TESTING)
   if(TARGET display_factory_test)
     target_compile_definitions(display_factory_test PUBLIC
       -D_TEST_PLUGIN_DESCRIPTIONS="${CMAKE_CURRENT_SOURCE_DIR}")
-    target_link_libraries(display_factory_test rviz_common Qt5::Widgets)
+    target_link_libraries(display_factory_test rviz_common Qt6::Widgets)
   endif()
 
   ament_add_gmock(frame_manager_test
@@ -440,7 +440,7 @@ if(BUILD_TESTING)
     test/mock_property_change_receiver.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET rviz_common_display_test)
-    target_link_libraries(rviz_common_display_test rviz_common Qt5::Widgets)
+    target_link_libraries(rviz_common_display_test rviz_common Qt6::Widgets)
     ament_target_dependencies(rviz_common_display_test yaml_cpp_vendor)
   endif()
 endif()

--- a/rviz_common/rviz_common-extras.cmake
+++ b/rviz_common/rviz_common-extras.cmake
@@ -25,6 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# find package Qt5 because otherwise using the rviz_common::rviz_common
-# exported target will complain that the Qt5::Widgets target does not exist
-find_package(Qt5 REQUIRED QUIET COMPONENTS Widgets)
+# find package Qt6 because otherwise using the rviz_common::rviz_common
+# exported target will complain that the Qt6::Widgets target does not exist
+find_package(Qt6 REQUIRED QUIET COMPONENTS Widgets)

--- a/rviz_common/src/rviz_common/add_display_dialog.cpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.cpp
@@ -29,7 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "./add_display_dialog.hpp"
+#include "add_display_dialog.hpp"
 
 #include <algorithm>
 #include <map>
@@ -594,7 +594,7 @@ void TopicDisplayWidget::findPlugins(DisplayFactory * factory)
       // For now, we assume that all types supported by plugins have the form
       // "<pkg_name>/msg/<type_name>", though in the future zero or more namespaces may be
       // permitted.
-      QRegExp delim("/");
+      QRegularExpression delim("/");
       QStringList topic_type_parts = topic_type.split(delim);
       if (topic_type_parts.size() == 2) {
         topic_type = topic_type_parts.at(0) + "/msg/" + topic_type_parts.at(1);

--- a/rviz_common/src/rviz_common/config.cpp
+++ b/rviz_common/src/rviz_common/config.cpp
@@ -222,7 +222,7 @@ bool Config::mapGetValue(const QString & key, QVariant * value_out) const
 bool Config::mapGetInt(const QString & key, int * value_out) const
 {
   QVariant v;
-  if (mapGetValue(key, &v) && (v.type() == QVariant::Int || v.type() == QVariant::String)) {
+  if (mapGetValue(key, &v) && (v.type() == QMetaType::Int || v.type() == QVariant::String)) {
     bool ok;
     int i = v.toInt(&ok);
     if (ok) {

--- a/rviz_common/src/rviz_common/properties/property_tree_model.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_model.cpp
@@ -186,7 +186,7 @@ QMimeData * PropertyTreeModel::mimeData(const QModelIndexList & indexes) const
   QMimeData * data = new QMimeData();
   QString format = types.at(0);
   QByteArray encoded;
-  QDataStream stream(&encoded, QIODevice::WriteOnly);
+  QDataStream stream(&encoded, QIODeviceBase::WriteOnly);
 
   QModelIndexList::ConstIterator it = indexes.begin();
   for (; it != indexes.end(); ++it) {
@@ -221,7 +221,7 @@ bool PropertyTreeModel::dropMimeData(
     return false;
   }
   QByteArray encoded = data->data(format);
-  QDataStream stream(&encoded, QIODevice::ReadOnly);
+  QDataStream stream(&encoded, QIODeviceBase::ReadOnly);
 
   Property * dest_parent_property = getProp(dest_parent);
 

--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -35,7 +35,7 @@
 
 #include <QKeyEvent>  // NOLINT: cpplint is unable to handle the include order here
 #include <QKeySequence>  // NOLINT: cpplint is unable to handle the include order here
-#include <QRegExp>  // NOLINT: cpplint is unable to handle the include order here
+#include <QRegularExpression>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/logging.hpp"
 
@@ -52,7 +52,7 @@ using rviz_common::properties::PropertyTreeModel;
 
 QString addSpaceToCamelCase(QString input)
 {
-  QRegExp re = QRegExp("([A-Z])([a-z]*)");
+  QRegularExpression re = QRegularExpression("([A-Z])([a-z]*)");
   input.replace(re, " \\1\\2");
   return input.trimmed();
 }

--- a/rviz_common/src/rviz_common/viewport_mouse_event.cpp
+++ b/rviz_common/src/rviz_common/viewport_mouse_event.cpp
@@ -80,7 +80,7 @@ bool ViewportMouseEvent::left()
 
 bool ViewportMouseEvent::middle()
 {
-  return buttons_down & Qt::MidButton;
+  return buttons_down & Qt::MiddleButton;
 }
 
 bool ViewportMouseEvent::right()
@@ -110,7 +110,7 @@ bool ViewportMouseEvent::leftUp()
 
 bool ViewportMouseEvent::middleUp()
 {
-  return type == QEvent::MouseButtonRelease && acting_button == Qt::MidButton;
+  return type == QEvent::MouseButtonRelease && acting_button == Qt::MiddleButton;
 }
 
 bool ViewportMouseEvent::rightUp()
@@ -125,7 +125,7 @@ bool ViewportMouseEvent::leftDown()
 
 bool ViewportMouseEvent::middleDown()
 {
-  return type == QEvent::MouseButtonPress && acting_button == Qt::MidButton;
+  return type == QEvent::MouseButtonPress && acting_button == Qt::MiddleButton;
 }
 
 bool ViewportMouseEvent::rightDown()

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -42,6 +42,7 @@
 #include <OgreMaterialManager.h>
 
 #include <QApplication>  // NOLINT cpplint cannot handle include order here
+#include <QActionGroup>
 #include <QCloseEvent>  // NOLINT cpplint cannot handle include order here
 #include <QDesktopServices>  // NOLINT cpplint cannot handle include order here
 #include <QDir>  // NOLINT cpplint cannot handle include order here
@@ -273,7 +274,7 @@ void VisualizationFrame::initialize(
   QWidget * central_widget = new QWidget(this);
   QHBoxLayout * central_layout = new QHBoxLayout;
   central_layout->setSpacing(0);
-  central_layout->setMargin(0);
+  central_layout->setContentsMargins(0,0,0,0);
 
   render_panel_ = new RenderPanel(central_widget);
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -56,10 +56,10 @@ find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Test)
 
 find_package(geometry_msgs REQUIRED)
-find_package(interactive_markers REQUIRED)
+# find_package(interactive_markers REQUIRED)
 find_package(laser_geometry REQUIRED)
 find_package(map_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
@@ -85,10 +85,10 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/displays/marker/marker_common.hpp
   include/rviz_default_plugins/displays/odometry/odometry_display.hpp
   include/rviz_default_plugins/transformation/transformer_guard.hpp
-  include/rviz_default_plugins/displays/interactive_markers/integer_action.hpp
-  include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
-  include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
-  include/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp
+  # include/rviz_default_plugins/displays/interactive_markers/integer_action.hpp
+  # include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
+  # include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
+  # include/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp
   include/rviz_default_plugins/displays/path/path_display.hpp
   include/rviz_default_plugins/displays/point/point_stamped_display.hpp
   include/rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp
@@ -122,7 +122,7 @@ set(rviz_default_plugins_headers_to_moc
 )
 
 foreach(header "${rviz_default_plugins_headers_to_moc}")
-  qt5_wrap_cpp(rviz_default_plugins_moc_files "${header}")
+  Qt6_wrap_cpp(rviz_default_plugins_moc_files "${header}")
 endforeach()
 
 set(rviz_default_plugins_source_files
@@ -134,11 +134,11 @@ set(rviz_default_plugins_source_files
   src/rviz_default_plugins/displays/illuminance/illuminance_display.cpp
   src/rviz_default_plugins/displays/image/image_display.cpp
   src/rviz_default_plugins/displays/image/ros_image_texture.cpp
-  src/rviz_default_plugins/displays/interactive_markers/integer_action.cpp
-  src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
-  src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
-  src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
-  src/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.cpp
+  # src/rviz_default_plugins/displays/interactive_markers/integer_action.cpp
+  # src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
+  # src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
+  # src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+  # src/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.cpp
   src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
   src/rviz_default_plugins/displays/map/map_display.cpp
   src/rviz_default_plugins/displays/map/palette_builder.cpp
@@ -219,7 +219,7 @@ add_library(rviz_default_plugins SHARED
 target_include_directories(rviz_default_plugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-  ${Qt5Widgets_INCLUDE_DIRS}
+  ${Qt6Widgets_INCLUDE_DIRS}
 )
 
 target_link_libraries(rviz_default_plugins PUBLIC
@@ -239,7 +239,7 @@ pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 ament_target_dependencies(rviz_default_plugins
   PUBLIC
   geometry_msgs
-  interactive_markers
+  # interactive_markers
   laser_geometry
   nav_msgs
   map_msgs
@@ -257,10 +257,10 @@ ament_target_dependencies(rviz_default_plugins
 ament_export_include_directories(include)
 ament_export_targets(rviz_default_plugins HAS_LIBRARY_TARGET)
 ament_export_dependencies(
-  Qt5
+  Qt6
   rviz_common
   geometry_msgs
-  interactive_markers
+  # interactive_markers
   laser_geometry
   map_msgs
   nav_msgs
@@ -310,7 +310,7 @@ if(BUILD_TESTING)
 
   set(TEST_INCLUDE_DIRS
     ${OGRE_INCLUDE_DIRS}
-    ${Qt5Widgets_INCLUDE_DIRS}
+    ${Qt6Widgets_INCLUDE_DIRS}
   )
   ament_include_directories_order(TEST_INCLUDE_DIRS ${TEST_INCLUDE_DIRS})
 
@@ -340,7 +340,7 @@ if(BUILD_TESTING)
   set(TEST_LINK_LIBRARIES
     display_test_fixture
     rviz_default_plugins
-    Qt5::Widgets
+    Qt6::Widgets
   )
 
   ament_add_gmock(fps_view_controller_test
@@ -728,16 +728,16 @@ if(BUILD_TESTING)
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
-  ament_add_gtest(interactive_marker_namespace_property_test
-    test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp)
-  if(TARGET interactive_marker_namespace_property_test)
-    target_include_directories(interactive_marker_namespace_property_test PUBLIC
-      ${TEST_INCLUDE_DIRS})
-    target_link_libraries(interactive_marker_namespace_property_test
-      ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(interactive_marker_namespace_property_test
-      ${TEST_TARGET_DEPENDENCIES})
-  endif()
+  # ament_add_gtest(interactive_marker_namespace_property_test
+  #   test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp)
+  # if(TARGET interactive_marker_namespace_property_test)
+  #   target_include_directories(interactive_marker_namespace_property_test PUBLIC
+  #     ${TEST_INCLUDE_DIRS})
+  #   target_link_libraries(interactive_marker_namespace_property_test
+  #     ${TEST_LINK_LIBRARIES})
+  #   ament_target_dependencies(interactive_marker_namespace_property_test
+  #     ${TEST_TARGET_DEPENDENCIES})
+  # endif()
 
   ament_add_gtest(laser_scan_display_visual_test
     test/rviz_default_plugins/displays/laser_scan/laser_scan_display_visual_test.cpp

--- a/rviz_default_plugins/include/rviz_default_plugins/tools/interaction/interaction_tool.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/tools/interaction/interaction_tool.hpp
@@ -80,7 +80,7 @@ protected:
   {
     // We are dragging if a button was down and is still down
     Qt::MouseButtons buttons = event.buttons_down &
-      (Qt::LeftButton | Qt::RightButton | Qt::MidButton);
+      (Qt::LeftButton | Qt::RightButton | Qt::MiddleButton);
     if (event.type == QEvent::MouseButtonPress) {
       buttons &= ~event.acting_button;
     }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -397,7 +397,7 @@ bool CameraDisplay::updateCamera()
   if (timeDifferenceInExactSyncMode(image, rviz_time)) {
     setStatus(
       StatusLevel::Warn, TIME_STATUS,
-      QString("Time-syncing active and no image at timestamp ") + rviz_time.nanoseconds() + ".");
+      QString("Time-syncing active and no image at timestamp ") + QString::number(rviz_time.nanoseconds()) + ".");
     return false;
   }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -221,7 +221,7 @@ void RobotModelDisplay::load_urdf_from_file(const std::string & filepath)
 {
   std::string content;
   QFile urdf_file(QString::fromStdString(filepath));
-  if (urdf_file.open(QIODevice::ReadOnly)) {
+  if (urdf_file.open(QIODeviceBase::ReadOnly)) {
     content = urdf_file.readAll().toStdString();
     urdf_file.close();
   }

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -120,7 +120,7 @@ macro(build_ogre)
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} /w /EHsc")
   elseif(APPLE)
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -std=c++14 -stdlib=libc++ -w")
-    list(APPEND extra_cmake_args "-DCMAKE_OSX_ARCHITECTURES='x86_64'")
+    list(APPEND extra_cmake_args "-DCMAKE_OSX_ARCHITECTURES='arm64'")
   else()  # Linux
     set(OGRE_C_FLAGS "${OGRE_C_FLAGS} -w")
     # include Clang -Wno-everything to disable warnings in that build. GCC doesn't mind it

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -1845,4 +1845,38 @@ diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
 +#pragma warning(pop)
 +#endif
  #endif
-
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3e09d2d..6a528bb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,7 +43,7 @@ if (APPLE AND NOT ANDROID)
+   endif()
+ 
+   if (NOT CMAKE_OSX_ARCHITECTURES)
+-    set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "") # target the common case
++    set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "") # target the common case
+   endif()
+ 
+   # otherwise apple defines a macro named check that conflicts with boost
+@@ -309,7 +309,7 @@ include(Dependencies)
+ 
+ # Customise what to build
+ option(OGRE_STATIC "Static build" FALSE)
+-option(OGRE_ENABLE_PRECOMPILED_HEADERS "Use precompiled headers to speed up build" TRUE)
++option(OGRE_ENABLE_PRECOMPILED_HEADERS "Use precompiled headers to speed up build" FALSE)
+ set(OGRE_RESOURCEMANAGER_STRICT "2" CACHE STRING 
+   "Make ResourceManager strict for faster operation. Possible values:
+   0 - OFF search in all groups twice - for case sensitive and insensitive lookup [DEPRECATED]
+diff --git a/OgreMain/include/OgrePlatformInformation.h b/OgreMain/include/OgrePlatformInformation.h
+index 8696960..d641fa0 100644
+--- a/OgreMain/include/OgrePlatformInformation.h
++++ b/OgreMain/include/OgrePlatformInformation.h
+@@ -51,7 +51,7 @@ namespace Ogre {
+ 
+ #elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE && defined(__BIG_ENDIAN__)
+ #   define OGRE_CPU OGRE_CPU_PPC
+-#elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE
++#elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE && defined(__x86_64__)
+ #   define OGRE_CPU OGRE_CPU_X86
+ #elif OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS && (defined(__i386__) || defined(__x86_64__))
+ #   define OGRE_CPU OGRE_CPU_X86

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_assimp_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 find_package(ament_index_cpp REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
@@ -40,29 +40,29 @@ find_package(Eigen3 REQUIRED)
 find_package(resource_retriever REQUIRED)
 
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
-if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
-  get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)
+if(Qt6_FOUND AND WIN32 AND TARGET Qt6::qmake AND NOT TARGET Qt6::windeployqt)
+  get_target_property(_Qt6_qmake_location Qt6::qmake IMPORTED_LOCATION)
 
   execute_process(
-    COMMAND "${_qt5_qmake_location}" -query QT_INSTALL_PREFIX
+    COMMAND "${_Qt6_qmake_location}" -query QT_INSTALL_PREFIX
     RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE qt5_install_prefix
+    OUTPUT_VARIABLE Qt6_install_prefix
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-  set(imported_location "${qt5_install_prefix}/bin/windeployqt.exe")
+  set(imported_location "${Qt6_install_prefix}/bin/windeployqt.exe")
 
   if(EXISTS ${imported_location})
-    add_executable(Qt5::windeployqt IMPORTED)
+    add_executable(Qt6::windeployqt IMPORTED)
 
-    set_target_properties(Qt5::windeployqt PROPERTIES
+    set_target_properties(Qt6::windeployqt PROPERTIES
       IMPORTED_LOCATION ${imported_location}
     )
   endif()
 endif()
 
 # These need to be added in the add_library() call
-qt5_wrap_cpp(rviz_rendering_moc_files include/rviz_rendering/render_window.hpp)
+Qt6_wrap_cpp(rviz_rendering_moc_files include/rviz_rendering/render_window.hpp)
 
 add_library(rviz_rendering SHARED
   ${rviz_rendering_moc_files}
@@ -99,7 +99,7 @@ target_link_libraries(rviz_rendering
   PUBLIC
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
-  Qt5::Widgets
+  Qt6::Widgets
   ament_index_cpp::ament_index_cpp
   resource_retriever::resource_retriever
 )
@@ -183,7 +183,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -195,7 +195,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -207,7 +207,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -219,7 +219,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -231,7 +231,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -244,7 +244,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreOverlay
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets
+      Qt6::Widgets
     )
   endif()
 
@@ -256,7 +256,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -268,7 +268,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 endif()

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(ament_cmake REQUIRED)
 if(BUILD_TESTING)
   # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
   find_package(rviz_ogre_vendor REQUIRED)
-  find_package(Qt5 REQUIRED COMPONENTS Widgets)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets)
   find_package(rviz_rendering REQUIRED)
   find_package(resource_retriever REQUIRED)
 

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(rviz_common REQUIRED)
 
 find_package(rviz_ogre_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Test)
 
 find_package(ament_cmake_gtest REQUIRED)
 ament_find_gtest()
@@ -61,17 +61,17 @@ set(visual_test_framework_source_files
 
 set(visual_tests_target_libaries
   rviz_common::rviz_common
-  Qt5::Widgets
-  Qt5::Test)
+  Qt6::Widgets
+  Qt6::Test)
 
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
-if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
-  get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)
+if(Qt6_FOUND AND WIN32 AND TARGET Qt6::qmake AND NOT TARGET Qt6::windeployqt)
+  get_target_property(_Qt6_qmake_location Qt6::qmake IMPORTED_LOCATION)
 
   execute_process(
-    COMMAND "${_qt5_qmake_location}" -query QT_INSTALL_PREFIX
+    COMMAND "${_Qt6_qmake_location}" -query QT_INSTALL_PREFIX
     RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE qt5_install_prefix
+    OUTPUT_VARIABLE Qt6_install_prefix
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 endif()
@@ -88,7 +88,7 @@ target_link_libraries(rviz_visual_testing_framework
 
 # export information to downstream packages
 ament_export_targets(rviz_visual_testing_framework)
-ament_export_dependencies(Qt5)
+ament_export_dependencies(Qt6)
 ament_export_dependencies(rviz_common)
 
 ament_export_include_directories(include)


### PR DESCRIPTION
This add qt6 and arm64 compatibility for the latest mac os big sur on arm64 (m1) --please note: this code is not final yet, this might have to get its own issue branch on the base repo. Will break things on x86_64 unless some backwards compatibility is added.

Tested on mac os big sur 11.4, with qt6 installed through brew. compiles and runs successfully