### PR TITLE
Make libraries to avoid compiling files multiple times

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -352,6 +352,23 @@ if(BUILD_TESTING)
     Qt5::Widgets
   )
 
+  # This code is used by many tests, so compile it just once
+  add_library(pointcloud_messages
+    test/rviz_default_plugins/pointcloud_messages.cpp)
+  target_include_directories(pointcloud_messages PUBLIC test)
+  target_link_libraries(pointcloud_messages PUBLIC
+    rclcpp::rclcpp
+    ${sensor_msgs_TARGETS})
+
+  # This code is used by many tests, so compile it just once
+  add_library(point_cloud_common_page_object
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp)
+  target_include_directories(point_cloud_common_page_object PUBLIC
+    test/page_objects
+    ${TEST_INCLUDE_DIRS})
+  target_link_libraries(point_cloud_common_page_object PUBLIC
+    rviz_visual_testing_framework::rviz_visual_testing_framework)
+
   ament_add_gmock(fps_view_controller_test
     test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
@@ -498,24 +515,24 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(point_cloud2_display_test
-    test/rviz_default_plugins/pointcloud_messages.hpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud2_display_test)
     target_include_directories(point_cloud2_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(point_cloud2_display_test ${TEST_LINK_LIBRARIES})
+    target_link_libraries(point_cloud2_display_test
+      ${TEST_LINK_LIBRARIES}
+      pointcloud_messages)
     ament_target_dependencies(point_cloud2_display_test ${TEST_TARGET_DEPENDENCIES})
   endif()
 
   ament_add_gmock(point_cloud_common_test
-    test/rviz_default_plugins/pointcloud_messages.hpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_common_test)
     target_include_directories(point_cloud_common_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(point_cloud_common_test ${TEST_LINK_LIBRARIES})
+    target_link_libraries(point_cloud_common_test
+      ${TEST_LINK_LIBRARIES}
+      pointcloud_messages)
     ament_target_dependencies(point_cloud_common_test ${TEST_TARGET_DEPENDENCIES})
   endif()
 
@@ -529,8 +546,6 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(point_cloud_transformers_test
-    test/rviz_default_plugins/pointcloud_messages.hpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
@@ -540,7 +555,9 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_transformers_test)
     target_include_directories(point_cloud_transformers_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(point_cloud_transformers_test ${TEST_LINK_LIBRARIES})
+    target_link_libraries(point_cloud_transformers_test
+      ${TEST_LINK_LIBRARIES}
+      pointcloud_messages)
     ament_target_dependencies(point_cloud_transformers_test ${TEST_TARGET_DEPENDENCIES})
   endif()
 
@@ -655,7 +672,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
     test/rviz_default_plugins/publishers/camera_info_publisher.hpp
     test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/image_publisher.hpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
     ${SKIP_VISUAL_TESTS}
@@ -665,14 +681,13 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(camera_display_visual_test
+      point_cloud_common_page_object
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -681,6 +696,8 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(fluid_pressure_display_visual_test
+      point_cloud_common_page_object
+      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -715,8 +732,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/illuminance_publisher.hpp
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -725,6 +740,8 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(illuminance_display_visual_test
+      point_cloud_common_page_object
+      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -757,7 +774,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(laser_scan_display_visual_test
     test/rviz_default_plugins/displays/laser_scan/laser_scan_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET laser_scan_display_visual_test)
@@ -765,6 +781,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(laser_scan_display_visual_test
+      point_cloud_common_page_object
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -864,7 +881,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(point_cloud_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -873,6 +889,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud_display_visual_test
+      point_cloud_common_page_object
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -880,8 +897,6 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
     test/rviz_default_plugins/publishers/point_cloud2_publisher.hpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud2_display_visual_test)
@@ -889,6 +904,8 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud2_display_visual_test
+      point_cloud_common_page_object
+      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -955,8 +972,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -965,6 +980,8 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(relative_humidity_display_visual_test
+      point_cloud_common_page_object
+      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -986,8 +1003,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/temperature_publisher.hpp
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -996,6 +1011,8 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(temperature_display_visual_test
+      point_cloud_common_page_object
+      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()


### PR DESCRIPTION
I noticed some packages are compiling files multiple times - usually test files. This PR makes libraries for the `pointcloud_messages.cpp` and `point_cloud_common_page_object.cpp` files because the are compiled 8 times each.