### PR TITLE
Efficiently handle 3-bytes pixel formats

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -261,16 +261,16 @@ void SelectionManager::setHighlightRect(Ogre::Viewport * viewport, int x1, int y
 
 void SelectionManager::unpackColors(const Ogre::PixelBox & box)
 {
-  auto w = box.getWidth();
-  auto h = box.getHeight();
+  uint32_t w = box.getWidth();
+  uint32_t h = box.getHeight();
 
   pixel_buffer_.clear();
   pixel_buffer_.reserve(w * h);
 
   size_t size = Ogre::PixelUtil::getMemorySize(1, 1, 1, box.format);
 
-  for (unsigned int y = 0; y < h; y++) {
-    for (unsigned int x = 0; x < w; x++) {
+  for (uint32_t y = 0; y < h; y++) {
+    for (uint32_t x = 0; x < w; x++) {
       uint32_t pos = (x + y * w) * size;
       uint32_t pix_val = 0;
       memcpy(

--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -267,14 +267,17 @@ void SelectionManager::unpackColors(const Ogre::PixelBox & box)
   pixel_buffer_.clear();
   pixel_buffer_.reserve(w * h);
 
-  for (uint32_t y = 0; y < h; ++y) {
-    for (uint32_t x = 0; x < w; ++x) {
-      uint32_t pos = (x + y * w) * 4;
+  size_t size = Ogre::PixelUtil::getMemorySize(1, 1, 1, box.format);
 
-      uint32_t pix_val = *reinterpret_cast<uint32_t *>(static_cast<uint8_t *>(box.data) + pos);
-      uint32_t handle = colorToHandle(box.format, pix_val);
-
-      pixel_buffer_.push_back(handle);
+  for (unsigned int y = 0; y < h; y++) {
+    for (unsigned int x = 0; x < w; x++) {
+      uint32_t pos = (x + y * w) * size;
+      uint32_t pix_val = 0;
+      memcpy(
+        reinterpret_cast<uint8_t *>(&pix_val),
+        reinterpret_cast<uint8_t *>(box.data + pos),
+        size);
+      pixel_buffer_.push_back(colorToHandle(box.format, pix_val));
     }
   }
 }

--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -271,7 +271,7 @@ void SelectionManager::unpackColors(const Ogre::PixelBox & box)
 
   for (uint32_t y = 0; y < h; y++) {
     for (uint32_t x = 0; x < w; x++) {
-      uint32_t pos = (x + y * w) * size;
+      uint32_t pos = static_cast<uint32_t>((x + y * w) * size);
       uint32_t pix_val = 0;
       memcpy(
         reinterpret_cast<uint8_t *>(&pix_val),


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

Related to this commit in RVIZ1 https://github.com/rhaschke/rviz/commit/2b31dc4be241e3ebd3a92c0f94d56fdb71391d51