### PR TITLE
clean up rviz render window resize

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -259,12 +259,8 @@ void PointCloudCommon::updateStyle()
 void PointCloudCommon::updateBillboardSize()
 {
   auto mode = static_cast<rviz_rendering::PointCloud::RenderMode>(style_property_->getOptionInt());
-  float size;
-  if (mode == rviz_rendering::PointCloud::RM_POINTS) {
-    size = point_pixel_size_property_->getFloat();
-  } else {
-    size = point_world_size_property_->getFloat();
-  }
+  float size = getSizeForRenderMode(mode);
+
   for (auto & cloud_info : cloud_infos_) {
     cloud_info->cloud_->setDimensions(size, size, size);
     cloud_info->selection_handler_->setBoxSize(getSelectionBoxSize());
@@ -718,7 +714,7 @@ void PointCloudCommon::onDisable()
 float PointCloudCommon::getSelectionBoxSize()
 {
   return style_property_->getOptionInt() != rviz_rendering::PointCloud::RM_POINTS ?
-         point_world_size_property_->getFloat() : 0.004f;
+         point_world_size_property_->getFloat() : point_pixel_size_property_->getFloat();
 }
 
 }  // namespace rviz_default_plugins

--- a/rviz_rendering/include/rviz_rendering/render_window.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_window.hpp
@@ -142,6 +142,9 @@ protected:
   void
   exposeEvent(QExposeEvent * expose_event) override;
 
+  void
+  resizeEvent(QResizeEvent * resize_event) override;
+
   bool
   event(QEvent * event) override;
 

--- a/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
@@ -487,6 +487,7 @@ void PointCloud::addPoints(
 
       internals = createNewRenderable(static_cast<uint32_t>(stop_iterator - current_point));
     }
+
     internals.aabb.merge(current_point->position);
     internals = addPointToHardwareBuffer(
       internals, current_point,
@@ -541,6 +542,7 @@ PointCloud::finishRenderable(
 {
   Ogre::RenderOperation * op = internals.rend->getRenderOperation();
   op->vertexData->vertexCount = vertex_count_of_renderable - op->vertexData->vertexStart;
+
   internals.rend->setBoundingBox(internals.aabb);
   bounding_box_.merge(internals.aabb);
   assert(
@@ -708,6 +710,7 @@ PointCloudRenderablePtr PointCloud::createRenderable(
   Ogre::Vector4 alpha(alpha_, 0.0f, 0.0f, 0.0f);
   Ogre::Vector4 highlight(0.0f, 0.0f, 0.0f, 0.0f);
   Ogre::Vector4 pick_col(pick_color_.r, pick_color_.g, pick_color_.b, pick_color_.a);
+
   rend->setCustomParameter(RVIZ_RENDERING_SIZE_PARAMETER, Ogre::Vector4(point_extensions_));
   rend->setCustomParameter(RVIZ_RENDERING_ALPHA_PARAMETER, alpha);
   rend->setCustomParameter(RVIZ_RENDERING_HIGHLIGHT_PARAMETER, highlight);

--- a/rviz_rendering/src/rviz_rendering/objects/point_cloud_renderable.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/point_cloud_renderable.cpp
@@ -35,100 +35,101 @@
 #include <OgreCamera.h>
 
 #include "rviz_rendering/objects/point_cloud.hpp"
+#include "rviz_rendering/logging.hpp"
 
 namespace rviz_rendering
 {
 
-PointCloudRenderable::PointCloudRenderable(
-  PointCloud * parent, int num_points, bool
-  use_tex_coords, Ogre::RenderOperation::OperationType operationType)
-: parent_(parent)
-{
-  initializeRenderOperation(operationType);
-  specifyBufferContent(use_tex_coords);
-  createAndBindBuffer(num_points);
-}
-
-PointCloudRenderable::~PointCloudRenderable()
-{
-  delete mRenderOp.vertexData;
-  delete mRenderOp.indexData;
-}
-
-Ogre::HardwareVertexBufferSharedPtr PointCloudRenderable::getBuffer()
-{
-  return mRenderOp.vertexData->vertexBufferBinding->getBuffer(0);
-}
-
-void PointCloudRenderable::_notifyCurrentCamera(Ogre::Camera * camera)
-{
-  Ogre::SimpleRenderable::_notifyCurrentCamera(camera);
-}
-
-Ogre::Real PointCloudRenderable::getBoundingRadius() const
-{
-  return Ogre::Math::Sqrt(
-    std::max(
-      mBox.getMaximum().squaredLength(),
-      mBox.getMinimum().squaredLength()));
-}
-
-Ogre::Real PointCloudRenderable::getSquaredViewDepth(const Ogre::Camera * cam) const
-{
-  Ogre::Vector3 vMin, vMax, vMid, vDist;
-  vMin = mBox.getMinimum();
-  vMax = mBox.getMaximum();
-  vMid = ((vMax - vMin) * 0.5) + vMin;
-  vDist = cam->getDerivedPosition() - vMid;
-
-  return vDist.squaredLength();
-}
-
-void PointCloudRenderable::getWorldTransforms(Ogre::Matrix4 * xform) const
-{
-  parent_->getWorldTransforms(xform);
-}
-
-const Ogre::LightList & PointCloudRenderable::getLights() const
-{
-  return parent_->queryLights();
-}
-
-void PointCloudRenderable::initializeRenderOperation(
-  Ogre::RenderOperation::OperationType operation_type)
-{
-  mRenderOp.operationType = operation_type;
-  mRenderOp.useIndexes = false;
-  mRenderOp.vertexData = new Ogre::VertexData;
-  mRenderOp.vertexData->vertexStart = 0;
-  mRenderOp.vertexData->vertexCount = 0;
-}
-
-void PointCloudRenderable::specifyBufferContent(bool use_tex_coords)
-{
-  Ogre::VertexDeclaration * declaration = mRenderOp.vertexData->vertexDeclaration;
-  size_t offset = 0;
-
-  declaration->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
-  offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
-
-  if (use_tex_coords) {
-    declaration->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_TEXTURE_COORDINATES, 0);
-    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+  PointCloudRenderable::PointCloudRenderable(
+      PointCloud *parent, int num_points, bool use_tex_coords, Ogre::RenderOperation::OperationType operationType)
+      : parent_(parent)
+  {
+    initializeRenderOperation(operationType);
+    specifyBufferContent(use_tex_coords);
+    createAndBindBuffer(num_points);
   }
 
-  declaration->addElement(0, offset, Ogre::VET_COLOUR, Ogre::VES_DIFFUSE);
-}
+  PointCloudRenderable::~PointCloudRenderable()
+  {
+    delete mRenderOp.vertexData;
+    delete mRenderOp.indexData;
+  }
 
-void PointCloudRenderable::createAndBindBuffer(int num_points)
-{
-  Ogre::HardwareVertexBufferSharedPtr vertexBuffer =
-    Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
-    mRenderOp.vertexData->vertexDeclaration->getVertexSize(0),
-    num_points,
-    Ogre::HardwareBuffer::HBU_DYNAMIC);
+  Ogre::HardwareVertexBufferSharedPtr PointCloudRenderable::getBuffer()
+  {
+    return mRenderOp.vertexData->vertexBufferBinding->getBuffer(0);
+  }
 
-  mRenderOp.vertexData->vertexBufferBinding->setBinding(0, vertexBuffer);
-}
+  void PointCloudRenderable::_notifyCurrentCamera(Ogre::Camera *camera)
+  {
+    Ogre::SimpleRenderable::_notifyCurrentCamera(camera);
+  }
 
-}  // namespace rviz_rendering
+  Ogre::Real PointCloudRenderable::getBoundingRadius() const
+  {
+    return Ogre::Math::Sqrt(
+        std::max(
+            mBox.getMaximum().squaredLength(),
+            mBox.getMinimum().squaredLength()));
+  }
+
+  Ogre::Real PointCloudRenderable::getSquaredViewDepth(const Ogre::Camera *cam) const
+  {
+    Ogre::Vector3 vMin, vMax, vMid, vDist;
+    vMin = mBox.getMinimum();
+    vMax = mBox.getMaximum();
+    vMid = ((vMax - vMin) * 0.5) + vMin;
+    vDist = cam->getDerivedPosition() - vMid;
+
+    return vDist.squaredLength();
+  }
+
+  void PointCloudRenderable::getWorldTransforms(Ogre::Matrix4 *xform) const
+  {
+    parent_->getWorldTransforms(xform);
+  }
+
+  const Ogre::LightList &PointCloudRenderable::getLights() const
+  {
+    return parent_->queryLights();
+  }
+
+  void PointCloudRenderable::initializeRenderOperation(
+      Ogre::RenderOperation::OperationType operation_type)
+  {
+    mRenderOp.operationType = operation_type;
+    mRenderOp.useIndexes = false;
+    mRenderOp.vertexData = new Ogre::VertexData;
+    mRenderOp.vertexData->vertexStart = 0;
+    mRenderOp.vertexData->vertexCount = 0;
+  }
+
+  void PointCloudRenderable::specifyBufferContent(bool use_tex_coords)
+  {
+    Ogre::VertexDeclaration *declaration = mRenderOp.vertexData->vertexDeclaration;
+    size_t offset = 0;
+
+    declaration->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_POSITION);
+    offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+
+    if (use_tex_coords)
+    {
+      declaration->addElement(0, offset, Ogre::VET_FLOAT3, Ogre::VES_TEXTURE_COORDINATES, 0);
+      offset += Ogre::VertexElement::getTypeSize(Ogre::VET_FLOAT3);
+    }
+
+    declaration->addElement(0, offset, Ogre::VET_COLOUR, Ogre::VES_DIFFUSE);
+  }
+
+  void PointCloudRenderable::createAndBindBuffer(int num_points)
+  {
+    Ogre::HardwareVertexBufferSharedPtr vertexBuffer =
+        Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
+            mRenderOp.vertexData->vertexDeclaration->getVertexSize(0),
+            num_points,
+            Ogre::HardwareBuffer::HBU_DYNAMIC);
+
+    mRenderOp.vertexData->vertexBufferBinding->setBinding(0, vertexBuffer);
+  }
+
+} // namespace rviz_rendering

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -231,13 +231,13 @@ RenderWindowImpl::initialize()
   }
 
   if (ogre_camera_) {
+    ogre_camera_->setAspectRatio(
+      Ogre::Real(parent_->width()) / Ogre::Real(parent_->height()));
+    ogre_camera_->setAutoAspectRatio(true);
+
     ogre_viewport_ = ogre_render_window_->addViewport(ogre_camera_);
     auto bg_color = Ogre::ColourValue(0.937254902f, 0.921568627f, 0.905882353f);  // Qt background
     ogre_viewport_->setBackgroundColour(bg_color);
-
-    ogre_camera_->setAspectRatio(
-      Ogre::Real(ogre_render_window_->getWidth()) / Ogre::Real(ogre_render_window_->getHeight()));
-    ogre_camera_->setAutoAspectRatio(true);
 
     Ogre::TextureManager::getSingleton().setDefaultNumMipmaps(5);
     Ogre::ResourceGroupManager::getSingleton().initialiseAllResourceGroups();
@@ -260,13 +260,8 @@ RenderWindowImpl::resize(size_t width, size_t height)
 {
   if (ogre_render_window_) {
     this->setCameraAspectRatio();
-    ogre_render_window_->resize(
-      static_cast<unsigned int>(width),  // NOLINT
-      static_cast<unsigned int>(height)  // NOLINT
-    );
     ogre_render_window_->windowMovedOrResized();
   }
-  this->renderLater();
 }
 
 #if 0
@@ -477,16 +472,15 @@ void RenderWindowImpl::setBackgroundColor(Ogre::ColourValue background_color)
 
 void RenderWindowImpl::setCameraAspectRatio()
 {
-  // auto width = parent_->width();
-  auto width = parent_->width() ? parent_->width() : 100;
-  // auto height = parent_->height();
-  auto height = parent_->height() ? parent_->height() : 100;
+  auto width = parent_->width();
+  //auto width = ogre_render_window_->getWidth() ? ogre_render_window_->getWidth() : 100;
+  auto height = parent_->height();
+  //auto height = ogre_render_window_->getHeight() ? ogre_render_window_->getHeight() : 100;
   if (ogre_camera_) {
     ogre_camera_->setAspectRatio(Ogre::Real(width) / Ogre::Real(height));
     // if (right_ogre_camera_) {
     //   right_ogre_camera_->setAspectRatio(Ogre::Real(width()) / Ogre::Real(height()));
     // }
-
     if (ogre_camera_->getProjectionType() == Ogre::PT_ORTHOGRAPHIC) {
       Ogre::Matrix4 proj = buildScaledOrthoMatrix(
         -width / ortho_scale_ / 2, width / ortho_scale_ / 2,

--- a/rviz_rendering/src/rviz_rendering/render_window.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window.cpp
@@ -43,6 +43,7 @@
 //   https://doc.qt.io/qt-5/qtgui-openglwindow-openglwindow-cpp.html
 
 #include "rviz_rendering/render_window.hpp"
+#include "rviz_rendering/logging.hpp"
 
 #include <OgreCamera.h>
 
@@ -119,8 +120,10 @@ RenderWindow::setupSceneAfterInit(setupSceneCallback setup_scene_callback)
 
 void RenderWindow::windowMovedOrResized()
 {
-  // It seems that the 'width' and 'height' parameters of the resize() method don't play a role here
-  impl_->resize(0, 0);
+  if (this->isExposed()) {
+    impl_->resize(this->width(), this->height());
+    this->renderNow();
+  }
 }
 
 void
@@ -152,6 +155,11 @@ ToString(const EnumType & enumValue)
   return QString("%1::%2").arg(enumName).arg(static_cast<int>(enumValue));
 }
 
+void RenderWindow::resizeEvent(QResizeEvent * resize_event)
+{
+  windowMovedOrResized();
+}
+
 bool
 RenderWindow::event(QEvent * event)
 {
@@ -159,11 +167,6 @@ RenderWindow::event(QEvent * event)
   //   "[" << QTime::currentTime().toString("HH:mm:ss:zzz") << "]:" <<
   //   "event->type() ==" << ToString(event->type());
   switch (event->type()) {
-    case QEvent::Resize:
-      if (this->isExposed()) {
-        impl_->resize(this->width(), this->height());
-      }
-      return QWindow::event(event);
     case QEvent::UpdateRequest:
       this->renderNow();
       return true;
@@ -192,10 +195,7 @@ RenderWindow::exposeEvent(QExposeEvent * expose_event)
 {
   Q_UNUSED(expose_event);
 
-  if (this->isExposed()) {
-    impl_->resize(this->width(), this->height());
-    this->renderNow();
-  }
+  windowMovedOrResized();
 }
 
 // bool


### PR DESCRIPTION
I was trying to [debug this rviz points resize issue](https://github.com/ros-visualization/rviz/issues/1508) that was first reported on ROS noetic, but has since now affected every ROS release since.

I was trying to dig in and figure out what was going on....havent fixed it yet but I have found a few things that could be improved going forward.

I can make another PR for the main `ros2` branch as well with these same changes if wanted.