### PR TITLE
[foxy backport] Ensure rviz_common::MessageFilterDisplay processes messages in the main thread (#620)

### DIFF
--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -127,7 +127,7 @@ protected:
       tf_filter_->connectInput(*subscription_);
       tf_filter_->registerCallback(
         std::bind(
-          &MessageFilterDisplay<MessageType>::messageTaken, this,
+          &MessageFilterDisplay<MessageType>::incomingMessage, this,
           std::placeholders::_1));
       setStatus(properties::StatusProperty::Ok, "Topic", "OK");
     } catch (rclcpp::exceptions::InvalidTopicNameError & e) {
@@ -174,7 +174,7 @@ protected:
     reset();
   }
 
-  void messageTaken(typename MessageType::ConstSharedPtr msg)
+  void incomingMessage(const typename MessageType::ConstSharedPtr msg)
   {
     if (!msg) {
       return;
@@ -187,7 +187,7 @@ protected:
     Q_EMIT typeErasedMessageTaken(std::static_pointer_cast<const void>(msg));
   }
 
-  void processTypeErasedMessage(std::shared_ptr<const void> type_erased_msg) override
+  void processTypeErasedMessage(std::shared_ptr<const void> type_erased_msg)
   {
     auto msg = std::static_pointer_cast<const MessageType>(type_erased_msg);
 

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -51,6 +51,12 @@
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
 #include "rviz_common/visibility_control.hpp"
 
+// Required, in combination with
+// `qRegisterMetaType<std::shared_ptr<const void>>` so that this
+// type can be queued by Qt slots.
+// See: http://doc.qt.io/qt-5/qmetatype.html#qRegisterMetaType-1
+Q_DECLARE_METATYPE(std::shared_ptr<const void>)
+
 namespace rviz_common
 {
 
@@ -66,6 +72,8 @@ public:
   : rviz_ros_node_(),
     qos_profile(5)
   {
+    qRegisterMetaType<std::shared_ptr<const void>>();
+
     topic_property_ = new properties::RosTopicProperty(
       "Topic", "",
       "", "", this, SLOT(updateTopic()));
@@ -92,9 +100,27 @@ public:
         this->qos_profile = profile;
         updateTopic();
       });
+
+    // Useful to _ROSTopicDisplay subclasses to ensure GUI updates
+    // are performed by the main thread only.
+    connect(
+      this,
+      SIGNAL(typeErasedMessageTaken(std::shared_ptr<const void>)),
+      this,
+      SLOT(processTypeErasedMessage(std::shared_ptr<const void>)),
+      // Force queued connections regardless of QObject thread affinity
+      Qt::QueuedConnection);
   }
 
+Q_SIGNALS:
+  void typeErasedMessageTaken(std::shared_ptr<const void> type_erased_message);
+
 protected Q_SLOTS:
+  virtual void processTypeErasedMessage(std::shared_ptr<const void> type_erased_message)
+  {
+    (void)type_erased_message;
+  }
+
   virtual void transformerChangedCallback()
   {
   }

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -116,7 +116,7 @@ Q_SIGNALS:
   void typeErasedMessageTaken(std::shared_ptr<const void> type_erased_message);
 
 protected Q_SLOTS:
-  virtual void processTypeErasedMessage(std::shared_ptr<const void> type_erased_message)
+  void processTypeErasedMessage(std::shared_ptr<const void> type_erased_message)
   {
     (void)type_erased_message;
   }


### PR DESCRIPTION
Backport https://github.com/ros2/rviz/pull/620 to Foxy