### PR TITLE
Backport #718 (Fix using plugins on Windows) into foxy

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
@@ -54,6 +54,8 @@
 
 #include "rviz_default_plugins/displays/interactive_markers/interactive_marker_control.hpp"
 
+#include "rviz_default_plugins/visibility_control.hpp"
+
 namespace Ogre
 {
 class SceneNode;
@@ -72,7 +74,7 @@ namespace displays
 {
 class InteractiveMarkerDisplay;
 
-class InteractiveMarker : public QObject
+class RVIZ_DEFAULT_PLUGINS_PUBLIC InteractiveMarker : public QObject
 {
   Q_OBJECT
 


### PR DESCRIPTION
To reiterate the description from #718:

On Windows, when attempting to use the MoveIt2 Rviz plugins, they would all fail to load, and I would get errors like

```
PluginlibFactory: The plugin for class 'moveit_rviz_plugin/PlanningScene' failed to load. Error: Failed to load library
```

I was able to fix these errors by exporting InteractiveMarkers