### PR TITLE
mass property visualization

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
@@ -145,9 +145,9 @@ protected:
   rviz_common::properties::FloatProperty * alpha_property_;
   rviz_common::properties::StringProperty * tf_prefix_property_;
 
-  rviz_common::properties::Property* mass_properties_;
-  rviz_common::properties::Property* mass_enabled_property_;
-  rviz_common::properties::Property* inertia_enabled_property_;
+  rviz_common::properties::Property * mass_properties_;
+  rviz_common::properties::Property * mass_enabled_property_;
+  rviz_common::properties::Property * inertia_enabled_property_;
 
   std::unique_ptr<rviz_default_plugins::transformation::TransformerGuard<
       rviz_default_plugins::transformation::TFFrameTransformer>> transformer_guard_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
@@ -107,6 +107,8 @@ private Q_SLOTS:
   void updateAlpha();
   void updatePropertyVisibility();
   void updateRobotDescription();
+  void updateMassVisible();
+  void updateInertiaVisible();
 
   void updateTopic() override;
 
@@ -142,6 +144,10 @@ protected:
   rviz_common::properties::FilePickerProperty * description_file_property_;
   rviz_common::properties::FloatProperty * alpha_property_;
   rviz_common::properties::StringProperty * tf_prefix_property_;
+
+  rviz_common::properties::Property* mass_properties_;
+  rviz_common::properties::Property* mass_enabled_property_;
+  rviz_common::properties::Property* inertia_enabled_property_;
 
   std::unique_ptr<rviz_default_plugins::transformation::TransformerGuard<
       rviz_default_plugins::transformation::TFFrameTransformer>> transformer_guard_;

--- a/rviz_default_plugins/include/rviz_default_plugins/robot/robot.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/robot.hpp
@@ -113,11 +113,12 @@ public:
    * @param mass Whether or not to load the mass representation
    * @param inertia Whether or not to load the inertia representation
    */
-  virtual void load(const urdf::ModelInterface & urdf, 
-                    bool visual = true, 
-                    bool collision = true,
-                    bool mass = true,
-                    bool inertia = true);
+  virtual void load(
+    const urdf::ModelInterface & urdf,
+    bool visual = true,
+    bool collision = true,
+    bool mass = true,
+    bool inertia = true);
 
   /**
    * \brief Clears all data loaded from a URDF
@@ -144,7 +145,7 @@ public:
    */
   void setCollisionVisible(bool visible);
 
-    /**
+  /**
    * \brief Set whether the mass of each part is visible
    * @param visible Whether the mass of each link is visible
    */
@@ -335,11 +336,12 @@ protected:
   float alpha_;
 
 private:
-  void createLinkProperties(const urdf::ModelInterface & urdf, 
-                            bool visual, 
-                            bool collision, 
-                            bool mass, 
-                            bool inertia);
+  void createLinkProperties(
+    const urdf::ModelInterface & urdf,
+    bool visual,
+    bool collision,
+    bool mass,
+    bool inertia);
   void createJointProperties(const urdf::ModelInterface & urdf);
   void log_error(
     const RobotLink * link,

--- a/rviz_default_plugins/include/rviz_default_plugins/robot/robot.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/robot.hpp
@@ -110,8 +110,14 @@ public:
    * @param urdf The robot description to read from
    * @param visual Whether or not to load the visual representation
    * @param collision Whether or not to load the collision representation
+   * @param mass Whether or not to load the mass representation
+   * @param inertia Whether or not to load the inertia representation
    */
-  virtual void load(const urdf::ModelInterface & urdf, bool visual = true, bool collision = true);
+  virtual void load(const urdf::ModelInterface & urdf, 
+                    bool visual = true, 
+                    bool collision = true,
+                    bool mass = true,
+                    bool inertia = true);
 
   /**
    * \brief Clears all data loaded from a URDF
@@ -138,6 +144,18 @@ public:
    */
   void setCollisionVisible(bool visible);
 
+    /**
+   * \brief Set whether the mass of each part is visible
+   * @param visible Whether the mass of each link is visible
+   */
+  void setMassVisible(bool visible);
+
+  /**
+   * \brief Set whether the inertia of each part is visible
+   * @param visible Whether the inertia of each link is visible
+   */
+  void setInertiaVisible(bool visible);
+
   /**
    * \brief Returns whether anything is visible
    */
@@ -152,6 +170,18 @@ public:
    * To be visible this and isVisible() must both be true.
    */
   bool isCollisionVisible();
+
+  /**
+   * \brief Returns whether or not mass of each link is visible.
+   * To be visible this and isVisible() must both be true
+   */
+  bool isMassVisible();
+
+  /**
+   * \brief Returns whether or not inertia of each link is visible.
+   * To be visible this and isVisible() must both be true
+   */
+  bool isInertiaVisible();
 
   void setAlpha(float a);
   float getAlpha() {return alpha_;}
@@ -190,7 +220,9 @@ public:
       const urdf::LinkConstSharedPtr & link,
       const std::string & parent_joint_name,
       bool visual,
-      bool collision);
+      bool collision,
+      bool mass,
+      bool inertia);
     virtual RobotJoint * createJoint(
       Robot * robot,
       const urdf::JointConstSharedPtr & joint);
@@ -280,6 +312,9 @@ protected:
   bool visual_visible_;                         ///< Should we show the visual representation?
   bool collision_visible_;                      ///< Should we show the collision representation?
 
+  bool mass_visible_;                           ///< Should we show mass of each link?
+  bool inertia_visible_;                        ///< Should we show inertia of each link?
+
   rviz_common::DisplayContext * context_;
   rviz_common::properties::Property * link_tree_;
   rviz_common::properties::EnumProperty * link_tree_style_;
@@ -300,7 +335,11 @@ protected:
   float alpha_;
 
 private:
-  void createLinkProperties(const urdf::ModelInterface & urdf, bool visual, bool collision);
+  void createLinkProperties(const urdf::ModelInterface & urdf, 
+                            bool visual, 
+                            bool collision, 
+                            bool mass, 
+                            bool inertia);
   void createJointProperties(const urdf::ModelInterface & urdf);
   void log_error(
     const RobotLink * link,

--- a/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
@@ -247,16 +247,12 @@ private:
   std::vector<Ogre::Entity *> collision_meshes_;  ///< The entities representing the
 ///< collision mesh of this link (if they exist)
 
-  Ogre::SceneNode * visual_node_;              ///< The scene node the visual meshes
-///< are attached to
-  Ogre::SceneNode * collision_node_;           ///< The scene node the collision meshes
-///< are attached to
-  Ogre::SceneNode * mass_node_;              ///< The scene node the visual meshes
-///< are attached to
-  Ogre::SceneNode * inertia_node_;           ///< The scene node the collision meshes
-///< are attached to
-  rviz_rendering::Shape* mass_shape_;                       ///< The shape representing the mass
-  rviz_rendering::Shape* inertia_shape_;                    ///< The shape representing the inertia
+  Ogre::SceneNode * visual_node_;         ///< The scene node the visual meshes are attached to
+  Ogre::SceneNode * collision_node_;      ///< The scene node the collision meshes are attached to
+  Ogre::SceneNode * mass_node_;           ///< The scene node the visual meshes are attached to
+  Ogre::SceneNode * inertia_node_;        ///< The scene node the collision meshes are attached to
+  rviz_rendering::Shape * mass_shape_;    ///< The shape representing the mass
+  rviz_rendering::Shape * inertia_shape_; ///< The shape representing the inertia
 
   Ogre::RibbonTrail * trail_;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
@@ -247,12 +247,12 @@ private:
   std::vector<Ogre::Entity *> collision_meshes_;  ///< The entities representing the
 ///< collision mesh of this link (if they exist)
 
-  Ogre::SceneNode * visual_node_;         ///< The scene node the visual meshes are attached to
-  Ogre::SceneNode * collision_node_;      ///< The scene node the collision meshes are attached to
-  Ogre::SceneNode * mass_node_;           ///< The scene node the visual meshes are attached to
-  Ogre::SceneNode * inertia_node_;        ///< The scene node the collision meshes are attached to
-  rviz_rendering::Shape * mass_shape_;    ///< The shape representing the mass
-  rviz_rendering::Shape * inertia_shape_; ///< The shape representing the inertia
+  Ogre::SceneNode * visual_node_;          ///< The scene node the visual meshes are attached to
+  Ogre::SceneNode * collision_node_;       ///< The scene node the collision meshes are attached to
+  Ogre::SceneNode * mass_node_;            ///< The scene node the visual meshes are attached to
+  Ogre::SceneNode * inertia_node_;         ///< The scene node the collision meshes are attached to
+  rviz_rendering::Shape * mass_shape_;     ///< The shape representing the mass
+  rviz_rendering::Shape * inertia_shape_;  ///< The shape representing the inertia
 
   Ogre::RibbonTrail * trail_;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
@@ -112,7 +112,9 @@ public:
     const urdf::LinkConstSharedPtr & link,
     const std::string & parent_joint_name,
     bool visual,
-    bool collision);
+    bool collision,
+    bool mass,
+    bool inertia);
   ~RobotLink() override;
 
   virtual void setRobotAlpha(float a);
@@ -188,6 +190,8 @@ private:
 
   void createCollision(const urdf::LinkConstSharedPtr & link);
   void createVisual(const urdf::LinkConstSharedPtr & link);
+  void createMass(const urdf::LinkConstSharedPtr & link);
+  void createInertia(const urdf::LinkConstSharedPtr & link);
   void createSelection();
 
   template<typename T>
@@ -247,6 +251,12 @@ private:
 ///< are attached to
   Ogre::SceneNode * collision_node_;           ///< The scene node the collision meshes
 ///< are attached to
+  Ogre::SceneNode * mass_node_;              ///< The scene node the visual meshes
+///< are attached to
+  Ogre::SceneNode * inertia_node_;           ///< The scene node the collision meshes
+///< are attached to
+  rviz_rendering::Shape* mass_shape_;                       ///< The shape representing the mass
+  rviz_rendering::Shape* inertia_shape_;                    ///< The shape representing the inertia
 
   Ogre::RibbonTrail * trail_;
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -94,6 +94,17 @@ RobotModelDisplay::RobotModelDisplay()
     "Whether to display the collision representation of the robot.",
     this, SLOT(updateCollisionVisible()));
 
+  mass_properties_ = new Property("Mass Properties", QVariant(), "", this);
+  mass_enabled_property_ = new Property(
+    "Mass", false,
+    "Whether to display the visual representation of the mass of each link.",
+    mass_properties_, SLOT(updateMassVisible()), this);
+  inertia_enabled_property_ = new Property(
+    "Inertia", false,
+    "Whether to display the visual representation of the inertia of each link.",
+    mass_properties_, SLOT(updateInertiaVisible()), this);
+  mass_properties_->collapse();
+
   update_rate_property_ = new FloatProperty(
     "Update Interval", 0,
     "Interval at which to update the links, in seconds. "
@@ -199,6 +210,18 @@ void RobotModelDisplay::updateCollisionVisible()
 void RobotModelDisplay::updateTfPrefix()
 {
   clearStatuses();
+  context_->queueRender();
+}
+
+void RobotModelDisplay::updateMassVisible()
+{
+  robot_->setMassVisible(mass_enabled_property_->getValue().toBool());
+  context_->queueRender();
+}
+
+void RobotModelDisplay::updateInertiaVisible()
+{
+  robot_->setInertiaVisible(inertia_enabled_property_->getValue().toBool());
   context_->queueRender();
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp
@@ -69,6 +69,8 @@ Robot::Robot(
   visible_(true),
   visual_visible_(true),
   collision_visible_(false),
+  mass_visible_(false),
+  inertia_visible_(false),
   context_(context),
   doing_set_checkbox_(false),
   robot_loaded_(false),
@@ -83,6 +85,8 @@ Robot::Robot(
 
   setVisualVisible(visual_visible_);
   setCollisionVisible(collision_visible_);
+  setMassVisible(mass_visible_);
+  setInertiaVisible(inertia_visible_);
   setAlpha(1.0f);
 
   link_tree_ = new Property("Links", QVariant(), "", parent_property);
@@ -136,7 +140,11 @@ Robot::~Robot()
   delete link_factory_;
 }
 
-void Robot::load(const urdf::ModelInterface & urdf, bool visual, bool collision)
+void Robot::load(const urdf::ModelInterface & urdf, 
+                 bool visual, 
+                 bool collision,
+                 bool mass,
+                 bool inertia)
 {
   link_tree_->hide();  // hide until loaded
   robot_loaded_ = false;
@@ -148,7 +156,7 @@ void Robot::load(const urdf::ModelInterface & urdf, bool visual, bool collision)
   root_link_ = nullptr;
 
   // Properties are not added to display until changedLinkTreeStyle() is called (below).
-  createLinkProperties(urdf, visual, collision);
+  createLinkProperties(urdf, visual, collision, mass, inertia);
   createJointProperties(urdf);
 
   // robot is now loaded
@@ -164,6 +172,8 @@ void Robot::load(const urdf::ModelInterface & urdf, bool visual, bool collision)
 
   setVisualVisible(isVisualVisible() );
   setCollisionVisible(isCollisionVisible() );
+  setMassVisible(isMassVisible());
+  setInertiaVisible(isInertiaVisible());
 }
 
 void Robot::clear()
@@ -279,6 +289,18 @@ void Robot::setCollisionVisible(bool visible)
   updateLinkVisibilities();
 }
 
+void Robot::setMassVisible(bool visible)
+{
+  mass_visible_ = visible;
+  updateLinkVisibilities();
+}
+
+void Robot::setInertiaVisible(bool visible)
+{
+  inertia_visible_ = visible;
+  updateLinkVisibilities();
+}
+
 void Robot::updateLinkVisibilities()
 {
   for (auto & link_map_entry : links_) {
@@ -300,6 +322,16 @@ bool Robot::isVisualVisible()
 bool Robot::isCollisionVisible()
 {
   return collision_visible_;
+}
+
+bool Robot::isMassVisible()
+{
+  return mass_visible_;
+}
+
+bool Robot::isInertiaVisible()
+{
+  return inertia_visible_;
 }
 
 void Robot::setAlpha(float a)
@@ -410,9 +442,11 @@ RobotLink * Robot::LinkFactory::createLink(
   const urdf::LinkConstSharedPtr & link,
   const std::string & parent_joint_name,
   bool visual,
-  bool collision)
+  bool collision,
+  bool mass,
+  bool inertia)
 {
-  return new RobotLink(robot, link, parent_joint_name, visual, collision);
+  return new RobotLink(robot, link, parent_joint_name, visual, collision, mass, inertia);
 }
 
 RobotJoint * Robot::LinkFactory::createJoint(
@@ -422,7 +456,7 @@ RobotJoint * Robot::LinkFactory::createJoint(
   return new RobotJoint(robot, joint);
 }
 
-void Robot::createLinkProperties(const urdf::ModelInterface & urdf, bool visual, bool collision)
+void Robot::createLinkProperties(const urdf::ModelInterface & urdf, bool visual, bool collision, bool mass, bool inertia)
 {
   for (const auto & link_entry : urdf.links_) {
     const urdf::LinkConstSharedPtr & urdf_link = link_entry.second;
@@ -433,7 +467,7 @@ void Robot::createLinkProperties(const urdf::ModelInterface & urdf, bool visual,
     }
 
     RobotLink * link = link_factory_->createLink(
-      this, urdf_link, parent_joint_name, visual, collision);
+      this, urdf_link, parent_joint_name, visual, collision, mass, inertia);
 
     if (urdf_link == urdf.getRoot()) {
       root_link_ = link;

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot.cpp
@@ -140,11 +140,12 @@ Robot::~Robot()
   delete link_factory_;
 }
 
-void Robot::load(const urdf::ModelInterface & urdf, 
-                 bool visual, 
-                 bool collision,
-                 bool mass,
-                 bool inertia)
+void Robot::load(
+  const urdf::ModelInterface & urdf,
+  bool visual,
+  bool collision,
+  bool mass,
+  bool inertia)
 {
   link_tree_->hide();  // hide until loaded
   robot_loaded_ = false;
@@ -456,7 +457,12 @@ RobotJoint * Robot::LinkFactory::createJoint(
   return new RobotJoint(robot, joint);
 }
 
-void Robot::createLinkProperties(const urdf::ModelInterface & urdf, bool visual, bool collision, bool mass, bool inertia)
+void Robot::createLinkProperties(
+  const urdf::ModelInterface & urdf,
+  bool visual,
+  bool collision,
+  bool mass,
+  bool inertia)
 {
   for (const auto & link_entry : urdf.links_) {
     const urdf::LinkConstSharedPtr & urdf_link = link_entry.second;

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -154,6 +154,12 @@ void RobotLinkSelectionHandler::preRenderPass(uint32_t pass)
     if (link_->collision_node_) {
       link_->collision_node_->setVisible(false);
     }
+    if (link_->mass_node_) {
+      link_->mass_node_->setVisible(false);
+    }
+    if (link_->inertia_node_) {
+      link_->inertia_node_->setVisible(false);
+    }
     if (link_->trail_) {
       link_->trail_->setVisible(false);
     }
@@ -176,13 +182,19 @@ RobotLink::RobotLink(
   const urdf::LinkConstSharedPtr & link,
   const std::string & parent_joint_name,
   bool visual,
-  bool collision)
+  bool collision,
+  bool mass,
+  bool inertia)
 : RobotElementBaseClass(robot, link->name),
   scene_manager_(robot->getDisplayContext()->getSceneManager()),
   context_(robot->getDisplayContext()),
   parent_joint_name_(parent_joint_name),
   visual_node_(nullptr),
   collision_node_(nullptr),
+  mass_node_(nullptr),
+  inertia_node_(nullptr),
+  mass_shape_(nullptr),
+  inertia_shape_(nullptr),
   trail_(nullptr),
   material_alpha_(1.0),
   robot_alpha_(1.0),
@@ -194,6 +206,8 @@ RobotLink::RobotLink(
 
   visual_node_ = robot_->getVisualNode()->createChildSceneNode();
   collision_node_ = robot_->getCollisionNode()->createChildSceneNode();
+  mass_node_ = robot_->getOtherNode()->createChildSceneNode();
+  inertia_node_ = robot_->getOtherNode()->createChildSceneNode();
 
   // create material for coloring links
   static int count = 1;
@@ -209,6 +223,14 @@ RobotLink::RobotLink(
 
   if (collision) {
     createCollision(link);
+  }
+
+  if (mass) {
+    createMass(link);
+  }
+
+  if (inertia) {
+    createInertia(link);
   }
 
   if (collision || visual) {
@@ -323,6 +345,8 @@ RobotLink::~RobotLink()
 
   scene_manager_->destroySceneNode(visual_node_);
   scene_manager_->destroySceneNode(collision_node_);
+  scene_manager_->destroySceneNode(mass_node_);
+  scene_manager_->destroySceneNode(inertia_node_);
 
   if (trail_) {
     scene_manager_->destroyRibbonTrail(trail_);
@@ -350,6 +374,16 @@ void RobotLink::setTransforms(
   if (collision_node_) {
     collision_node_->setPosition(collision_position);
     collision_node_->setOrientation(collision_orientation);
+  }
+
+  if (mass_node_) {
+    mass_node_->setPosition(visual_position);
+    mass_node_->setOrientation(visual_orientation);
+  }
+
+  if (inertia_node_) {
+    inertia_node_->setPosition(visual_position);
+    inertia_node_->setOrientation(visual_orientation);
   }
 
   position_property_->setVector(visual_position);
@@ -441,6 +475,12 @@ void RobotLink::updateVisibility()
   }
   if (collision_node_) {
     collision_node_->setVisible(enabled && robot_->isVisible() && robot_->isCollisionVisible());
+  }
+  if (mass_node_) {
+    mass_node_->setVisible(enabled && robot_->isVisible() && robot_->isMassVisible());
+  }
+  if (inertia_node_) {
+    inertia_node_->setVisible(enabled && robot_->isVisible() && robot_->isInertiaVisible());
   }
   if (trail_) {
     trail_->setVisible(enabled && robot_->isVisible());
@@ -776,6 +816,48 @@ void RobotLink::createVisual(const urdf::LinkConstSharedPtr & link)
     link, visual_meshes_, link->visual_array, link->visual, visual_node_);
 
   visual_node_->setVisible(getEnabled());
+}
+
+void RobotLink::createMass(const urdf::LinkConstSharedPtr & link)
+{
+  if(link->inertial)
+  {
+    // display a sphere sized as if it were a ball of lead
+    // with the same mass as the link
+    // mass = 4/3 pi r^3 density
+    urdf::Pose pose = link->inertial->origin;
+    Ogre::Vector3 translate(pose.position.x, pose.position.y, pose.position.z);
+    Ogre::SceneNode* offset_node = mass_node_->createChildSceneNode(translate);
+    mass_shape_ = new Shape(Shape::Sphere, scene_manager_, offset_node);
+
+    double density_of_lead = 11340;
+    double diameter = 2*cbrt((0.75 * link->inertial->mass) / (M_PI * density_of_lead));
+    mass_shape_->setColor(1,0,0,1);
+    mass_shape_->setScale(Ogre::Vector3(diameter, diameter, diameter));
+  }
+}
+
+void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
+{
+  if(link->inertial)
+  {
+    // display a box sized as if it were a box of uniform density
+    // with the same inertia as the link
+    // Ixx = mass/12 (ly^2 + lz^2)
+    // Iyy = mass/12 (lx^2 + lz^2)
+    // Izz = mass/12 (lx^2 + ly^2)
+    urdf::Pose pose = link->inertial->origin;
+    Ogre::Vector3 translate(pose.position.x, pose.position.y, pose.position.z);
+    Ogre::Quaternion rotate(pose.rotation.w, pose.rotation.x, pose.rotation.y, pose.rotation.z);
+    Ogre::SceneNode* offset_node = inertia_node_->createChildSceneNode(translate, rotate);
+    inertia_shape_ = new Shape(Shape::Cube, scene_manager_, offset_node);
+
+    double length_x = sqrt(6/link->inertial->mass*(link->inertial->iyy + link->inertial->izz - link->inertial->ixx));
+    double length_y = sqrt(6/link->inertial->mass*(link->inertial->ixx + link->inertial->izz - link->inertial->iyy));
+    double length_z = sqrt(6/link->inertial->mass*(link->inertial->ixx + link->inertial->iyy - link->inertial->izz));
+    inertia_shape_->setColor(1,0,0,1);
+    inertia_shape_->setScale(Ogre::Vector3(length_x, length_y, length_z));
+  }
 }
 
 void RobotLink::createSelection()

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -30,6 +30,8 @@
 
 #include "rviz_default_plugins/robot/robot_link.hpp"
 
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include <map>
 #include <memory>
 #include <string>

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -850,12 +850,16 @@ void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
     Ogre::SceneNode * offset_node = inertia_node_->createChildSceneNode(translate, rotate);
     inertia_shape_ = new Shape(Shape::Cube, scene_manager_, offset_node);
 
-    double length_x = sqrt(6/link->inertial->mass * (link->inertial->iyy + link->inertial->izz -
-                                                     link->inertial->ixx));
-    double length_y = sqrt(6/link->inertial->mass * (link->inertial->ixx + link->inertial->izz -
-                                                     link->inertial->iyy));
-    double length_z = sqrt(6/link->inertial->mass * (link->inertial->ixx + link->inertial->iyy -
-                                                     link->inertial->izz));
+    double length_x = sqrt(
+      6 / link->inertial->mass * (link->inertial->iyy + link->inertial->izz -
+      link->inertial->ixx));
+    double length_y = sqrt(
+      6 / link->inertial->mass * (link->inertial->ixx + link->inertial->izz -
+      link->inertial->iyy));
+    double length_z = sqrt(
+      6 / link->inertial->mass * (link->inertial->ixx + link->inertial->iyy -
+      link->inertial->izz));
+
     inertia_shape_->setColor(1, 0, 0, 1);
     inertia_shape_->setScale(Ogre::Vector3(length_x, length_y, length_z));
   }

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -820,27 +820,25 @@ void RobotLink::createVisual(const urdf::LinkConstSharedPtr & link)
 
 void RobotLink::createMass(const urdf::LinkConstSharedPtr & link)
 {
-  if(link->inertial)
-  {
+  if(link->inertial) {
     // display a sphere sized as if it were a ball of lead
     // with the same mass as the link
     // mass = 4/3 pi r^3 density
     urdf::Pose pose = link->inertial->origin;
     Ogre::Vector3 translate(pose.position.x, pose.position.y, pose.position.z);
-    Ogre::SceneNode* offset_node = mass_node_->createChildSceneNode(translate);
+    Ogre::SceneNode * offset_node = mass_node_->createChildSceneNode(translate);
     mass_shape_ = new Shape(Shape::Sphere, scene_manager_, offset_node);
 
     double density_of_lead = 11340;
-    double diameter = 2*cbrt((0.75 * link->inertial->mass) / (M_PI * density_of_lead));
-    mass_shape_->setColor(1,0,0,1);
+    double diameter = 2 * cbrt((0.75 * link->inertial->mass) / (M_PI * density_of_lead));
+    mass_shape_->setColor(1, 0, 0, 1);
     mass_shape_->setScale(Ogre::Vector3(diameter, diameter, diameter));
   }
 }
 
 void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
 {
-  if(link->inertial)
-  {
+  if(link->inertial) {
     // display a box sized as if it were a box of uniform density
     // with the same inertia as the link
     // Ixx = mass/12 (ly^2 + lz^2)
@@ -849,13 +847,16 @@ void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
     urdf::Pose pose = link->inertial->origin;
     Ogre::Vector3 translate(pose.position.x, pose.position.y, pose.position.z);
     Ogre::Quaternion rotate(pose.rotation.w, pose.rotation.x, pose.rotation.y, pose.rotation.z);
-    Ogre::SceneNode* offset_node = inertia_node_->createChildSceneNode(translate, rotate);
+    Ogre::SceneNode * offset_node = inertia_node_->createChildSceneNode(translate, rotate);
     inertia_shape_ = new Shape(Shape::Cube, scene_manager_, offset_node);
 
-    double length_x = sqrt(6/link->inertial->mass*(link->inertial->iyy + link->inertial->izz - link->inertial->ixx));
-    double length_y = sqrt(6/link->inertial->mass*(link->inertial->ixx + link->inertial->izz - link->inertial->iyy));
-    double length_z = sqrt(6/link->inertial->mass*(link->inertial->ixx + link->inertial->iyy - link->inertial->izz));
-    inertia_shape_->setColor(1,0,0,1);
+    double length_x = sqrt(6/link->inertial->mass * (link->inertial->iyy + link->inertial->izz -
+                                                     link->inertial->ixx));
+    double length_y = sqrt(6/link->inertial->mass * (link->inertial->ixx + link->inertial->izz -
+                                                     link->inertial->iyy));
+    double length_z = sqrt(6/link->inertial->mass * (link->inertial->ixx + link->inertial->iyy -
+                                                     link->inertial->izz));
+    inertia_shape_->setColor(1, 0, 0, 1);
     inertia_shape_->setScale(Ogre::Vector3(length_x, length_y, length_z));
   }
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -820,7 +820,7 @@ void RobotLink::createVisual(const urdf::LinkConstSharedPtr & link)
 
 void RobotLink::createMass(const urdf::LinkConstSharedPtr & link)
 {
-  if(link->inertial) {
+  if (link->inertial) {
     // display a sphere sized as if it were a ball of lead
     // with the same mass as the link
     // mass = 4/3 pi r^3 density
@@ -838,7 +838,7 @@ void RobotLink::createMass(const urdf::LinkConstSharedPtr & link)
 
 void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
 {
-  if(link->inertial) {
+  if (link->inertial) {
     // display a box sized as if it were a box of uniform density
     // with the same inertia as the link
     // Ixx = mass/12 (ly^2 + lz^2)

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_view_picker.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_view_picker.hpp
@@ -75,7 +75,7 @@ public:
 
   bool get3DPatch(
     rviz_common::RenderPanel * panel, int x, int y, unsigned width, unsigned height,
-    bool skip_missing, std::vector<Ogre::Vector3> & result_points) override
+    bool skip_missing, std::vector<Ogre::Vector3> & result_points)
   {
     (void) panel;
     (void) skip_missing;

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_view_picker.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_view_picker.hpp
@@ -75,7 +75,7 @@ public:
 
   bool get3DPatch(
     rviz_common::RenderPanel * panel, int x, int y, unsigned width, unsigned height,
-    bool skip_missing, std::vector<Ogre::Vector3> & result_points)
+    bool skip_missing, std::vector<Ogre::Vector3> & result_points) override
   {
     (void) panel;
     (void) skip_missing;


### PR DESCRIPTION
Add mass properties to robot model display, robot, and robot link.
Visual representation is based on gazebo,
i.e. visualize mass as equivalent lead ball and inertia as box, located at center of mass.

Changes are based on: https://github.com/vstuhumanoid/rviz/commit/f215b91db6fd673b8569ef61c7c3a4001fa20cc1