### PR TITLE
Set topic namespace in interactive markers display

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
@@ -84,6 +84,8 @@ protected:
 
   void onDisable() override;
 
+  void setTopic(const QString & topic, const QString & datatype) override;
+
 protected Q_SLOTS:
   void namespaceChanged();
   void updateShowDescriptions();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
@@ -148,8 +148,8 @@ void InteractiveMarkerDisplay::setTopic(const QString & topic, const QString & d
   (void) datatype;
 
   // Separate the namespace from the rest of the topic name, usually formatted '/namespace/update'
-  std::string s = topic.toStdString();
-  std::string topic_namespace = s.substr(0, s.find('/', 1));
+  std::string topic_name = topic.toStdString();
+  std::string topic_namespace = topic_name.substr(0, topic_name.find('/', 1));
 
   interactive_marker_namespace_property_->setString(QString::fromStdString(topic_namespace));
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
@@ -143,6 +143,17 @@ void InteractiveMarkerDisplay::onDisable()
   unsubscribe();
 }
 
+void InteractiveMarkerDisplay::setTopic(const QString & topic, const QString & datatype)
+{
+  (void) datatype;
+
+  // Separate the namespace from the rest of the topic name, usually formatted '/namespace/update'
+  std::string s = topic.toStdString();
+  std::string topic_namespace = s.substr(0, s.find('/', 1));
+
+  interactive_marker_namespace_property_->setString(QString::fromStdString(topic_namespace));
+}
+
 void InteractiveMarkerDisplay::namespaceChanged()
 {
   unsubscribe();


### PR DESCRIPTION
Fixes #658 

The interactive markers display inherits from `Display` instead of `RosTopicDisplay`, so it was missing the `setTopic()` function. With these changes, the topic namespace will now be set by default when adding the interactive markers display by topic.

Signed-off-by: Rebecca Butler <rebecca@openrobotics.org>