### PR TITLE
Remove TF filter from ImageTransportDisplay

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -47,6 +47,7 @@
 # include <OgreSharedPtr.h>
 
 # include "sensor_msgs/msg/camera_info.hpp"
+# include "tf2_ros/message_filter.h"
 
 # include "rviz_default_plugins/displays/image/image_transport_display.hpp"
 # include "rviz_default_plugins/displays/image/ros_image_texture_iface.hpp"
@@ -129,6 +130,8 @@ protected:
 
   void onDisable() override;
 
+  void fixedFrameChanged() override;
+
   void processMessage(sensor_msgs::msg::Image::ConstSharedPtr msg) override;
 
 private Q_SLOTS:
@@ -181,6 +184,9 @@ private:
   Ogre::MaterialPtr overlay_material_;
 
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr caminfo_sub_;
+
+  std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::Image,
+    rviz_common::transformation::FrameTransformer>> tf_filter_;
 
   std::unique_ptr<ROSImageTextureIface> texture_;
   std::unique_ptr<rviz_common::RenderPanel> render_panel_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -95,7 +95,8 @@ bool validateFloats(const sensor_msgs::msg::CameraInfo & msg)
 }
 
 CameraDisplay::CameraDisplay()
-: texture_(std::make_unique<ROSImageTexture>()),
+: tf_filter_(nullptr),
+  texture_(std::make_unique<ROSImageTexture>()),
   new_caminfo_(false),
   caminfo_ok_(false),
   force_render_(false)
@@ -267,9 +268,36 @@ void CameraDisplay::onDisable()
   clear();
 }
 
+void CameraDisplay::fixedFrameChanged()
+{
+  if (tf_filter_) {
+    tf_filter_->setTargetFrame(fixed_frame_.toStdString());
+  }
+  reset();
+}
+
 void CameraDisplay::subscribe()
 {
   ITDClass::subscribe();
+
+  if (!subscription_) {
+    return;
+  }
+
+  // Unregster the callback registered by the ImageTransportDisplay
+  // and instead connect it to the TF filter
+  subscription_callback_.disconnect();
+
+  tf_filter_ = std::make_shared<
+    tf2_ros::MessageFilter<sensor_msgs::msg::Image,
+    rviz_common::transformation::FrameTransformer>>(
+      *context_->getFrameManager()->getTransformer(),
+      fixed_frame_.toStdString(), 10, rviz_ros_node_.lock()->get_raw_node());
+
+  tf_filter_->connectInput(*subscription_);
+  tf_filter_->registerCallback([=](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
+    this->incomingMessage(msg);
+  });
 
   if ((!isEnabled()) || (topic_property_->getTopicStd().empty())) {
     return;
@@ -320,6 +348,7 @@ void CameraDisplay::unsubscribe()
 {
   ITDClass::unsubscribe();
   caminfo_sub_.reset();
+  tf_filter_.reset();
 }
 
 void CameraDisplay::updateAlpha()
@@ -358,6 +387,10 @@ void CameraDisplay::clear()
 
   rviz_rendering::RenderWindowOgreAdapter::getOgreCamera(
     render_panel_->getRenderWindow())->setPosition(rviz_common::RenderPanel::default_camera_pose_);
+
+  if (tf_filter_) {
+    tf_filter_->clear();
+  }
 }
 
 void CameraDisplay::update(float wall_dt, float ros_dt)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -291,13 +291,14 @@ void CameraDisplay::subscribe()
   tf_filter_ = std::make_shared<
     tf2_ros::MessageFilter<sensor_msgs::msg::Image,
     rviz_common::transformation::FrameTransformer>>(
-      *context_->getFrameManager()->getTransformer(),
-      fixed_frame_.toStdString(), 10, rviz_ros_node_.lock()->get_raw_node());
+    *context_->getFrameManager()->getTransformer(),
+    fixed_frame_.toStdString(), 10, rviz_ros_node_.lock()->get_raw_node());
 
   tf_filter_->connectInput(*subscription_);
-  tf_filter_->registerCallback([=](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
-    this->incomingMessage(msg);
-  });
+  tf_filter_->registerCallback(
+    [ = ](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
+      this->incomingMessage(msg);
+    });
 
   if ((!isEnabled()) || (topic_property_->getTopicStd().empty())) {
     return;


### PR DESCRIPTION
Fixes #639

Only the CameraDisplay cares about TF data, so this change moves the TF filter logic into the CameraDisplay.

This allows users to view images with the ImageDisplay no matter what the fixed frame is set to.