### PR TITLE
Move changes from #572 into foxy

### DIFF
--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -151,8 +151,8 @@ protected:
 
   virtual void unsubscribe()
   {
-    subscription_.reset();
     tf_filter_.reset();
+    subscription_.reset();
   }
 
   void onEnable() override


### PR DESCRIPTION
The fix from PR #572 is essential to get RViz to work on macOS. Otherwise, crashing RViz is as simple as this:

- Open RViz
- Add /goal_pose to the display
- Uncheck Pose in the left sidebar

The `foxy` branch is what's used for the binary build of ROS2 Foxy on macOS, so this change needs to be in the foxy branch in order for rviz to be usable on macOS. This PR moves that change.