### PR TITLE
[foxy] Add rviz_rendering dependency to rviz_common (#727)

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -240,7 +240,6 @@ target_link_libraries(rviz_common
   PUBLIC
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
-  rviz_rendering::rviz_rendering
   Qt5::Widgets
   ${TinyXML_LIBRARIES}
 )
@@ -252,6 +251,7 @@ ament_target_dependencies(rviz_common
   rclcpp
   resource_retriever
   rviz_assimp_vendor
+  rviz_rendering
   sensor_msgs
   std_msgs
   tf2


### PR DESCRIPTION
Backport #727 to Foxy.

Related to https://github.com/ros2/rviz/issues/784