### PR TITLE
[galactic] Export Qt5 dependencies properly (#687)

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -257,7 +257,6 @@ ament_target_dependencies(rviz_default_plugins
 ament_export_include_directories(include)
 ament_export_targets(rviz_default_plugins HAS_LIBRARY_TARGET)
 ament_export_dependencies(
-  Qt5
   rviz_common
   geometry_msgs
   interactive_markers
@@ -1013,4 +1012,6 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS "rviz_default_plugins-extras.cmake"
+)

--- a/rviz_default_plugins/rviz_default_plugins-extras.cmake
+++ b/rviz_default_plugins/rviz_default_plugins-extras.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) 2021, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# find package Qt5 because otherwise using the rviz_default_plugins::rviz_default_plugins
+# exported target will complain that the Qt5::Widgets target does not exist
+find_package(Qt5 REQUIRED QUIET COMPONENTS Widgets)

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -277,4 +277,6 @@ list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS
   "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/register_rviz_ogre_media_exports_hook-extras.cmake"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/register_rviz_ogre_media_exports.cmake")
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS "rviz_rendering-extras.cmake"
+)

--- a/rviz_rendering/rviz_rendering-extras.cmake
+++ b/rviz_rendering/rviz_rendering-extras.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) 2021, Open Source Robotics Foundation, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# find package Qt5 because otherwise using the rviz_rendering::rviz_rendering
+# exported target will complain that the Qt5::Widgets target does not exist
+find_package(Qt5 REQUIRED QUIET COMPONENTS Widgets)


### PR DESCRIPTION
This pull request backports #687 to Galactic.

Galactic CI above `rviz_default_plugins` and `rviz_rendering`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15529)](http://ci.ros2.org/job/ci_linux/15529/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10215)](http://ci.ros2.org/job/ci_linux-aarch64/10215/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=13199)](http://ci.ros2.org/job/ci_osx/13199/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=15740)](http://ci.ros2.org/job/ci_windows/15740/)
