### PR TITLE
Removed some memory leaks in rviz_rendering and rviz_rendering_tests

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -114,6 +114,7 @@ SelectionManager::~SelectionManager()
 
   highlight_node_->getParentSceneNode()->removeAndDestroyChild(highlight_node_);
   delete highlight_rectangle_;
+  context_->getSceneManager()->destroyCamera(camera_);
 
   for (auto & pixel_box : pixel_boxes_) {
     delete[] static_cast<uint8_t *>(pixel_box.data);

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -259,6 +259,7 @@ bool VisualizerApp::init(int argc, char ** argv)
   //
   if (enable_ogre_log) {
     rviz_rendering::OgreLogging::get()->useLogFileAndStandardOut();
+    rviz_rendering::OgreLogging::get()->configureLogging();
   }
   //
   // if (force_gl_version) {

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -258,7 +258,7 @@ bool VisualizerApp::init(int argc, char ** argv)
   // nh_.reset(new ros::NodeHandle);
   //
   if (enable_ogre_log) {
-    rviz_rendering::OgreLogging::useLogFileAndStandardOut();
+    rviz_rendering::OgreLogging::get()->useLogFileAndStandardOut();
   }
   //
   // if (force_gl_version) {

--- a/rviz_common/test/display_context_fixture.cpp
+++ b/rviz_common/test/display_context_fixture.cpp
@@ -35,7 +35,7 @@
 
 #include <OgreSceneNode.h>
 
-void DisplayContextFixture::SetUpTestCase()
+void DisplayContextFixture::SetUp()
 {
   testing_environment_ = std::make_shared<rviz_common::OgreTestingEnvironment>();
   testing_environment_->setUpOgreTestEnvironment();
@@ -52,19 +52,5 @@ DisplayContextFixture::DisplayContextFixture()
   EXPECT_CALL(*context_, getClock()).WillRepeatedly(testing::Return(clock_));
   EXPECT_CALL(*context_, getWindowManager()).WillRepeatedly(testing::Return(window_manager_.get()));
   EXPECT_CALL(*context_, getSceneManager()).WillRepeatedly(
-    testing::Invoke([]() {return scene_manager_;}));
+    testing::Invoke([&]() {return scene_manager_;}));
 }
-
-DisplayContextFixture::~DisplayContextFixture()
-{
-  scene_manager_->getRootSceneNode()->removeAndDestroyAllChildren();
-}
-
-void DisplayContextFixture::TearDownTestCase()
-{
-  Ogre::Root::getSingletonPtr()->destroySceneManager(scene_manager_);
-}
-
-Ogre::SceneManager * DisplayContextFixture::scene_manager_ = nullptr;
-std::shared_ptr<rviz_common::OgreTestingEnvironment>
-DisplayContextFixture::testing_environment_ = nullptr;

--- a/rviz_common/test/display_context_fixture.hpp
+++ b/rviz_common/test/display_context_fixture.hpp
@@ -51,16 +51,12 @@
 class DisplayContextFixture : public testing::Test
 {
 public:
-  static void SetUpTestCase();
+  void SetUp();
 
   DisplayContextFixture();
 
-  ~DisplayContextFixture();
-
-  static void TearDownTestCase();
-
-  static std::shared_ptr<rviz_common::OgreTestingEnvironment> testing_environment_;
-  static Ogre::SceneManager * scene_manager_;
+  std::shared_ptr<rviz_common::OgreTestingEnvironment> testing_environment_;
+  Ogre::SceneManager * scene_manager_;
 
   std::shared_ptr<MockDisplayContext> context_;
   std::shared_ptr<MockWindowManagerInterface> window_manager_;

--- a/rviz_common/test/interaction/mock_selection_renderer.hpp
+++ b/rviz_common/test/interaction/mock_selection_renderer.hpp
@@ -92,6 +92,7 @@ public:
     auto height = static_cast<uint32_t>(rectangle.y2 - rectangle.y1);
 
     auto data = new uint8_t[Ogre::PixelUtil::getMemorySize(width, height, 1, Ogre::PF_A8R8G8B8)]();
+    delete[] static_cast<uint8_t *>(dst_box.data);
     dst_box = Ogre::PixelBox(width, height, 1, Ogre::PF_A8R8G8B8, data);
 
     // The data is stored in uchars where four contiguous uchars correspond to one pixel (each

--- a/rviz_common/test/interaction/selection_manager_test.cpp
+++ b/rviz_common/test/interaction/selection_manager_test.cpp
@@ -54,6 +54,12 @@ public:
     return object;
   }
 
+  ~SelectionManagerTestFixture()
+  {
+    if (render_window_)
+      delete render_window_;
+  }
+
   rviz_rendering::RenderWindow * render_window_ = nullptr;
 };
 

--- a/rviz_common/test/interaction/selection_manager_test.cpp
+++ b/rviz_common/test/interaction/selection_manager_test.cpp
@@ -56,8 +56,9 @@ public:
 
   ~SelectionManagerTestFixture()
   {
-    if (render_window_)
+    if (render_window_) {
       delete render_window_;
+    }
   }
 
   rviz_rendering::RenderWindow * render_window_ = nullptr;

--- a/rviz_common/test/interaction/selection_test_fixture.hpp
+++ b/rviz_common/test/interaction/selection_test_fixture.hpp
@@ -48,6 +48,12 @@ using namespace ::testing;  // NOLINT
 class SelectionTestFixture : public DisplayContextFixture
 {
 public:
+  void SetUp()
+  {
+    DisplayContextFixture::SetUp();
+    selection_manager_->initialize();
+  }
+
   SelectionTestFixture()
   {
     renderer_ = std::make_shared<MockSelectionRenderer>(context_.get());
@@ -62,7 +68,6 @@ public:
       Invoke([handler_manager_weak_ptr]() {return handler_manager_weak_ptr.lock();}));
     EXPECT_CALL(*context_, getSelectionManager()).WillRepeatedly(
       Invoke([selection_manager_weak_ptr]() {return selection_manager_weak_ptr.lock();}));
-    selection_manager_->initialize();
   }
 
   std::shared_ptr<MockSelectionRenderer> renderer_;

--- a/rviz_common/test/ogre_testing_environment.cpp
+++ b/rviz_common/test/ogre_testing_environment.cpp
@@ -53,4 +53,9 @@ void OgreTestingEnvironment::setUpRenderSystem()
   rviz_rendering::RenderSystem::get();
 }
 
+OgreTestingEnvironment::~OgreTestingEnvironment()
+{
+  delete rviz_rendering::RenderSystem::get();
+}
+
 }  // end namespace rviz_common

--- a/rviz_common/test/ogre_testing_environment.hpp
+++ b/rviz_common/test/ogre_testing_environment.hpp
@@ -44,6 +44,8 @@ public:
   void setUpOgreTestEnvironment(bool debug = false);
 
   void setUpRenderSystem();
+
+  ~OgreTestingEnvironment();
 };
 
 }  // namespace rviz_common

--- a/rviz_common/test/property_test.cpp
+++ b/rviz_common/test/property_test.cpp
@@ -99,6 +99,10 @@ TEST(Property, children) {
   // Accessing a missing property should not crash.
   printf("Next line should say 'ERROR' but not crash.\n");
   display->subProp("Position")->subProp("Z")->getValue().toFloat();
+
+  delete beta;
+  delete position;
+  delete display;
 }
 
 TEST(VectorProperty, default_value) {

--- a/rviz_common/test/ros_node_abstraction_test.cpp
+++ b/rviz_common/test/ros_node_abstraction_test.cpp
@@ -40,12 +40,12 @@ using namespace ::testing;  // NOLINT
 class RosNodeAbstractionTestFixture : public Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     rclcpp::init(0, nullptr);
   }
 
-  static void TearDownTestCase()
+  void TearDown()
   {
     rclcpp::shutdown();
   }

--- a/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
+++ b/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
@@ -90,6 +90,7 @@ public:
   /**
    * This must be called before Ogre::Root is instantiated!
    */
+  RVIZ_RENDERING_PUBLIC
   void
   configureLogging();
 

--- a/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
+++ b/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
@@ -31,6 +31,7 @@
 #ifndef RVIZ_RENDERING__OGRE_LOGGING_HPP_
 #define RVIZ_RENDERING__OGRE_LOGGING_HPP_
 
+#include <memory>
 #include <string>
 
 #include "rviz_rendering/visibility_control.hpp"
@@ -48,6 +49,10 @@ namespace rviz_rendering
  * configureLogging() is called at the right time by the RenderSystem
  * constructor, so you generally won't need to call it explicitly.
  */
+
+// forward declarations
+class OgreLoggingPrivate;
+
 class OgreLogging
 {
 public:
@@ -92,10 +97,11 @@ private:
   OgreLogging();
 
   static OgreLogging * instance_;
-
   typedef enum { StandardOut, FileLogging, NoLogging } Preference;
   Preference preference_ = OgreLogging::NoLogging;
   std::string filename_ = "Ogre.log";
+
+  std::unique_ptr<OgreLoggingPrivate> dataPtr;
 };
 
 }  // namespace rviz_rendering

--- a/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
+++ b/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
@@ -51,7 +51,10 @@ namespace rviz_rendering
 class OgreLogging
 {
 public:
-  OgreLogging();
+  RVIZ_RENDERING_PUBLIC
+  static
+  OgreLogging *
+  get();
 
   ~OgreLogging();
 
@@ -86,6 +89,10 @@ public:
   configureLogging();
 
 private:
+  OgreLogging();
+
+  static OgreLogging * instance_;
+
   typedef enum { StandardOut, FileLogging, NoLogging } Preference;
   Preference preference_ = OgreLogging::NoLogging;
   std::string filename_ = "Ogre.log";

--- a/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
+++ b/rviz_rendering/include/rviz_rendering/ogre_logging.hpp
@@ -51,13 +51,16 @@ namespace rviz_rendering
 class OgreLogging
 {
 public:
+  OgreLogging();
+
+  ~OgreLogging();
+
   /// Configure Ogre to write output to the given log file name.
   /**
    * If file name is a relative path, it will be relative to
    * the directory which is current when the program is run.  Default
    * is "Ogre.log".
    */
-  static
   void
   useLogFile(const std::string & filename = "Ogre.log");
 
@@ -67,13 +70,11 @@ public:
    * the directory which is current when the program is run.  Default
    * is "Ogre.log".
    */
-  static
   RVIZ_RENDERING_PUBLIC
   void
   useLogFileAndStandardOut(const std::string & filename = "Ogre.log");
 
   /// Disable Ogre logging entirely, this is the default.
-  static
   void
   noLog();
 
@@ -81,14 +82,13 @@ public:
   /**
    * This must be called before Ogre::Root is instantiated!
    */
-  static
   void
   configureLogging();
 
 private:
   typedef enum { StandardOut, FileLogging, NoLogging } Preference;
-  static Preference preference_;
-  static std::string filename_;
+  Preference preference_ = OgreLogging::NoLogging;
+  std::string filename_ = "Ogre.log";
 };
 
 }  // namespace rviz_rendering

--- a/rviz_rendering/include/rviz_rendering/render_system.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_system.hpp
@@ -80,6 +80,7 @@ public:
   Ogre::Root *
   getOgreRoot();
 
+  RVIZ_RENDERING_PUBLIC
   ~RenderSystem();
 
   void Destroy();

--- a/rviz_rendering/include/rviz_rendering/render_system.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_system.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_RENDERING__RENDER_SYSTEM_HPP_
 #define RVIZ_RENDERING__RENDER_SYSTEM_HPP_
 
+#define OGRE_VERSION_HIGHER_OR_EQUAL_1_9_0 (OGRE_VERSION >= ((1 << 16) | (9 << 8) | 0))
+
 #include <cstdint>
 #include <string>
 
@@ -42,7 +44,6 @@
 
 #ifdef __linux__
 
-#include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <GL/glx.h>
 

--- a/rviz_rendering/include/rviz_rendering/render_system.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_system.hpp
@@ -40,7 +40,16 @@
 
 #include <QDir>  // NOLINT cpplint cannot handle include order here
 
+#ifdef __linux__
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <GL/glx.h>
+
+#endif
+
 #include "rviz_rendering/visibility_control.hpp"
+#include "rviz_rendering/ogre_logging.hpp"
 
 namespace rviz_rendering
 {
@@ -69,6 +78,10 @@ public:
 
   Ogre::Root *
   getOgreRoot();
+
+  ~RenderSystem();
+
+  void Destroy();
 
   // Prepare a scene_manager to render overlays.
   // Needed for Ogre >= 1.9 to use fonts; does nothing for prior versions.
@@ -135,8 +148,6 @@ private:
   void
   detectGlVersion();
 
-  static Ogre::GLPlugin * render_system_gl_plugin_;
-
   static RenderSystem * instance_;
 
   // ID for a dummy window of size 1x1, used to keep Ogre happy.
@@ -151,6 +162,12 @@ private:
   static int force_gl_version_;
   bool stereo_supported_;
   static bool force_no_stereo_;
+  rviz_rendering::OgreLogging * ogre_logging;
+#if !defined(__APPLE__) && !defined(_WIN32)
+  void * dummyDisplay = nullptr;
+  void * dummyContext = nullptr;
+  XVisualInfo * dummyVisual = nullptr;
+#endif
 };
 
 }  // namespace rviz_rendering

--- a/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
@@ -106,6 +106,7 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
       Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(
         resource_path, ROS_PACKAGE_NAME);
       ser.importMesh(stream, mesh.get());
+      stream->close();
 
       return mesh;
     } else if (ext == "stl" || ext == "STL" || ext == "stlb" || ext == "STLB") {

--- a/rviz_rendering/src/rviz_rendering/objects/billboard_line.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/billboard_line.cpp
@@ -120,7 +120,7 @@ Ogre::BillboardChain * BillboardLine::createChain()
   static int count = 0;
   ss << "BillboardLine chain" << count++;
   Ogre::BillboardChain * chain = scene_manager_->createBillboardChain(ss.str());
-  chain->setMaterialName(material_->getName() );
+  chain->setMaterialName(material_->getName());
   scene_node_->attachObject(chain);
 
   chain_containers_.push_back(chain);

--- a/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
@@ -30,6 +30,7 @@
 
 #include "rviz_rendering/ogre_logging.hpp"
 
+#include <memory>
 #include <string>
 
 #include <OgreLogManager.h>
@@ -81,6 +82,12 @@ public:
 namespace rviz_rendering
 {
 
+class OgreLoggingPrivate
+{
+public:
+  CustomOgreLogListener custom_ogre_log_listener;
+};
+
 OgreLogging * OgreLogging::instance_ = nullptr;
 
 OgreLogging *
@@ -93,8 +100,8 @@ OgreLogging::get()
 }
 
 OgreLogging::OgreLogging()
+: dataPtr(std::make_unique<OgreLoggingPrivate>())
 {
-  this->configureLogging();
 }
 
 OgreLogging::~OgreLogging()
@@ -123,7 +130,6 @@ void OgreLogging::noLog()
 
 void OgreLogging::configureLogging()
 {
-  CustomOgreLogListener custom_ogre_log_listener;
   Ogre::LogManager * log_manager = Ogre::LogManager::getSingletonPtr();
   if (!log_manager) {
     // suppressing this memleak warning from cppcheck below
@@ -131,11 +137,11 @@ void OgreLogging::configureLogging()
     log_manager = new Ogre::LogManager();
   }
   Ogre::Log * l = log_manager->createLog(filename_, false, false, (preference_ == NoLogging));
-  l->addListener(&custom_ogre_log_listener);
+  l->addListener(&this->dataPtr->custom_ogre_log_listener);
 
   // Printing to standard out is what Ogre does if you don't do any LogManager calls.
   if (preference_ == StandardOut) {
-    custom_ogre_log_listener.min_lml = Ogre::LML_NORMAL;
+    this->dataPtr->custom_ogre_log_listener.min_lml = Ogre::LML_NORMAL;
   }
   // cppcheck-suppress memleak
 }

--- a/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
@@ -80,10 +80,16 @@ public:
 
 namespace rviz_rendering
 {
+OgreLogging::OgreLogging()
+{
+  this->configureLogging();
+}
 
-OgreLogging::Preference OgreLogging::preference_ = OgreLogging::NoLogging;
-// TODO(wjwwood): refactor this to not have static members.
-std::string OgreLogging::filename_;  // NOLINT: cpplint doesn't allow static strings
+OgreLogging::~OgreLogging()
+{
+  Ogre::LogManager * log_manager = Ogre::LogManager::getSingletonPtr();
+  delete log_manager;
+}
 
 void OgreLogging::useLogFile(const std::string & filename)
 {
@@ -104,7 +110,7 @@ void OgreLogging::noLog()
 
 void OgreLogging::configureLogging()
 {
-  static CustomOgreLogListener ll;
+  CustomOgreLogListener custom_ogre_log_listener;
   Ogre::LogManager * log_manager = Ogre::LogManager::getSingletonPtr();
   if (!log_manager) {
     // suppressing this memleak warning from cppcheck below
@@ -112,11 +118,11 @@ void OgreLogging::configureLogging()
     log_manager = new Ogre::LogManager();
   }
   Ogre::Log * l = log_manager->createLog(filename_, false, false, (preference_ == NoLogging));
-  l->addListener(&ll);
+  l->addListener(&custom_ogre_log_listener);
 
   // Printing to standard out is what Ogre does if you don't do any LogManager calls.
   if (preference_ == StandardOut) {
-    ll.min_lml = Ogre::LML_NORMAL;
+    custom_ogre_log_listener.min_lml = Ogre::LML_NORMAL;
   }
   // cppcheck-suppress memleak
 }

--- a/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
@@ -80,6 +80,18 @@ public:
 
 namespace rviz_rendering
 {
+
+OgreLogging * OgreLogging::instance_ = nullptr;
+
+OgreLogging *
+OgreLogging::get()
+{
+  if (instance_ == 0) {
+    instance_ = new OgreLogging();
+  }
+  return instance_;
+}
+
 OgreLogging::OgreLogging()
 {
   this->configureLogging();
@@ -89,6 +101,7 @@ OgreLogging::~OgreLogging()
 {
   Ogre::LogManager * log_manager = Ogre::LogManager::getSingletonPtr();
   delete log_manager;
+  instance_ = nullptr;
 }
 
 void OgreLogging::useLogFile(const std::string & filename)

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -31,6 +31,7 @@
 
 #include "rviz_rendering/render_system.hpp"
 
+#include <iostream>
 #include <map>
 #include <memory>
 #include <string>

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -158,7 +158,7 @@ RenderSystem::forceNoStereo()
 RenderSystem::RenderSystem()
 : dummy_window_id_(0), ogre_overlay_system_(nullptr), stereo_supported_(false)
 {
-  this->ogre_logging = new rviz_rendering::OgreLogging();
+  this->ogre_logging = rviz_rendering::OgreLogging::get();
 
   setResourceDirectory();
   setPluginDirectory();

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -82,7 +82,7 @@ RenderSystem::getOgreRoot()
 
 void RenderSystem::Destroy()
 {
-#if (OGRE_VERSION >= ((1 << 16) | (9 << 8) | 0))
+#if OGRE_VERSION_HIGHER_OR_EQUAL_1_9_0
   OGRE_DELETE this->ogre_overlay_system_;
   this->ogre_overlay_system_ = nullptr;
 #endif

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -159,6 +159,7 @@ RenderSystem::RenderSystem()
 : dummy_window_id_(0), ogre_overlay_system_(nullptr), stereo_supported_(false)
 {
   this->ogre_logging = rviz_rendering::OgreLogging::get();
+  this->ogre_logging->configureLogging();
 
   setResourceDirectory();
   setPluginDirectory();

--- a/rviz_rendering/test/rviz_rendering/objects/billboard_line_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/billboard_line_test.cpp
@@ -45,17 +45,14 @@ using namespace ::testing;  // NOLINT
 class BillboardLineTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment>
-BillboardLineTestFixture::testing_environment_ = nullptr;
 
 static std::vector<Ogre::Vector3> squareCenteredAtZero
 {

--- a/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
@@ -50,7 +50,7 @@ using rviz_rendering::findAllSpheres;
 class CovarianceVisualTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
@@ -74,14 +74,11 @@ protected:
     return std::make_tuple(position, offset);
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
 
   std::unique_ptr<rviz_rendering::CovarianceVisual> covariance_visual_;
   Ogre::SceneNode * covariance_visual_node_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment>
-CovarianceVisualTestFixture::testing_environment_ = nullptr;
 
 // *INDENT-OFF* - uncrustify cannot deal with layout of matrices here
 std::array<double, 36> getCovariances3D()

--- a/rviz_rendering/test/rviz_rendering/objects/grid_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/grid_test.cpp
@@ -47,17 +47,14 @@ using namespace ::testing;  // NOLINT
 class GridTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment>
-GridTestFixture::testing_environment_ = nullptr;
 
 rviz_rendering::Grid createGrid(
   rviz_rendering::Grid::Style style,

--- a/rviz_rendering/test/rviz_rendering/objects/line_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/line_test.cpp
@@ -45,17 +45,14 @@
 class LineTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment> LineTestFixture::testing_environment_ =
-  nullptr;
 
 TEST_F(LineTestFixture, setPoints_sets_the_line_position_and_size) {
   auto scene_manager = Ogre::Root::getSingletonPtr()->createSceneManager();
@@ -69,4 +66,5 @@ TEST_F(LineTestFixture, setPoints_sets_the_line_position_and_size) {
 
   ASSERT_THAT(aabb.getMinimum(), Vector3Eq(Ogre::Vector3(-5, -5, -5)));
   ASSERT_THAT(aabb.getMaximum(), Vector3Eq(Ogre::Vector3(3, 3, 3)));
+  delete line;
 }

--- a/rviz_rendering/test/rviz_rendering/objects/movable_text_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/movable_text_test.cpp
@@ -46,17 +46,14 @@ using namespace ::testing;  // NOLINT
 class MovableTextTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment>
-MovableTextTestFixture::testing_environment_ = nullptr;
 
 float getCharWidth(std::shared_ptr<rviz_rendering::MovableText> movable_text, char character)
 {

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
@@ -44,13 +44,14 @@ using namespace ::testing;  // NOLINT
 class PointCloudRenderableTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
+    PointCloudRenderable();
   }
 
-  PointCloudRenderableTestFixture()
+  void PointCloudRenderable()
   {
     cloud_ = std::make_shared<rviz_rendering::PointCloud>();
     auto points = std::vector<rviz_rendering::PointCloud::Point>(
@@ -59,13 +60,10 @@ protected:
     renderable_ = cloud_->getRenderables().front();
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
   std::shared_ptr<rviz_rendering::PointCloud> cloud_;
   rviz_rendering::PointCloudRenderablePtr renderable_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment>
-PointCloudRenderableTestFixture::testing_environment_ = nullptr;
 
 TEST_F(PointCloudRenderableTestFixture, getBoundingRadius_returns_radius_from_coordinate_origin) {
   auto boundingBox = Ogre::AxisAlignedBox(Ogre::Vector3(-1, -1, -1), Ogre::Vector3(2, 2, 0));

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
@@ -51,17 +51,14 @@ using namespace ::testing;  // NOLINT
 class PointCloudTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment>
-PointCloudTestFixture::testing_environment_ = nullptr;
 
 static Ogre::ColourValue colorValue = Ogre::ColourValue(0.5f, 0.5f, 0.5f, 1.0f);
 

--- a/rviz_rendering/test/rviz_rendering/objects/wrench_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/wrench_visual_test.cpp
@@ -54,17 +54,14 @@ MATCHER_P(Vector3Eq, expected, "") {
 class WrenchVisualTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
   }
 
-  static std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering::OgreTestingEnvironment> testing_environment_;
 };
-
-std::shared_ptr<rviz_rendering::OgreTestingEnvironment>
-WrenchVisualTestFixture::testing_environment_ = nullptr;
 
 Ogre::SceneNode * findForceArrow(Ogre::SceneNode * scene_node)
 {

--- a/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
+++ b/rviz_rendering/test/rviz_rendering/ogre_testing_environment.cpp
@@ -58,4 +58,9 @@ int OgreTestingEnvironment::getGlslVersion() const
   return RenderSystem::get()->getGlslVersion();
 }
 
+OgreTestingEnvironment::~OgreTestingEnvironment()
+{
+  delete rviz_rendering::RenderSystem::get();
+}
+
 }  // end namespace rviz_rendering

--- a/rviz_rendering/test/rviz_rendering/ogre_testing_environment.hpp
+++ b/rviz_rendering/test/rviz_rendering/ogre_testing_environment.hpp
@@ -46,6 +46,8 @@ public:
   void setUpRenderSystem();
 
   int getGlslVersion() const;
+
+  ~OgreTestingEnvironment();
 };
 
 }  // namespace rviz_rendering

--- a/rviz_rendering_tests/test/mesh_loader_test.cpp
+++ b/rviz_rendering_tests/test/mesh_loader_test.cpp
@@ -47,17 +47,14 @@ using namespace ::testing;  // NOLINT
 class MeshLoaderTestFixture : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
+  void SetUp()
   {
     testing_environment_ = std::make_shared<rviz_rendering_tests::OgreTestingEnvironment>();
     testing_environment_->setUpOgreTestEnvironment();
   }
 
-  static std::shared_ptr<rviz_rendering_tests::OgreTestingEnvironment> testing_environment_;
+  std::shared_ptr<rviz_rendering_tests::OgreTestingEnvironment> testing_environment_;
 };
-
-std::shared_ptr<rviz_rendering_tests::OgreTestingEnvironment>
-MeshLoaderTestFixture::testing_environment_ = nullptr;
 
 void assertVector3Equality(Ogre::Vector3 actual, Ogre::Vector3 expected)
 {

--- a/rviz_rendering_tests/test/ogre_testing_environment.cpp
+++ b/rviz_rendering_tests/test/ogre_testing_environment.cpp
@@ -53,4 +53,9 @@ void OgreTestingEnvironment::setUpRenderSystem()
   rviz_rendering::RenderSystem::get();
 }
 
+OgreTestingEnvironment::~OgreTestingEnvironment()
+{
+  delete rviz_rendering::RenderSystem::get();
+}
+
 }  // end namespace rviz_rendering_tests

--- a/rviz_rendering_tests/test/ogre_testing_environment.hpp
+++ b/rviz_rendering_tests/test/ogre_testing_environment.hpp
@@ -44,6 +44,8 @@ public:
   void setUpOgreTestEnvironment(bool debug = false);
 
   void setUpRenderSystem();
+
+  ~OgreTestingEnvironment();
 };
 
 }  // namespace rviz_rendering_tests


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

I ran `ASAN` in `rviz_rendering` and `rviz_rendering_tests` and I founded some memory leaks. 

 - Destroy OgreRoot properly
 - Destroy RenderSystem properly
 - Refactor OgreLogging class to not use static variables.
 - Fix some tests

There are still two more memory leaks in particular in the mes_loader class:

 - When loading `.mesh` files. The OgreSerializer is adding the leaks
    ```
      ser.importMesh(stream, mesh.get());
    ```
 - When loading collada (`.dae`) files