### PR TITLE
[backport foxy] Fixed crash when changing rendering parameters for pointcloud2 while 'Selectable' box is unchecked (#768)

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -267,7 +267,9 @@ void PointCloudCommon::updateBillboardSize()
   }
   for (auto & cloud_info : cloud_infos_) {
     cloud_info->cloud_->setDimensions(size, size, size);
-    cloud_info->selection_handler_->setBoxSize(getSelectionBoxSize());
+    if (cloud_info->selection_handler_) {
+      cloud_info->selection_handler_->setBoxSize(getSelectionBoxSize());
+    }
   }
   context_->queueRender();
 }


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>