### PR TITLE
Fix memory leaks in dialog handling

### DIFF
--- a/rviz_common/src/rviz_common/displays_panel.cpp
+++ b/rviz_common/src/rviz_common/displays_panel.cpp
@@ -119,7 +119,7 @@ void DisplaysPanel::onNewDisplay()
   QStringList empty;
 
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  AddDisplayDialog * dialog = new AddDisplayDialog(
+  AddDisplayDialog dialog(
     vis_manager_->getDisplayFactory(),
     empty,
     empty,
@@ -131,7 +131,7 @@ void DisplaysPanel::onNewDisplay()
   QApplication::restoreOverrideCursor();
 
   vis_manager_->stopUpdate();
-  if (dialog->exec() == QDialog::Accepted) {
+  if (dialog.exec() == QDialog::Accepted) {
     Display * disp = vis_manager_->createDisplay(lookup_name, display_name, true);
     if (!topic.isEmpty() && !datatype.isEmpty()) {
       disp->setTopic(topic, datatype);
@@ -139,7 +139,6 @@ void DisplaysPanel::onNewDisplay()
   }
   vis_manager_->startUpdate();
   activateWindow();  // Force keyboard focus back on main window.
-  delete dialog;
 }
 
 void DisplaysPanel::onDuplicateDisplay()

--- a/rviz_common/src/rviz_common/properties/color_editor.cpp
+++ b/rviz_common/src/rviz_common/properties/color_editor.cpp
@@ -108,17 +108,17 @@ void ColorEditor::onButtonClick()
   ColorProperty * prop = property_;
   QColor original_color = prop->getColor();
 
-  QColorDialog * dialog = new QColorDialog(color_, parentWidget() );
+  QColorDialog dialog(color_, parentWidget());
 
   connect(
-    dialog, SIGNAL(currentColorChanged(const QColor&)),
+    &dialog, SIGNAL(currentColorChanged(const QColor&)),
     property_, SLOT(setColor(const QColor&)));
 
   // Without this connection the PropertyTreeWidget does not update
   // the color info "live" when it changes in the dialog and the 3D
   // view.
   connect(
-    dialog, SIGNAL(currentColorChanged(const QColor&)),
+    &dialog, SIGNAL(currentColorChanged(const QColor&)),
     parentWidget(), SLOT(update()));
 
   // On the TWM window manager under linux, and on OSX, this
@@ -131,7 +131,7 @@ void ColorEditor::onButtonClick()
   // deleteLater() will take effect and "this" will be destroyed.
   // Therefore, everything we do in this function after dialog->exec()
   // should only use variables on the stack, not member variables.
-  if (dialog->exec() != QDialog::Accepted) {
+  if (dialog.exec() != QDialog::Accepted) {
     prop->setColor(original_color);
   }
 }

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -708,11 +708,13 @@ void VisualizationFrame::loadDisplayConfig(const QString & qpath)
   setWindowModified(false);
   loading_ = true;
 
-  LoadingDialog * dialog = nullptr;
+  std::unique_ptr<LoadingDialog> dialog;
   if (initialized_) {
-    dialog = new LoadingDialog(this);
+    dialog.reset(new LoadingDialog(this));
     dialog->show();
-    connect(this, SIGNAL(statusUpdate(const QString&)), dialog, SLOT(showMessage(const QString&)));
+    connect(
+      this, SIGNAL(statusUpdate(const QString&)),
+      dialog.get(), SLOT(showMessage(const QString&)));
   }
 
   YamlConfigReader reader;
@@ -731,8 +733,6 @@ void VisualizationFrame::loadDisplayConfig(const QString & qpath)
   setDisplayConfigFile(path);
 
   last_config_dir_ = path_info.absolutePath().toStdString();
-
-  delete dialog;
 
   post_load_timer_->start(1000);
 }


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

Related to this PR in rviz https://github.com/ros-visualization/rviz/pull/1602/files.

Fixed some memory leaks in dialog handling