### PR TITLE
Fix Image topic property not populating

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -61,11 +61,7 @@ public:
   : tf_filter_(nullptr),
     messages_received_(0)
   {
-    // TODO(Martin-Idel-SI): We need a way to extract the MessageType from the template to set a
-    // correct string. Previously was:
-    // QString message_type =
-    //   QString::fromStdString(message_filters::message_traits::datatype<MessageType>());
-    QString message_type = QString::fromStdString("");
+    QString message_type = QString::fromStdString(rosidl_generator_traits::name<MessageType>());
     topic_property_->setMessageType(message_type);
     topic_property_->setDescription(message_type + " topic to subscribe to.");
   }


### PR DESCRIPTION
I might have misunderstood something here, but seems to me like we can use the same method of extracting the MessageType that is being used in [MessageFilterDisplay](https://github.com/ros2/rviz/blob/cd1da34cfc01d9c6223c181ba6e7bf277ee4c1a8/rviz_common/include/rviz_common/message_filter_display.hpp#L63).