### PR TITLE
Handle NaN values for Wrench msgs

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/wrench/wrench_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/wrench/wrench_display.hpp
@@ -93,7 +93,7 @@ private:
 
   std::deque<std::shared_ptr<rviz_rendering::WrenchVisual>> visuals_;
 
-  rviz_common::properties::BoolProperty * accept_NaN_values_;
+  rviz_common::properties::BoolProperty * accept_nan_values_;
   rviz_common::properties::ColorProperty * force_color_property_;
   rviz_common::properties::ColorProperty * torque_color_property_;
   rviz_common::properties::FloatProperty * alpha_property_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/wrench/wrench_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/wrench/wrench_display.hpp
@@ -93,6 +93,7 @@ private:
 
   std::deque<std::shared_ptr<rviz_rendering::WrenchVisual>> visuals_;
 
+  rviz_common::properties::BoolProperty * accept_NaN_values_;
   rviz_common::properties::ColorProperty * force_color_property_;
   rviz_common::properties::ColorProperty * torque_color_property_;
   rviz_common::properties::FloatProperty * alpha_property_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -133,9 +133,9 @@ bool validateFloats(const geometry_msgs::msg::WrenchStamped & msg)
 void WrenchDisplay::processMessage(geometry_msgs::msg::WrenchStamped::ConstSharedPtr msg)
 {
   auto adjusted_msg = std::make_shared<geometry_msgs::msg::WrenchStamped>();
-  bool accept_NaN = accept_nan_values_->getBool();
+  bool accept_nan = accept_nan_values_->getBool();
 
-  if (!accept_NaN) {
+  if (!accept_nan) {
     if (!validateFloats(*msg)) {
       setStatus(
         rviz_common::properties::StatusProperty::Error, "Topic",
@@ -143,15 +143,18 @@ void WrenchDisplay::processMessage(geometry_msgs::msg::WrenchStamped::ConstShare
       return;
     }
   } else {
-      adjusted_msg->wrench.force.x = (std::isnan(msg->wrench.force.x)) ?  0.0 : msg->wrench.force.x;
-      adjusted_msg->wrench.force.y = (std::isnan(msg->wrench.force.y)) ?  0.0 : msg->wrench.force.y;
-      adjusted_msg->wrench.force.z = (std::isnan(msg->wrench.force.z)) ?  0.0 : msg->wrench.force.z;
+    adjusted_msg->wrench.force.x = (std::isnan(msg->wrench.force.x)) ?  0.0 : msg->wrench.force.x;
+    adjusted_msg->wrench.force.y = (std::isnan(msg->wrench.force.y)) ?  0.0 : msg->wrench.force.y;
+    adjusted_msg->wrench.force.z = (std::isnan(msg->wrench.force.z)) ?  0.0 : msg->wrench.force.z;
 
-      adjusted_msg->wrench.torque.x = (std::isnan(msg->wrench.torque.x)) ?  0.0 : msg->wrench.torque.x;
-      adjusted_msg->wrench.torque.y = (std::isnan(msg->wrench.torque.y)) ?  0.0 : msg->wrench.torque.y;
-      adjusted_msg->wrench.torque.z = (std::isnan(msg->wrench.torque.z)) ?  0.0 : msg->wrench.torque.z;
+    adjusted_msg->wrench.torque.x = (std::isnan(msg->wrench.torque.x)) ?  0.0 :
+      msg->wrench.torque.x;
+    adjusted_msg->wrench.torque.y = (std::isnan(msg->wrench.torque.y)) ?  0.0 :
+      msg->wrench.torque.y;
+    adjusted_msg->wrench.torque.z = (std::isnan(msg->wrench.torque.z)) ?  0.0 :
+      msg->wrench.torque.z;
 
-      if (!validateFloats(*msg)) {
+    if (!validateFloats(*msg)) {
       setStatus(
         rviz_common::properties::StatusProperty::Error, "Topic",
         "Message contained invalid floating point values (nans or infs)");
@@ -178,7 +181,7 @@ void WrenchDisplay::processMessage(geometry_msgs::msg::WrenchStamped::ConstShare
     visuals_.pop_front();
   }
 
-  auto visual = (!accept_NaN) ? createWrenchVisual(msg, orientation, position) :
+  auto visual = (!accept_nan) ? createWrenchVisual(msg, orientation, position) :
     createWrenchVisual(adjusted_msg, orientation, position);
 
   visuals_.push_back(visual);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -134,7 +134,6 @@ bool validateFloats(const geometry_msgs::msg::WrenchStamped & msg)
 void WrenchDisplay::processMessage(geometry_msgs::msg::WrenchStamped::ConstSharedPtr msg)
 {
   auto custom_msg = std::make_shared<geometry_msgs::msg::WrenchStamped>();
-  bool accept_NaN = accept_NaN_values_->getBool();
 
   if (!accept_NaN) {
     if (!validateFloats(*msg)) {

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -52,7 +52,7 @@ namespace displays
 WrenchDisplay::WrenchDisplay()
 {
   accept_NaN_values_ = new rviz_common::properties::BoolProperty(
-    "Accept NaN Values", true,
+    "Accept NaN Values", false,
     "Convert NaN values to 0 if checked.", this, SLOT(updateWrenchVisuals()));
 
   force_color_property_ = new rviz_common::properties::ColorProperty(

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -53,7 +53,8 @@ WrenchDisplay::WrenchDisplay()
 {
   accept_nan_values_ = new rviz_common::properties::BoolProperty(
     "Accept NaN Values", false,
-    "NaN values in incoming messages are converted to 0 to display wrench vector.", this, SLOT(updateWrenchVisuals()));
+    "NaN values in incoming messages are converted to 0 to display wrench vector.", this,
+    SLOT(updateWrenchVisuals()));
 
   force_color_property_ = new rviz_common::properties::ColorProperty(
     "Force Color", QColor(204, 51, 51), "Color to draw the force arrows.", this,
@@ -100,7 +101,6 @@ void WrenchDisplay::reset()
 
 void WrenchDisplay::updateWrenchVisuals()
 {
-  // bool accept_NaN = accept_NaN_values_->getBool();
   float alpha = alpha_property_->getFloat();
   float force_scale = force_scale_property_->getFloat();
   float torque_scale = torque_scale_property_->getFloat();
@@ -109,7 +109,6 @@ void WrenchDisplay::updateWrenchVisuals()
   Ogre::ColourValue torque_color = torque_color_property_->getOgreColor();
 
   for (const auto & visual : visuals_) {
-    // visual->setNaN(accept_NaN);
     visual->setForceColor(force_color.r, force_color.g, force_color.b, alpha);
     visual->setTorqueColor(torque_color.r, torque_color.g, torque_color.b, alpha);
     visual->setForceScale(force_scale);
@@ -205,7 +204,6 @@ std::shared_ptr<rviz_rendering::WrenchVisual> WrenchDisplay::createWrenchVisual(
   visual->setFramePosition(position);
   visual->setFrameOrientation(orientation);
 
-  // bool accept_NaN = accept_NaN_values_->getBool();
   float alpha = alpha_property_->getFloat();
   float force_scale = force_scale_property_->getFloat();
   float torque_scale = torque_scale_property_->getFloat();
@@ -213,7 +211,6 @@ std::shared_ptr<rviz_rendering::WrenchVisual> WrenchDisplay::createWrenchVisual(
   Ogre::ColourValue force_color = force_color_property_->getOgreColor();
   Ogre::ColourValue torque_color = torque_color_property_->getOgreColor();
 
-  // visual->setNaN(accept_NaN);
   visual->setForceColor(force_color.r, force_color.g, force_color.b, alpha);
   visual->setTorqueColor(torque_color.r, torque_color.g, torque_color.b, alpha);
   visual->setForceScale(force_scale);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -143,15 +143,15 @@ void WrenchDisplay::processMessage(geometry_msgs::msg::WrenchStamped::ConstShare
       return;
     }
   } else {
-    adjusted_msg->wrench.force.x = (std::isnan(msg->wrench.force.x)) ?  0.0 : msg->wrench.force.x;
-    adjusted_msg->wrench.force.y = (std::isnan(msg->wrench.force.y)) ?  0.0 : msg->wrench.force.y;
-    adjusted_msg->wrench.force.z = (std::isnan(msg->wrench.force.z)) ?  0.0 : msg->wrench.force.z;
+    adjusted_msg->wrench.force.x = (std::isnan(msg->wrench.force.x)) ? 0.0 : msg->wrench.force.x;
+    adjusted_msg->wrench.force.y = (std::isnan(msg->wrench.force.y)) ? 0.0 : msg->wrench.force.y;
+    adjusted_msg->wrench.force.z = (std::isnan(msg->wrench.force.z)) ? 0.0 : msg->wrench.force.z;
 
-    adjusted_msg->wrench.torque.x = (std::isnan(msg->wrench.torque.x)) ?  0.0 :
+    adjusted_msg->wrench.torque.x = (std::isnan(msg->wrench.torque.x)) ? 0.0 :
       msg->wrench.torque.x;
-    adjusted_msg->wrench.torque.y = (std::isnan(msg->wrench.torque.y)) ?  0.0 :
+    adjusted_msg->wrench.torque.y = (std::isnan(msg->wrench.torque.y)) ? 0.0 :
       msg->wrench.torque.y;
-    adjusted_msg->wrench.torque.z = (std::isnan(msg->wrench.torque.z)) ?  0.0 :
+    adjusted_msg->wrench.torque.z = (std::isnan(msg->wrench.torque.z)) ? 0.0 :
       msg->wrench.torque.z;
 
     if (!validateFloats(*msg)) {

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -133,7 +133,7 @@ bool validateFloats(const geometry_msgs::msg::WrenchStamped & msg)
 
 void WrenchDisplay::processMessage(geometry_msgs::msg::WrenchStamped::ConstSharedPtr msg)
 {
-  auto custom_msg = std::make_shared<geometry_msgs::msg::WrenchStamped>();
+  auto adjusted_msg = std::make_shared<geometry_msgs::msg::WrenchStamped>();
 
   if (!accept_NaN) {
     if (!validateFloats(*msg)) {

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/wrench/wrench_display.cpp
@@ -53,7 +53,7 @@ WrenchDisplay::WrenchDisplay()
 {
   accept_NaN_values_ = new rviz_common::properties::BoolProperty(
     "Accept NaN Values", false,
-    "Convert NaN values to 0 if checked.", this, SLOT(updateWrenchVisuals()));
+    "NaN values in incoming messages are converted to 0 to display wrench vector.", this, SLOT(updateWrenchVisuals()));
 
   force_color_property_ = new rviz_common::properties::ColorProperty(
     "Force Color", QColor(204, 51, 51), "Color to draw the force arrows.", this,


### PR DESCRIPTION
**Problems in Rviz**
1. Rviz can not process NaN values and shows error
2. In ROS2 controllers, NaN values are being used to indicate unavailable axis for Wrench messages. And it leads to error in Rviz.

**This PR will contain the changes to,**

1. handle NaN values for Wrench messages (in this PR).
2. add a 'checkbox' to enable/disable this feature.
3. If NaN values are received in Wrench messages and the 'checkbox' is marked, it will be converted to 0.0. If disabled, it will work as existing Rviz.
