### PR TITLE
Add rviz_rendering dependency to rviz_common

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -246,6 +246,7 @@ ament_target_dependencies(rviz_common
   rclcpp
   resource_retriever
   rviz_assimp_vendor
+  rviz_rendering
   sensor_msgs
   std_msgs
   tf2

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -235,7 +235,6 @@ target_link_libraries(rviz_common
   PUBLIC
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
-  rviz_rendering::rviz_rendering
   Qt5::Widgets
 )
 


### PR DESCRIPTION
I was unable to build `rviz_common` due to the following error in `visualizer_app.cpp`:

```
error: ‘get’ is not a member of ‘rviz_rendering::OgreLogging’
  280 |     rviz_rendering::OgreLogging::get()->useLogFileAndStandardOut();
```

Adding the missing dependency on `rviz_rendering` seems to fix the issue.

Signed-off-by: Rebecca Butler <rebecca@openrobotics.org>