### PR TITLE
Fix for ogre failing when material already exists

### DIFF
--- a/rviz_rendering/src/rviz_rendering/material_manager.cpp
+++ b/rviz_rendering/src/rviz_rendering/material_manager.cpp
@@ -122,9 +122,9 @@ void MaterialManager::enableAlphaBlending(
 
 void MaterialManager::createDefaultMaterials()
 {
-  auto material = Ogre::MaterialManager::getSingleton().create(
+  auto retrieve_result = Ogre::MaterialManager::getSingleton().createOrRetrieve(
     "BaseWhiteNoLighting", "rviz_rendering");
-  material->setLightingEnabled(false);
+  std::dynamic_pointer_cast<Ogre::Material>(retrieve_result.first)->setLightingEnabled(false);
 }
 
 }  // namespace rviz_rendering

--- a/rviz_rendering/src/rviz_rendering/material_manager.cpp
+++ b/rviz_rendering/src/rviz_rendering/material_manager.cpp
@@ -124,7 +124,10 @@ void MaterialManager::createDefaultMaterials()
 {
   auto retrieve_result = Ogre::MaterialManager::getSingleton().createOrRetrieve(
     "BaseWhiteNoLighting", "rviz_rendering");
-  std::dynamic_pointer_cast<Ogre::Material>(retrieve_result.first)->setLightingEnabled(false);
+   auto material = std::dynamic_pointer_cast<Ogre::Material>(retrieve_result.first);
+   if (material) {
+     material->setLightingEnabled(false);
+   }
 }
 
 }  // namespace rviz_rendering

--- a/rviz_rendering/src/rviz_rendering/material_manager.cpp
+++ b/rviz_rendering/src/rviz_rendering/material_manager.cpp
@@ -124,10 +124,10 @@ void MaterialManager::createDefaultMaterials()
 {
   auto retrieve_result = Ogre::MaterialManager::getSingleton().createOrRetrieve(
     "BaseWhiteNoLighting", "rviz_rendering");
-   auto material = std::dynamic_pointer_cast<Ogre::Material>(retrieve_result.first);
-   if (material) {
-     material->setLightingEnabled(false);
-   }
+  auto material = std::dynamic_pointer_cast<Ogre::Material>(retrieve_result.first);
+  if (material) {
+    material->setLightingEnabled(false);
+  }
 }
 
 }  // namespace rviz_rendering


### PR DESCRIPTION
This came up in the RoboStack project where we're using a more recent OGRE