### PR TITLE
[FEATURE] separate functionality and msg type for map display

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -86,6 +86,7 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/displays/illuminance/illuminance_display.hpp
   include/rviz_default_plugins/displays/image/image_display.hpp
   include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+  include/rviz_default_plugins/displays/map/q_map_display_object.hpp
   include/rviz_default_plugins/displays/map/map_display.hpp
   include/rviz_default_plugins/displays/marker/marker_common.hpp
   include/rviz_default_plugins/displays/odometry/odometry_display.hpp
@@ -147,6 +148,7 @@ set(rviz_default_plugins_source_files
   src/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.cpp
   src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
   src/rviz_default_plugins/displays/map/map_display.cpp
+  src/rviz_default_plugins/displays/map/q_map_display_object.cpp
   src/rviz_default_plugins/displays/map/palette_builder.cpp
   src/rviz_default_plugins/displays/map/swatch.cpp
   src/rviz_default_plugins/displays/marker/markers/arrow_marker.cpp

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -63,6 +63,8 @@ class RVIZ_DEFAULT_PLUGINS_PUBLIC MapDisplay : public
 public:
   // TODO(botteroa-si): Constructor for testing, remove once ros_nodes can be mocked and call
   // initialize() instead
+
+  /** @brief create palettes and setup respective property */
   explicit MapDisplay(rviz_common::DisplayContext * context);
   MapDisplay() = default;
   ~MapDisplay() override = default;
@@ -71,11 +73,14 @@ public:
   void processMessage(MsgConstSharedPtr msg) override;
 
   protected Q_SLOT:
+  /** @brief triggered by property update, update palette for all swatches */
   void updatePalette();
 
 protected:
+  /** @brief call super class showValidMap and updatePalette() */
   void showValidMap() override;
 
+  /** @brief create message specific swatch */
   std::shared_ptr<SwatchBase<nav_msgs::msg::OccupancyGrid>> createSwatch(
     Ogre::SceneManager * scene_manager,
     Ogre::SceneNode * parent_scene_node,
@@ -83,15 +88,20 @@ protected:
     float resolution, bool draw_under
   ) override;
 
+  /** @brief validate message specific floats */
   bool validateFloats(const nav_msgs::msg::OccupancyGrid & msg) const override;
 
   /** @brief Copy update's data into current_map_ and call showMap(). */
   void incomingUpdate(UpdateMsgConstSharedPtr update);
 
-  bool updateDataOutOfBounds(UpdateMsgConstSharedPtr update) const override;
-  void updateMapDataInMemory(UpdateMsgConstSharedPtr update) override;
+  /** @brief check if new data is out of bound */
+  bool updateDataOutOfBounds(UpdateMsgConstSharedPtr update) const;
+  /** @brief copy update data row-wise for valid heights*/
+  void updateMapDataInMemory(UpdateMsgConstSharedPtr update);
 
-  rviz_common::properties::EnumProperty * color_scheme_property_;
+  // protected member
+  // color scheme property to select palette
+  rviz_common::properties::EnumProperty * color_scheme_property_ {nullptr};
 
   std::vector<Ogre::TexturePtr> palette_textures_;
   std::vector<bool> color_scheme_transparency_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012, Willow Garage, Inc.
  * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * Copyright (c) 2021, Thomas Wodtko @ Institute of Measurement, Control and Microtechnology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -32,17 +32,7 @@
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__MAP_DISPLAY_HPP_
 
 #include <memory>
-#include <string>
 #include <vector>
-
-#ifndef Q_MOC_RUN
-
-#include <OgreTexture.h>
-#include <OgreMaterial.h>
-#include <OgreVector3.h>
-#include <OgreSharedPtr.h>
-
-#endif  // Q_MOC_RUN
 
 #include "nav_msgs/msg/map_meta_data.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
@@ -50,44 +40,23 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/qos.hpp"
 
-#include "rviz_common/message_filter_display.hpp"
-
+#include "rviz_common/properties/enum_property.hpp"
+#include "rviz_default_plugins/displays/map/map_display_base.hpp"
 #include "rviz_default_plugins/displays/map/swatch.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
-namespace Ogre
-{
-class ManualObject;
-}
-
-namespace rviz_common
-{
-namespace properties
-{
-
-class EnumProperty;
-class FloatProperty;
-class IntProperty;
-class Property;
-class QuaternionProperty;
-class VectorProperty;
-
-}  // namespace properties
-}  // namespace rviz_common
 
 namespace rviz_default_plugins
 {
 namespace displays
 {
-class AlphaSetter;
-
 
 /**
  * \class MapDisplay
  * \brief Displays a map along the XY plane.
  */
 class RVIZ_DEFAULT_PLUGINS_PUBLIC MapDisplay : public
-  rviz_common::MessageFilterDisplay<nav_msgs::msg::OccupancyGrid>
+  MapDisplayBase<nav_msgs::msg::OccupancyGrid, map_msgs::msg::OccupancyGridUpdate>
 {
   Q_OBJECT
 
@@ -95,98 +64,37 @@ public:
   // TODO(botteroa-si): Constructor for testing, remove once ros_nodes can be mocked and call
   // initialize() instead
   explicit MapDisplay(rviz_common::DisplayContext * context);
-  MapDisplay();
-  ~MapDisplay() override;
-
-  void onInitialize() override;
-  void fixedFrameChanged() override;
-  void reset() override;
-
-  float getResolution() {return resolution_;}
-  size_t getWidth() {return width_;}
-  size_t getHeight() {return height_;}
+  MapDisplay() = default;
+  ~MapDisplay() override = default;
 
   /** @brief Copy msg into current_map_ and call showMap(). */
-  void processMessage(nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg) override;
+  void processMessage(MsgConstSharedPtr msg) override;
 
-public Q_SLOTS:
-  void showMap();
-
-Q_SIGNALS:
-  /** @brief Emitted when a new map is received*/
-  void mapUpdated();
-
-protected Q_SLOTS:
-  void updateAlpha();
-  void updateDrawUnder() const;
+  protected Q_SLOT:
   void updatePalette();
-  /** @brief Show current_map_ in the scene. */
-  void transformMap();
-  void updateMapUpdateTopic();
 
 protected:
-  void updateTopic() override;
-  void update(float wall_dt, float ros_dt) override;
+  void showValidMap() override;
 
-  void subscribe() override;
-  void unsubscribe() override;
+  std::shared_ptr<SwatchBase<nav_msgs::msg::OccupancyGrid>> createSwatch(
+    Ogre::SceneManager * scene_manager,
+    Ogre::SceneNode * parent_scene_node,
+    size_t x, size_t y, size_t width, size_t height,
+    float resolution, bool draw_under
+  ) override;
 
-  void onEnable() override;
+  bool validateFloats(const nav_msgs::msg::OccupancyGrid & msg) const override;
 
   /** @brief Copy update's data into current_map_ and call showMap(). */
-  void incomingUpdate(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
+  void incomingUpdate(UpdateMsgConstSharedPtr update);
 
-  bool updateDataOutOfBounds(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update) const;
-  void updateMapDataInMemory(map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update);
+  bool updateDataOutOfBounds(UpdateMsgConstSharedPtr update) const override;
+  void updateMapDataInMemory(UpdateMsgConstSharedPtr update) override;
 
-  void clear();
+  rviz_common::properties::EnumProperty * color_scheme_property_;
 
-  void subscribeToUpdateTopic();
-  void unsubscribeToUpdateTopic();
-
-  void showValidMap();
-  void resetSwatchesIfNecessary(size_t width, size_t height, float resolution);
-  void createSwatches();
-  void doubleSwatchNumber(
-    size_t & swatch_width, size_t & swatch_height,
-    int & number_swatches) const;
-  void tryCreateSwatches(
-    size_t width,
-    size_t height,
-    float resolution,
-    size_t swatch_width,
-    size_t swatch_height,
-    int number_swatches);
-  size_t getEffectiveDimension(size_t map_dimension, size_t swatch_dimension, size_t position);
-  void updateSwatches() const;
-
-  std::vector<std::shared_ptr<Swatch>> swatches_;
   std::vector<Ogre::TexturePtr> palette_textures_;
   std::vector<bool> color_scheme_transparency_;
-  bool loaded_;
-
-  float resolution_;
-  size_t width_;
-  size_t height_;
-  std::string frame_;
-  nav_msgs::msg::OccupancyGrid current_map_;
-
-  rclcpp::Subscription<map_msgs::msg::OccupancyGridUpdate>::SharedPtr update_subscription_;
-  rclcpp::QoS update_profile_;
-
-  rviz_common::properties::RosTopicProperty * update_topic_property_;
-  rviz_common::properties::QosProfileProperty * update_profile_property_;
-  rviz_common::properties::FloatProperty * resolution_property_;
-  rviz_common::properties::IntProperty * width_property_;
-  rviz_common::properties::IntProperty * height_property_;
-  rviz_common::properties::VectorProperty * position_property_;
-  rviz_common::properties::QuaternionProperty * orientation_property_;
-  rviz_common::properties::FloatProperty * alpha_property_;
-  rviz_common::properties::Property * draw_under_property_;
-  rviz_common::properties::EnumProperty * color_scheme_property_;
-  rviz_common::properties::BoolProperty * transform_timestamp_property_;
-
-  uint32_t update_messages_received_;
 };
 
 }  // namespace displays

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display_base.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display_base.hpp
@@ -1,0 +1,669 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__MAP_DISPLAY_BASE_HPP_
+#define RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__MAP_DISPLAY_BASE_HPP_
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifndef Q_MOC_RUN
+
+#include <OgreMaterial.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreSharedPtr.h>
+#include <OgreTechnique.h>
+#include <OgreTextureManager.h>
+#include <OgreTexture.h>
+#include <OgreVector3.h>
+
+#endif  // Q_MOC_RUN
+
+#include "rclcpp/time.hpp"
+
+#include "rviz_rendering/material_manager.hpp"
+#include "rviz_rendering/objects/grid.hpp"
+#include "rviz_common/display_context.hpp"
+#include "rviz_common/logging.hpp"
+#include "rviz_common/msg_conversions.hpp"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/validate_floats.hpp"
+
+#include "rviz_default_plugins/displays/map/palette_builder.hpp"
+#include "rviz_default_plugins/displays/map/swatch_base.hpp"
+#include "rviz_default_plugins/displays/map/q_map_display_object.hpp"
+#include "rviz_default_plugins/visibility_control.hpp"
+
+namespace Ogre
+{
+class ManualObject;
+}
+
+namespace rviz_common
+{
+namespace properties
+{
+
+class EnumProperty;
+class FloatProperty;
+class IntProperty;
+class Property;
+class QuaternionProperty;
+class VectorProperty;
+
+}  // namespace properties
+}  // namespace rviz_common
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+/**
+ * \class MapDisplayBase
+ * \brief Displays a map along the XY plane.
+ */
+template<class MessageT, class UpdateMessageT = MessageT>
+class RVIZ_DEFAULT_PLUGINS_PUBLIC MapDisplayBase : public
+  rviz_common::MessageFilterDisplay<MessageT>
+{
+public:
+  // simplyfy usage of MFDClass
+  using MFDClass = typename rviz_common::MessageFilterDisplay<MessageT>::MFDClass;
+
+  using MsgConstSharedPtr = typename MessageT::ConstSharedPtr;
+  using UpdateMsgConstSharedPtr = typename UpdateMessageT::ConstSharedPtr;
+
+  // TODO(botteroa-si): Constructor for testing, remove once ros_nodes can be mocked and call
+  // initialize() instead
+  explicit MapDisplayBase(rviz_common::DisplayContext * context);
+  MapDisplayBase();
+  ~MapDisplayBase() override;
+
+  void onInitialize() override;
+  void fixedFrameChanged() override;
+  void reset() override;
+
+  float getResolution() {return resolution_;}
+  size_t getWidth() {return width_;}
+  size_t getHeight() {return height_;}
+
+  /** @brief Copy msg into current_map_ and call showMap(). */
+  void processMessage(typename MessageT::ConstSharedPtr msg) override;
+
+public:
+  void showMap();
+
+protected:
+  virtual void updateAlpha();
+  void updateDrawUnder() const;
+  /** @brief Show current_map_ in the scene. */
+  void transformMap();
+  void updateMapUpdateTopic();
+
+protected:
+  void updateTopic() override;
+  void update(float wall_dt, float ros_dt) override;
+
+  void subscribe() override;
+  void unsubscribe() override;
+
+  void onEnable() override;
+
+  /** @brief Copy update's data into current_map_ and call showMap(). */
+  virtual void incomingUpdate(typename UpdateMessageT::ConstSharedPtr update) = 0;
+
+  virtual bool updateDataOutOfBounds(typename UpdateMessageT::ConstSharedPtr update) const = 0;
+  virtual void updateMapDataInMemory(typename UpdateMessageT::ConstSharedPtr update) = 0;
+
+  void clear();
+
+  void subscribeToUpdateTopic();
+  void unsubscribeToUpdateTopic();
+
+  virtual void showValidMap();
+  virtual void resetSwatchesIfNecessary(size_t width, size_t height, float resolution);
+  virtual void createSwatches();
+  virtual void doubleSwatchNumber(
+    size_t & swatch_width, size_t & swatch_height,
+    int & number_swatches) const;
+
+  virtual std::shared_ptr<SwatchBase<MessageT>> createSwatch(
+    Ogre::SceneManager * scene_manager,
+    Ogre::SceneNode * parent_scene_node,
+    size_t x, size_t y, size_t width, size_t height,
+    float resolution, bool draw_under
+  ) = 0;
+  virtual void tryCreateSwatches(
+    size_t width,
+    size_t height,
+    float resolution,
+    size_t swatch_width,
+    size_t swatch_height,
+    int number_swatches);
+  virtual size_t getEffectiveDimension(
+    size_t map_dimension,
+    size_t swatch_dimension,
+    size_t position
+  );
+
+  virtual void updateSwatches() const;
+
+  virtual bool validateFloats(const MessageT & msg) const = 0;
+
+  std::vector<std::shared_ptr<SwatchBase<MessageT>>> swatches_;
+  bool loaded_;
+
+  float resolution_;
+  size_t width_;
+  size_t height_;
+  std::string frame_;
+  MessageT current_map_;
+
+  typename rclcpp::Subscription<UpdateMessageT>::SharedPtr update_subscription_;
+
+  uint32_t update_messages_received_;
+
+  QMapDisplayObject * q_helper_object_{nullptr};
+};
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::processMessage(
+  typename MessageT::ConstSharedPtr msg)
+{
+  current_map_ = *msg;
+  loaded_ = true;
+  // updated via signal in case ros spinner is in a different thread
+  Q_EMIT q_helper_object_->mapUpdated();
+}
+
+template<class MessageT, class UpdateMessageT>
+MapDisplayBase<MessageT, UpdateMessageT>::MapDisplayBase()
+: loaded_(false),
+  resolution_(0.0f),
+  width_(0),
+  height_(0),
+  update_messages_received_(0)
+{
+  q_helper_object_ = new QMapDisplayObject{this};
+
+  q_helper_object_->showMap_ = [this]() {showMap();};
+  q_helper_object_->updateAlpha_ = [this]() {updateAlpha();};
+  q_helper_object_->updateDrawUnder_ = [this]() {updateDrawUnder();};
+  q_helper_object_->transformMap_ = [this]() {transformMap();};
+  q_helper_object_->updateMapUpdateTopic_ = [this]() {updateMapUpdateTopic();};
+}
+
+template<class MessageT, class UpdateMessageT>
+MapDisplayBase<MessageT, UpdateMessageT>::MapDisplayBase(rviz_common::DisplayContext * context)
+: MapDisplayBase<MessageT, UpdateMessageT>()
+{
+  this->context_ = context;
+  this->scene_manager_ = this->context_->getSceneManager();
+  this->scene_node_ = this->scene_manager_->getRootSceneNode()->createChildSceneNode();
+}
+
+template<class MessageT, class UpdateMessageT>
+MapDisplayBase<MessageT, UpdateMessageT>::~MapDisplayBase()
+{
+  unsubscribe();
+  clear();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::onInitialize()
+{
+  MFDClass::onInitialize();
+
+  this->rviz_ros_node_ = this->context_->getRosNodeAbstraction();
+  q_helper_object_->update_topic_property_->initialize(this->rviz_ros_node_);
+
+  q_helper_object_->update_profile_property_->initialize(
+    [this](rclcpp::QoS profile) {
+      q_helper_object_->update_profile_ = profile;
+      updateMapUpdateTopic();
+    });
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::updateTopic()
+{
+  q_helper_object_->update_topic_property_->setValue(
+    this->topic_property_->getTopic() + "_updates");
+  MFDClass::updateTopic();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::subscribe()
+{
+  if (!this->isEnabled()) {
+    return;
+  }
+
+  if (this->topic_property_->isEmpty()) {
+    this->setStatus(
+      rviz_common::properties::StatusProperty::Error,
+      "Topic",
+      QString("Error subscribing: Empty topic name"));
+    return;
+  }
+
+  MFDClass::subscribe();
+
+  subscribeToUpdateTopic();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::subscribeToUpdateTopic()
+{
+  try {
+    rclcpp::SubscriptionOptions sub_opts;
+    sub_opts.event_callbacks.message_lost_callback =
+      [&](rclcpp::QOSMessageLostInfo & info)
+      {
+        std::ostringstream sstm;
+        sstm << "Some messages were lost:\n>\tNumber of new lost messages: " <<
+          info.total_count_change << " \n>\tTotal number of messages lost: " <<
+          info.total_count;
+        this->setStatus(
+          rviz_common::properties::StatusProperty::Warn, "Update Topic",
+          QString(sstm.str().c_str()));
+      };
+
+    update_subscription_ =
+      this->rviz_ros_node_.lock()->get_raw_node()->
+      template create_subscription<UpdateMessageT>(
+      q_helper_object_->update_topic_property_->getTopicStd(),
+      q_helper_object_->update_profile_,
+      [this](const typename UpdateMessageT::ConstSharedPtr message) {
+        incomingUpdate(message);
+      },
+      sub_opts);
+    this->setStatus(rviz_common::properties::StatusProperty::Ok, "Update Topic", "OK");
+  } catch (rclcpp::exceptions::InvalidTopicNameError & e) {
+    this->setStatus(
+      rviz_common::properties::StatusProperty::Error, "Update Topic",
+      QString("Error subscribing: ") + e.what());
+  }
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::unsubscribe()
+{
+  MFDClass::unsubscribe();
+  unsubscribeToUpdateTopic();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::unsubscribeToUpdateTopic()
+{
+  update_subscription_.reset();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::updateAlpha()
+{
+  float alpha = q_helper_object_->alpha_property_->getFloat();
+  Ogre::SceneBlendType scene_blending;
+  bool depth_write;
+
+  rviz_rendering::MaterialManager::enableAlphaBlending(scene_blending, depth_write, alpha);
+
+  for (const auto & swatch : swatches_) {
+    swatch->updateAlpha(scene_blending, depth_write, alpha);
+  }
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::updateDrawUnder() const
+{
+  bool draw_under = q_helper_object_->draw_under_property_->getValue().toBool();
+
+  if (q_helper_object_->alpha_property_->getFloat() >= rviz_rendering::unit_alpha_threshold) {
+    for (const auto & swatch : swatches_) {
+      swatch->setDepthWriteEnabled(!draw_under);
+    }
+  }
+
+  uint8_t group = draw_under ? Ogre::RENDER_QUEUE_4 : Ogre::RENDER_QUEUE_MAIN;
+  for (const auto & swatch : swatches_) {
+    swatch->setRenderQueueGroup(group);
+  }
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::clear()
+{
+  if (this->isEnabled()) {
+    this->setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
+  }
+
+  if (!loaded_) {
+    return;
+  }
+
+  swatches_.clear();
+  height_ = 0;
+  width_ = 0;
+  resolution_ = 0.0f;
+
+  loaded_ = false;
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::createSwatches()
+{
+  size_t width = current_map_.info.width;
+  size_t height = current_map_.info.height;
+  float resolution = current_map_.info.resolution;
+
+  size_t swatch_width = width;
+  size_t swatch_height = height;
+  int number_swatches = 1;
+  // One swatch can have up to 2^16 * 2^16 pixel (8 bit texture, i.e. 4GB of data)
+  // Since the width and height are separately limited by 2^16 it might be necessary to have several
+  // pieces, however more than 8 swatches is probably unnecessary due to memory limitations
+  const size_t maximum_number_swatch_splittings = 4;
+
+  for (size_t i = 0; i < maximum_number_swatch_splittings; ++i) {
+    RVIZ_COMMON_LOG_INFO_STREAM(
+      "Trying to create a map of size " << width <<
+        " x " << height << " using " << number_swatches << " swatches");
+
+    swatches_.clear();
+    try {
+      tryCreateSwatches(width, height, resolution, swatch_width, swatch_height, number_swatches);
+      updateDrawUnder();
+      return;
+    } catch (Ogre::InvalidParametersException &) {
+      doubleSwatchNumber(swatch_width, swatch_height, number_swatches);
+    } catch (Ogre::RenderingAPIException &) {
+      // This exception seems no longer thrown on some systems. May still be relevant for others.
+      doubleSwatchNumber(swatch_width, swatch_height, number_swatches);
+    }
+  }
+  RVIZ_COMMON_LOG_ERROR_STREAM(
+    "Creating " << number_swatches <<
+      "failed. This map is too large to be displayed by RViz.");
+  swatches_.clear();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::doubleSwatchNumber(
+  size_t & swatch_width, size_t & swatch_height, int & number_swatches) const
+{
+  RVIZ_COMMON_LOG_ERROR_STREAM(
+    "Failed to create map using " << number_swatches <<
+      " swatches. At least one swatch seems to need too much memory");
+
+  if (swatch_width > swatch_height) {
+    swatch_width /= 2;
+  } else {
+    swatch_height /= 2;
+  }
+  number_swatches *= 2;
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::tryCreateSwatches(
+  size_t width,
+  size_t height,
+  float resolution,
+  size_t swatch_width,
+  size_t swatch_height,
+  int number_swatches)
+{
+  size_t x = 0;
+  size_t y = 0;
+  for (int i = 0; i < number_swatches; i++) {
+    size_t effective_width = getEffectiveDimension(width, swatch_width, x);
+    size_t effective_height = getEffectiveDimension(height, swatch_height, y);
+
+    swatches_.push_back(
+      createSwatch(
+        this->scene_manager_,
+        this->scene_node_,
+        x, y,
+        effective_width,
+        effective_height,
+        resolution,
+        q_helper_object_->draw_under_property_->getValue().toBool()));
+
+    swatches_[i]->updateData(current_map_);
+
+    x += effective_width;
+    if (x >= width) {
+      x = 0;
+      y += effective_height;
+    }
+  }
+  updateAlpha();
+}
+
+template<class MessageT, class UpdateMessageT>
+size_t MapDisplayBase<MessageT, UpdateMessageT>::getEffectiveDimension(
+  size_t map_dimension, size_t swatch_dimension, size_t position)
+{
+  // Last swatch is bigger than swatch_dimension for odd numbers.
+  // subtracting the swatch_dimension in the LHS handles this case.
+  return map_dimension - position - swatch_dimension >= swatch_dimension ?
+         swatch_dimension :
+         map_dimension - position;
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::showMap()
+{
+  if (current_map_.data.empty()) {
+    return;
+  }
+
+  if (!validateFloats(current_map_)) {
+    this->setStatus(
+      rviz_common::properties::StatusProperty::Error, "Map",
+      "Message contained invalid floating point values (nans or infs)");
+    return;
+  }
+
+  size_t width = current_map_.info.width;
+  size_t height = current_map_.info.height;
+
+  if (width * height == 0) {
+    std::string message =
+      "Map is zero-sized (" + std::to_string(width) + "x" + std::to_string(height) + ")";
+    this->setStatus(
+      rviz_common::properties::StatusProperty::Error, "Map", QString::fromStdString(message));
+    return;
+  }
+
+  if (width * height != current_map_.data.size()) {
+    std::string message =
+      "Data size doesn't match width*height: width = " + std::to_string(width) + ", height = " +
+      std::to_string(height) + ", data size = " + std::to_string(current_map_.data.size());
+    this->setStatus(
+      rviz_common::properties::StatusProperty::Error, "Map", QString::fromStdString(message));
+    return;
+  }
+
+  this->setStatus(rviz_common::properties::StatusProperty::Ok, "Message", "Map received");
+
+  RVIZ_COMMON_LOG_DEBUG_STREAM(
+    "Received a " << current_map_.info.width <<
+      " X " << current_map_.info.height <<
+      " map @ " << current_map_.info.resolution << "m/pix\n");
+
+  showValidMap();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::showValidMap()
+{
+  size_t width = current_map_.info.width;
+  size_t height = current_map_.info.height;
+
+  float resolution = current_map_.info.resolution;
+
+  resetSwatchesIfNecessary(width, height, resolution);
+
+  frame_ = current_map_.header.frame_id;
+  if (frame_.empty()) {
+    frame_ = "/map";
+  }
+
+  updateSwatches();
+
+  this->setStatus(rviz_common::properties::StatusProperty::Ok, "Map", "Map OK");
+
+  q_helper_object_->resolution_property_->setValue(resolution);
+  q_helper_object_->width_property_->setValue(static_cast<unsigned int>(width));
+  q_helper_object_->height_property_->setValue(static_cast<unsigned int>(height));
+
+  q_helper_object_->position_property_->setVector(
+    rviz_common::pointMsgToOgre(current_map_.info.origin.position));
+  q_helper_object_->orientation_property_->setQuaternion(
+    rviz_common::quaternionMsgToOgre(current_map_.info.origin.orientation));
+
+  transformMap();
+
+  updateDrawUnder();
+
+  this->context_->queueRender();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::resetSwatchesIfNecessary(
+  size_t width, size_t height, float resolution
+)
+{
+  if (width != width_ || height != height_ || resolution_ != resolution) {
+    createSwatches();
+    width_ = width;
+    height_ = height;
+    resolution_ = resolution;
+  }
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::updateSwatches() const
+{
+  for (const auto & swatch : swatches_) {
+    swatch->updateData(current_map_);
+
+    Ogre::Pass * pass = swatch->getTechniquePass();
+    Ogre::TextureUnitState * tex_unit = nullptr;
+    if (pass->getNumTextureUnitStates() > 0) {
+      tex_unit = pass->getTextureUnitState(0);
+    } else {
+      tex_unit = pass->createTextureUnitState();
+    }
+
+    tex_unit->setTextureName(swatch->getTextureName());
+    tex_unit->setTextureFiltering(Ogre::TFO_NONE);
+    swatch->setVisible(true);
+    swatch->resetOldTexture();
+  }
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::transformMap()
+{
+  if (!loaded_) {
+    return;
+  }
+
+  rclcpp::Time transform_time = this->context_->getClock()->now();
+
+  if (q_helper_object_->transform_timestamp_property_->getBool()) {
+    transform_time = current_map_.header.stamp;
+  }
+
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  if (!this->context_->getFrameManager()->transform(
+      frame_, transform_time, current_map_.info.origin, position, orientation) &&
+    !this->context_->getFrameManager()->transform(
+      frame_, rclcpp::Time(0, 0, this->context_->getClock()->get_clock_type()),
+      current_map_.info.origin, position, orientation))
+  {
+    this->setMissingTransformToFixedFrame(frame_);
+    this->scene_node_->setVisible(false);
+  } else {
+    this->setTransformOk();
+
+    this->scene_node_->setPosition(position);
+    this->scene_node_->setOrientation(orientation);
+  }
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::fixedFrameChanged()
+{
+  transformMap();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::reset()
+{
+  MFDClass::reset();
+  update_messages_received_ = 0;
+  clear();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::update(float wall_dt, float ros_dt)
+{
+  (void) wall_dt;
+  (void) ros_dt;
+
+  transformMap();
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::onEnable()
+{
+  MFDClass::onEnable();
+  this->setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
+}
+
+template<class MessageT, class UpdateMessageT>
+void MapDisplayBase<MessageT, UpdateMessageT>::updateMapUpdateTopic()
+{
+  unsubscribeToUpdateTopic();
+  reset();
+  subscribeToUpdateTopic();
+  this->context_->queueRender();
+}
+
+}  // namespace displays
+}  // namespace rviz_default_plugins
+
+#endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__MAP_DISPLAY_BASE_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display_base.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display_base.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012, Willow Garage, Inc.
  * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * Copyright (c) 2021, Thomas Wodtko @ Institute of Measurement, Control and Microtechnology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/q_map_display_object.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/q_map_display_object.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012, Willow Garage, Inc.
  * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * Copyright (c) 2021, Thomas Wodtko @ Institute of Measurement, Control and Microtechnology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/q_map_display_object.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/q_map_display_object.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__Q_MAP_DISPLAY_OBJECT_HPP_
+#define RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__Q_MAP_DISPLAY_OBJECT_HPP_
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/qos.hpp"
+
+#include "rviz_common/properties/bool_property.hpp"
+#include "rviz_common/properties/enum_property.hpp"
+#include "rviz_common/properties/float_property.hpp"
+#include "rviz_common/properties/int_property.hpp"
+#include "rviz_common/properties/property.hpp"
+#include "rviz_common/properties/qos_profile_property.hpp"
+#include "rviz_common/properties/quaternion_property.hpp"
+#include "rviz_common/properties/ros_topic_property.hpp"
+#include "rviz_common/properties/vector_property.hpp"
+
+#include <QObject>  // NOLINT: cpplint is unable to handle the include order here
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+
+class QMapDisplayObject : public QObject
+{
+  Q_OBJECT
+
+public:
+  using EmptyCallback = std::function<void ()>;
+
+  explicit QMapDisplayObject(rviz_common::properties::Property * parent);
+  ~QMapDisplayObject() override = default;
+
+public Q_SLOTS:
+  void showMap();
+
+  virtual void updateAlpha();
+  void updateDrawUnder();
+  /** @brief Show current_map_ in the scene. */
+  void transformMap();
+  void updateMapUpdateTopic();
+
+Q_SIGNALS:
+  /** @brief Emitted when a new map is received*/
+  void mapUpdated();
+
+public:
+  // "SLOTS" to use non O_OBJECT functions
+  EmptyCallback showMap_;
+  EmptyCallback updateAlpha_;
+  EmptyCallback updateDrawUnder_;
+  EmptyCallback transformMap_;
+  EmptyCallback updateMapUpdateTopic_;
+
+  rclcpp::QoS update_profile_;
+
+  rviz_common::properties::RosTopicProperty * update_topic_property_;
+  rviz_common::properties::QosProfileProperty * update_profile_property_;
+  rviz_common::properties::FloatProperty * resolution_property_;
+  rviz_common::properties::IntProperty * width_property_;
+  rviz_common::properties::IntProperty * height_property_;
+  rviz_common::properties::VectorProperty * position_property_;
+  rviz_common::properties::QuaternionProperty * orientation_property_;
+  rviz_common::properties::FloatProperty * alpha_property_;
+  rviz_common::properties::Property * draw_under_property_;
+  rviz_common::properties::BoolProperty * transform_timestamp_property_;
+};
+
+}  // namespace displays
+}  // namespace rviz_default_plugins
+
+#endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__Q_MAP_DISPLAY_OBJECT_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/q_map_display_object.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/q_map_display_object.hpp
@@ -54,28 +54,38 @@ namespace rviz_default_plugins
 {
 namespace displays
 {
-
+/**
+ * @class Helper class to handle all qt related communication for the MapDisplayBase class.
+ *        Since template classes cannot by Q_OBJECTS, the functionality has to be separated
+ */
 class QMapDisplayObject : public QObject
 {
   Q_OBJECT
 
 public:
+  // naming the callback function type
   using EmptyCallback = std::function<void ()>;
 
+  /** @brief set up all properties and hook them into the parent branch */
   explicit QMapDisplayObject(rviz_common::properties::Property * parent);
   ~QMapDisplayObject() override = default;
 
 public Q_SLOTS:
+  /** @brief connected to mapUpdated, call showMap_() is valid */
   void showMap();
 
+  // the following functions are triggered by property updates
+  // respective callbacks can be set and are called if valid
+  /** @brief call updateAlpha_() if valid */
   virtual void updateAlpha();
+  /** @brief call updateDrawUnder_() if valid */
   void updateDrawUnder();
-  /** @brief Show current_map_ in the scene. */
+  /** @brief call transformMap_() if valid */
   void transformMap();
   void updateMapUpdateTopic();
 
 Q_SIGNALS:
-  /** @brief Emitted when a new map is received*/
+  /** @brief Emitted when a new map is received */
   void mapUpdated();
 
 public:
@@ -88,16 +98,17 @@ public:
 
   rclcpp::QoS update_profile_;
 
-  rviz_common::properties::RosTopicProperty * update_topic_property_;
-  rviz_common::properties::QosProfileProperty * update_profile_property_;
-  rviz_common::properties::FloatProperty * resolution_property_;
-  rviz_common::properties::IntProperty * width_property_;
-  rviz_common::properties::IntProperty * height_property_;
-  rviz_common::properties::VectorProperty * position_property_;
-  rviz_common::properties::QuaternionProperty * orientation_property_;
-  rviz_common::properties::FloatProperty * alpha_property_;
-  rviz_common::properties::Property * draw_under_property_;
-  rviz_common::properties::BoolProperty * transform_timestamp_property_;
+  // properties handled by this helper class
+  rviz_common::properties::RosTopicProperty * update_topic_property_ {nullptr};
+  rviz_common::properties::QosProfileProperty * update_profile_property_ {nullptr};
+  rviz_common::properties::FloatProperty * resolution_property_ {nullptr};
+  rviz_common::properties::IntProperty * width_property_ {nullptr};
+  rviz_common::properties::IntProperty * height_property_ {nullptr};
+  rviz_common::properties::VectorProperty * position_property_ {nullptr};
+  rviz_common::properties::QuaternionProperty * orientation_property_ {nullptr};
+  rviz_common::properties::FloatProperty * alpha_property_ {nullptr};
+  rviz_common::properties::Property * draw_under_property_ {nullptr};
+  rviz_common::properties::BoolProperty * transform_timestamp_property_ {nullptr};
 };
 
 }  // namespace displays

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
@@ -41,6 +41,7 @@
 #include "nav_msgs/msg/occupancy_grid.hpp"
 
 #include "rviz_default_plugins/visibility_control.hpp"
+#include "rviz_default_plugins/displays/map/swatch_base.hpp"
 
 namespace Ogre
 {
@@ -55,7 +56,7 @@ namespace displays
 {
 class MapDisplay;
 
-class Swatch
+class Swatch : public SwatchBase<nav_msgs::msg::OccupancyGrid>
 {
 public:
   RVIZ_DEFAULT_PLUGINS_PUBLIC
@@ -66,53 +67,10 @@ public:
     float resolution, bool draw_under);
 
   RVIZ_DEFAULT_PLUGINS_PUBLIC
-  ~Swatch();
+  ~Swatch() override = default;
 
   RVIZ_DEFAULT_PLUGINS_PUBLIC
-  void updateAlpha(
-    const Ogre::SceneBlendType & sceneBlending, bool depth_write, float alpha);
-
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  void updateData(const nav_msgs::msg::OccupancyGrid & map);
-
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  void setVisible(bool visible);
-
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  void resetOldTexture();
-
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  void setRenderQueueGroup(uint8_t group);
-
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  void setDepthWriteEnabled(bool depth_write_enabled);
-
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  Ogre::Pass * getTechniquePass();
-
-  RVIZ_DEFAULT_PLUGINS_PUBLIC
-  std::string getTextureName();
-
-private:
-  void setupMaterial();
-  void resetTexture(Ogre::DataStreamPtr & pixel_stream);
-  void setupSceneNodeWithManualObject();
-  void setupSquareManualObject();
-  void addPointWithPlaneCoordinates(float x, float y);
-
-  static size_t material_count_;
-  static size_t map_count_;
-  static size_t node_count_;
-  static size_t texture_count_;
-
-  Ogre::SceneManager * scene_manager_;
-  Ogre::SceneNode * parent_scene_node_;
-  Ogre::SceneNode * scene_node_;
-  Ogre::ManualObject * manual_object_;
-  Ogre::TexturePtr texture_;
-  Ogre::TexturePtr old_texture_;
-  Ogre::MaterialPtr material_;
-  size_t x_, y_, width_, height_;
+  void updateData(const nav_msgs::msg::OccupancyGrid & map) override;
 };
 
 }  // namespace displays

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012, Willow Garage, Inc.
  * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * Copyright (c) 2021, Thomas Wodtko @ Institute of Measurement, Control and Microtechnology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch_base.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch_base.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012, Willow Garage, Inc.
  * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * Copyright (c) 2021, Thomas Wodtko @ Institute of Measurement, Control and Microtechnology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch_base.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/swatch_base.hpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its contributors
+ *       may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__SWATCH_BASE_HPP_
+#define RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__SWATCH_BASE_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include <OgreBlendMode.h>
+#include <OgreManualObject.h>
+#include <OgreMaterialManager.h>
+#include <OgrePrerequisites.h>
+#include <OgreRenderable.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreSharedPtr.h>
+#include <OgreTechnique.h>
+#include <OgreTextureManager.h>
+
+#include "rviz_rendering/custom_parameter_indices.hpp"
+
+#include "rviz_default_plugins/visibility_control.hpp"
+
+namespace Ogre
+{
+class SceneManager;
+class SceneNode;
+class ManualObject;
+}
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+
+template<class MessageT>
+class SwatchBase
+{
+public:
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  SwatchBase(
+    Ogre::SceneManager * scene_manager,
+    Ogre::SceneNode * parent_scene_node,
+    size_t x, size_t y, size_t width, size_t height,
+    float resolution, bool draw_under);
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  virtual ~SwatchBase();
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  void updateAlpha(
+    const Ogre::SceneBlendType & sceneBlending, bool depth_write, float alpha);
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  virtual void updateData(const MessageT & map) = 0;
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  void setVisible(bool visible);
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  void resetOldTexture();
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  void setRenderQueueGroup(uint8_t group);
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  void setDepthWriteEnabled(bool depth_write_enabled);
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  Ogre::Pass * getTechniquePass();
+
+  RVIZ_DEFAULT_PLUGINS_PUBLIC
+  std::string getTextureName();
+
+protected:
+  void setupMaterial();
+  void resetTexture(Ogre::DataStreamPtr & pixel_stream);
+  void setupSceneNodeWithManualObject();
+  void setupSquareManualObject();
+  void addPointWithPlaneCoordinates(float x, float y);
+
+  static size_t material_count_;
+  static size_t map_count_;
+  static size_t node_count_;
+  static size_t texture_count_;
+
+  Ogre::SceneManager * scene_manager_;
+  Ogre::SceneNode * parent_scene_node_;
+  Ogre::SceneNode * scene_node_;
+  Ogre::ManualObject * manual_object_;
+  Ogre::TexturePtr texture_;
+  Ogre::TexturePtr old_texture_;
+  Ogre::MaterialPtr material_;
+  size_t x_, y_, width_, height_;
+
+private:
+  // Helper class to set alpha parameter on all renderables.
+  class AlphaSetter : public Ogre::Renderable::Visitor
+  {
+public:
+    explicit AlphaSetter(float alpha)
+    : alpha_vec_(alpha, alpha, alpha, alpha)
+    {}
+
+    void
+    visit(Ogre::Renderable * rend, Ogre::ushort lodIndex, bool isDebug, Ogre::Any * pAny) override
+    {
+      (void) lodIndex;
+      (void) isDebug;
+      (void) pAny;
+
+      rend->setCustomParameter(RVIZ_RENDERING_ALPHA_PARAMETER, alpha_vec_);
+    }
+
+private:
+    Ogre::Vector4 alpha_vec_;
+  };
+};
+
+
+template<class MessageT>
+SwatchBase<MessageT>::SwatchBase(
+  Ogre::SceneManager * scene_manager,
+  Ogre::SceneNode * parent_scene_node,
+  size_t x, size_t y, size_t width, size_t height,
+  float resolution, bool draw_under)
+: scene_manager_(scene_manager),
+  parent_scene_node_(parent_scene_node),
+  manual_object_(nullptr),
+  x_(x), y_(y), width_(width), height_(height)
+{
+  setupMaterial();
+  setupSceneNodeWithManualObject();
+
+  scene_node_->setPosition(x * resolution, y * resolution, 0);
+  scene_node_->setScale(width * resolution, height * resolution, 1.0);
+
+  if (draw_under) {
+    manual_object_->setRenderQueueGroup(Ogre::RENDER_QUEUE_4);
+  }
+
+  // don't show map until the plugin is actually enabled
+  manual_object_->setVisible(false);
+}
+
+template<class MessageT>
+SwatchBase<MessageT>::~SwatchBase()
+{
+  scene_manager_->destroyManualObject(manual_object_);
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::updateAlpha(
+  const Ogre::SceneBlendType & sceneBlending, bool depth_write, float alpha)
+{
+  material_->setSceneBlending(sceneBlending);
+  material_->setDepthWriteEnabled(depth_write);
+  if (manual_object_) {
+    AlphaSetter alpha_setter(alpha);
+    manual_object_->visitRenderables(&alpha_setter);
+  }
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::setVisible(bool visible)
+{
+  if (manual_object_) {
+    manual_object_->setVisible(visible);
+  }
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::resetOldTexture()
+{
+  if (old_texture_) {
+    Ogre::TextureManager::getSingleton().remove(old_texture_);
+    old_texture_.reset();
+  }
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::setRenderQueueGroup(uint8_t group)
+{
+  if (manual_object_) {
+    manual_object_->setRenderQueueGroup(group);
+  }
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::setDepthWriteEnabled(bool depth_write_enabled)
+{
+  if (material_) {
+    material_->setDepthWriteEnabled(depth_write_enabled);
+  }
+}
+
+template<class MessageT>
+Ogre::Pass * SwatchBase<MessageT>::getTechniquePass()
+{
+  if (material_) {
+    return material_->getTechnique(0)->getPass(0);
+  }
+  return nullptr;
+}
+
+template<class MessageT>
+std::string SwatchBase<MessageT>::getTextureName()
+{
+  if (texture_) {
+    return texture_->getName();
+  }
+  return "";
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::resetTexture(Ogre::DataStreamPtr & pixel_stream)
+{
+  old_texture_ = texture_;
+
+  texture_ = Ogre::TextureManager::getSingleton().loadRawData(
+    "MapTexture" + std::to_string(texture_count_++),
+    "rviz_rendering",
+    pixel_stream,
+    static_cast<uint16_t>(width_), static_cast<uint16_t>(height_),
+    Ogre::PF_L8, Ogre::TEX_TYPE_2D, 0);
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::setupMaterial()
+{
+  material_ = Ogre::MaterialManager::getSingleton().getByName("rviz/Indexed8BitImage");
+  material_ = material_->clone("MapMaterial" + std::to_string(material_count_++));
+
+  material_->setReceiveShadows(false);
+  material_->getTechnique(0)->setLightingEnabled(false);
+  material_->setDepthBias(-16.0f, 0.0f);
+  material_->setCullingMode(Ogre::CULL_NONE);
+  material_->setDepthWriteEnabled(false);
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::setupSceneNodeWithManualObject()
+{
+  manual_object_ = scene_manager_->createManualObject("MapObject" + std::to_string(map_count_++));
+
+  scene_node_ = parent_scene_node_->createChildSceneNode(
+    "NodeObject" + std::to_string(node_count_++));
+  scene_node_->attachObject(manual_object_);
+
+  setupSquareManualObject();
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::setupSquareManualObject()
+{
+  manual_object_->begin(
+    material_->getName(), Ogre::RenderOperation::OT_TRIANGLE_LIST, "rviz_rendering");
+
+  // first triangle
+  addPointWithPlaneCoordinates(0.0f, 0.0f);
+  addPointWithPlaneCoordinates(1.0f, 1.0f);
+  addPointWithPlaneCoordinates(0.0f, 1.0f);
+
+  // second triangle
+  addPointWithPlaneCoordinates(0.0f, 0.0f);
+  addPointWithPlaneCoordinates(1.0f, 0.0f);
+  addPointWithPlaneCoordinates(1.0f, 1.0f);
+
+  manual_object_->end();
+}
+
+template<class MessageT>
+void SwatchBase<MessageT>::addPointWithPlaneCoordinates(float x, float y)
+{
+  manual_object_->position(x, y, 0.0f);
+  manual_object_->textureCoord(x, y);
+  manual_object_->normal(0.0f, 0.0f, 1.0f);
+}
+
+}  // namespace displays
+}  // namespace rviz_default_plugins
+
+#endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__MAP__SWATCH_BASE_HPP_

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -30,7 +30,6 @@
 
 #include "rviz_default_plugins/displays/map/map_display.hpp"
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
@@ -39,111 +38,18 @@
 #include <OgreSceneNode.h>
 #include <OgreTextureManager.h>
 #include <OgreTechnique.h>
-#include <OgreSharedPtr.h>
 
-#include "rclcpp/time.hpp"
 
-#include "rviz_rendering/material_manager.hpp"
 #include "rviz_rendering/objects/grid.hpp"
-#include "rviz_common/logging.hpp"
-#include "rviz_common/msg_conversions.hpp"
-#include "rviz_common/properties/enum_property.hpp"
-#include "rviz_common/properties/float_property.hpp"
-#include "rviz_common/properties/int_property.hpp"
 #include "rviz_common/properties/property.hpp"
-#include "rviz_common/properties/quaternion_property.hpp"
-#include "rviz_common/properties/ros_topic_property.hpp"
-#include "rviz_common/properties/vector_property.hpp"
 #include "rviz_common/validate_floats.hpp"
 #include "rviz_common/display_context.hpp"
-#include "rviz_default_plugins/displays/map/palette_builder.hpp"
 
 
 namespace rviz_default_plugins
 {
 namespace displays
 {
-
-MapDisplay::MapDisplay()
-: loaded_(false),
-  resolution_(0.0f),
-  width_(0),
-  height_(0),
-  update_profile_(rclcpp::QoS(5)),
-  update_messages_received_(0)
-{
-  connect(this, SIGNAL(mapUpdated()), this, SLOT(showMap()));
-
-  update_topic_property_ = new rviz_common::properties::RosTopicProperty(
-    "Update Topic", "",
-    "", "Topic where updates to this map display are received. "
-    "This topic is automatically determined by the map topic. "
-    "If the map is received on 'map_topic', the display assumes updates are received on "
-    "'map_topic_updates'."
-    "This can be overridden in the UI by clicking on the topic and setting the desired topic.",
-    this, SLOT(updateMapUpdateTopic()));
-
-  update_profile_property_ = new rviz_common::properties::QosProfileProperty(
-    update_topic_property_, update_profile_);
-
-  alpha_property_ = new rviz_common::properties::FloatProperty(
-    "Alpha", 0.7f,
-    "Amount of transparency to apply to the map.",
-    this, SLOT(updateAlpha()));
-  alpha_property_->setMin(0);
-  alpha_property_->setMax(1);
-
-  color_scheme_property_ = new rviz_common::properties::EnumProperty(
-    "Color Scheme", "map",
-    "How to color the occupancy values.",
-    this, SLOT(updatePalette()));
-  // Option values here must correspond to indices in palette_textures_ array in onInitialize()
-  // below.
-  color_scheme_property_->addOption("map", 0);
-  color_scheme_property_->addOption("costmap", 1);
-  color_scheme_property_->addOption("raw", 2);
-
-  draw_under_property_ = new rviz_common::properties::BoolProperty(
-    "Draw Behind", false,
-    "Rendering option, controls whether or not the map is always"
-    " drawn behind everything else.",
-    this, SLOT(updateDrawUnder()));
-
-  resolution_property_ = new rviz_common::properties::FloatProperty(
-    "Resolution", 0,
-    "Resolution of the map. (not editable)", this);
-  resolution_property_->setReadOnly(true);
-
-  width_property_ = new rviz_common::properties::IntProperty(
-    "Width", 0,
-    "Width of the map, in meters. (not editable)", this);
-  width_property_->setReadOnly(true);
-
-  height_property_ = new rviz_common::properties::IntProperty(
-    "Height", 0,
-    "Height of the map, in meters. (not editable)", this);
-  height_property_->setReadOnly(true);
-
-  position_property_ = new rviz_common::properties::VectorProperty(
-    "Position", Ogre::Vector3::ZERO,
-    "Position of the bottom left corner of the map, in meters. (not editable)",
-    this);
-  position_property_->setReadOnly(true);
-
-  orientation_property_ = new rviz_common::properties::QuaternionProperty(
-    "Orientation", Ogre::Quaternion::IDENTITY, "Orientation of the map. (not editable)", this);
-  orientation_property_->setReadOnly(true);
-
-  transform_timestamp_property_ = new rviz_common::properties::BoolProperty(
-    "Use Timestamp", false,
-    "Use map header timestamp when transforming", this, SLOT(transformMap()));
-}
-
-MapDisplay::~MapDisplay()
-{
-  unsubscribe();
-  clear();
-}
 
 Ogre::TexturePtr makePaletteTexture(std::vector<unsigned char> palette_bytes)
 {
@@ -157,31 +63,8 @@ Ogre::TexturePtr makePaletteTexture(std::vector<unsigned char> palette_bytes)
 }
 
 MapDisplay::MapDisplay(rviz_common::DisplayContext * context)
-: MapDisplay()
+: MapDisplayBase<nav_msgs::msg::OccupancyGrid, map_msgs::msg::OccupancyGridUpdate>(context)
 {
-  context_ = context;
-  scene_manager_ = context->getSceneManager();
-  scene_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode();
-
-  palette_textures_.push_back(makePaletteTexture(makeMapPalette()));
-  color_scheme_transparency_.push_back(false);
-  palette_textures_.push_back(makePaletteTexture(makeCostmapPalette()));
-  color_scheme_transparency_.push_back(true);
-  palette_textures_.push_back(makePaletteTexture(makeRawPalette()));
-  color_scheme_transparency_.push_back(true);
-}
-
-void MapDisplay::onInitialize()
-{
-  MFDClass::onInitialize();
-  rviz_ros_node_ = context_->getRosNodeAbstraction();
-  update_topic_property_->initialize(rviz_ros_node_);
-
-  update_profile_property_->initialize(
-    [this](rclcpp::QoS profile) {
-      this->update_profile_ = profile;
-      updateMapUpdateTopic();
-    });
   // Order of palette textures here must match option indices for color_scheme_property_ above.
   palette_textures_.push_back(makePaletteTexture(makeMapPalette()));
   color_scheme_transparency_.push_back(false);
@@ -189,135 +72,28 @@ void MapDisplay::onInitialize()
   color_scheme_transparency_.push_back(true);
   palette_textures_.push_back(makePaletteTexture(makeRawPalette()));
   color_scheme_transparency_.push_back(true);
+
+  // add property for color_map selection
+  color_scheme_property_ = new rviz_common::properties::EnumProperty(
+    "Color Scheme", "map",
+    "How to color the occupancy values.",
+    this, SLOT(updatePalette()));
+  // Option values here must correspond to indices in palette_textures_ array above
+  color_scheme_property_->addOption("map", 0);
+  color_scheme_property_->addOption("costmap", 1);
+  color_scheme_property_->addOption("raw", 2);
 }
 
-void MapDisplay::updateTopic()
+void MapDisplay::showValidMap()
 {
-  update_topic_property_->setValue(topic_property_->getTopic() + "_updates");
-  MFDClass::updateTopic();
+  MapDisplayBase::showValidMap();
+  updatePalette();
 }
 
-void MapDisplay::subscribe()
-{
-  if (!isEnabled()) {
-    return;
-  }
-
-  if (topic_property_->isEmpty()) {
-    setStatus(
-      rviz_common::properties::StatusProperty::Error,
-      "Topic",
-      QString("Error subscribing: Empty topic name"));
-    return;
-  }
-
-  MFDClass::subscribe();
-
-  subscribeToUpdateTopic();
-}
-
-void MapDisplay::subscribeToUpdateTopic()
-{
-  try {
-    rclcpp::SubscriptionOptions sub_opts;
-    sub_opts.event_callbacks.message_lost_callback =
-      [&](rclcpp::QOSMessageLostInfo & info)
-      {
-        std::ostringstream sstm;
-        sstm << "Some messages were lost:\n>\tNumber of new lost messages: " <<
-          info.total_count_change << " \n>\tTotal number of messages lost: " <<
-          info.total_count;
-        setStatus(
-          rviz_common::properties::StatusProperty::Warn, "Update Topic",
-          QString(sstm.str().c_str()));
-      };
-
-    update_subscription_ =
-      rviz_ros_node_.lock()->get_raw_node()->
-      template create_subscription<map_msgs::msg::OccupancyGridUpdate>(
-      update_topic_property_->getTopicStd(), update_profile_,
-      [this](const map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr message) {
-        incomingUpdate(message);
-      },
-      sub_opts);
-    setStatus(rviz_common::properties::StatusProperty::Ok, "Update Topic", "OK");
-  } catch (rclcpp::exceptions::InvalidTopicNameError & e) {
-    setStatus(
-      rviz_common::properties::StatusProperty::Error, "Update Topic",
-      QString("Error subscribing: ") + e.what());
-  }
-}
-
-void MapDisplay::unsubscribe()
-{
-  MFDClass::unsubscribe();
-  unsubscribeToUpdateTopic();
-}
-
-void MapDisplay::unsubscribeToUpdateTopic()
-{
-  update_subscription_.reset();
-}
-
-void MapDisplay::updateAlpha()
-{
-  float alpha = alpha_property_->getFloat();
-  Ogre::SceneBlendType scene_blending;
-  bool depth_write;
-
-  rviz_rendering::MaterialManager::enableAlphaBlending(scene_blending, depth_write, alpha);
-
-  for (const auto & swatch : swatches_) {
-    swatch->updateAlpha(scene_blending, depth_write, alpha);
-  }
-}
-
-void MapDisplay::updateDrawUnder() const
-{
-  bool draw_under = draw_under_property_->getValue().toBool();
-
-  if (alpha_property_->getFloat() >= rviz_rendering::unit_alpha_threshold) {
-    for (const auto & swatch : swatches_) {
-      swatch->setDepthWriteEnabled(!draw_under);
-    }
-  }
-
-  uint8_t group = draw_under ? Ogre::RENDER_QUEUE_4 : Ogre::RENDER_QUEUE_MAIN;
-  for (const auto & swatch : swatches_) {
-    swatch->setRenderQueueGroup(group);
-  }
-}
-
-void MapDisplay::clear()
-{
-  if (isEnabled()) {
-    setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
-  }
-
-  if (!loaded_) {
-    return;
-  }
-
-  swatches_.clear();
-  height_ = 0;
-  width_ = 0;
-  resolution_ = 0.0f;
-
-  loaded_ = false;
-}
-
-bool validateFloats(const nav_msgs::msg::OccupancyGrid & msg)
+bool MapDisplay::validateFloats(const nav_msgs::msg::OccupancyGrid & msg) const
 {
   return rviz_common::validateFloats(msg.info.resolution) &&
          rviz_common::validateFloats(msg.info.origin);
-}
-
-void MapDisplay::processMessage(nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg)
-{
-  current_map_ = *msg;
-  loaded_ = true;
-  // updated via signal in case ros spinner is in a different thread
-  Q_EMIT mapUpdated();
 }
 
 void MapDisplay::incomingUpdate(const map_msgs::msg::OccupancyGridUpdate::ConstSharedPtr update)
@@ -344,7 +120,7 @@ void MapDisplay::incomingUpdate(const map_msgs::msg::OccupancyGridUpdate::ConstS
   setStatus(rviz_common::properties::StatusProperty::Ok, "Update", "Update OK");
 
   // updated via signal in case ros spinner is in a different thread
-  Q_EMIT mapUpdated();
+  Q_EMIT q_helper_object_->mapUpdated();
 }
 
 bool MapDisplay::updateDataOutOfBounds(
@@ -367,205 +143,12 @@ void MapDisplay::updateMapDataInMemory(
   }
 }
 
-void MapDisplay::createSwatches()
+void MapDisplay::processMessage(nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg)
 {
-  size_t width = current_map_.info.width;
-  size_t height = current_map_.info.height;
-  float resolution = current_map_.info.resolution;
-
-  size_t swatch_width = width;
-  size_t swatch_height = height;
-  int number_swatches = 1;
-  // One swatch can have up to 2^16 * 2^16 pixel (8 bit texture, i.e. 4GB of data)
-  // Since the width and height are separately limited by 2^16 it might be necessary to have several
-  // pieces, however more than 8 swatches is probably unnecessary due to memory limitations
-  const size_t maximum_number_swatch_splittings = 4;
-
-  for (size_t i = 0; i < maximum_number_swatch_splittings; ++i) {
-    RVIZ_COMMON_LOG_INFO_STREAM(
-      "Trying to create a map of size " <<
-        width << " x " << height << " using " << number_swatches << " swatches");
-    swatches_.clear();
-    try {
-      tryCreateSwatches(width, height, resolution, swatch_width, swatch_height, number_swatches);
-      updateDrawUnder();
-      return;
-    } catch (Ogre::InvalidParametersException &) {
-      doubleSwatchNumber(swatch_width, swatch_height, number_swatches);
-    } catch (Ogre::RenderingAPIException &) {
-      // This exception seems no longer thrown on some systems. May still be relevant for others.
-      doubleSwatchNumber(swatch_width, swatch_height, number_swatches);
-    }
-  }
-  RVIZ_COMMON_LOG_ERROR_STREAM(
-    "Creating " << number_swatches << "failed. "
-      "This map is too large to be displayed by RViz.");
-  swatches_.clear();
-}
-
-void MapDisplay::doubleSwatchNumber(
-  size_t & swatch_width, size_t & swatch_height, int & number_swatches) const
-{
-  RVIZ_COMMON_LOG_ERROR_STREAM(
-    "Failed to create map using " << number_swatches << " swatches. "
-      "At least one swatch seems to need too much memory");
-  if (swatch_width > swatch_height) {
-    swatch_width /= 2;
-  } else {
-    swatch_height /= 2;
-  }
-  number_swatches *= 2;
-}
-
-void MapDisplay::tryCreateSwatches(
-  size_t width,
-  size_t height,
-  float resolution,
-  size_t swatch_width,
-  size_t swatch_height,
-  int number_swatches)
-{
-  size_t x = 0;
-  size_t y = 0;
-  for (int i = 0; i < number_swatches; i++) {
-    size_t effective_width = getEffectiveDimension(width, swatch_width, x);
-    size_t effective_height = getEffectiveDimension(height, swatch_height, y);
-
-    swatches_.push_back(
-      std::make_shared<Swatch>(
-        scene_manager_,
-        scene_node_,
-        x, y,
-        effective_width,
-        effective_height,
-        resolution,
-        draw_under_property_->getValue().toBool()));
-
-    swatches_[i]->updateData(current_map_);
-
-    x += effective_width;
-    if (x >= width) {
-      x = 0;
-      y += effective_height;
-    }
-  }
-  updateAlpha();
-}
-
-size_t MapDisplay::getEffectiveDimension(
-  size_t map_dimension, size_t swatch_dimension, size_t position)
-{
-  // Last swatch is bigger than swatch_dimension for odd numbers.
-  // subtracting the swatch_dimension in the LHS handles this case.
-  return map_dimension - position - swatch_dimension >= swatch_dimension ?
-         swatch_dimension :
-         map_dimension - position;
-}
-
-void MapDisplay::showMap()
-{
-  if (current_map_.data.empty()) {
-    return;
-  }
-
-  if (!validateFloats(current_map_)) {
-    setStatus(
-      rviz_common::properties::StatusProperty::Error, "Map",
-      "Message contained invalid floating point values (nans or infs)");
-    return;
-  }
-
-  size_t width = current_map_.info.width;
-  size_t height = current_map_.info.height;
-
-  if (width * height == 0) {
-    std::string message =
-      "Map is zero-sized (" + std::to_string(width) + "x" + std::to_string(height) + ")";
-    setStatus(
-      rviz_common::properties::StatusProperty::Error, "Map", QString::fromStdString(message));
-    return;
-  }
-
-  if (width * height != current_map_.data.size()) {
-    std::string message =
-      "Data size doesn't match width*height: width = " + std::to_string(width) + ", height = " +
-      std::to_string(height) + ", data size = " + std::to_string(current_map_.data.size());
-    setStatus(
-      rviz_common::properties::StatusProperty::Error, "Map", QString::fromStdString(message));
-    return;
-  }
-
-  setStatus(rviz_common::properties::StatusProperty::Ok, "Message", "Map received");
-
-  RVIZ_COMMON_LOG_DEBUG_STREAM(
-    "Received a " << current_map_.info.width << " X " <<
-      current_map_.info.height << " map @ " << current_map_.info.resolution << "m/pix\n");
-
-  showValidMap();
-}
-
-void MapDisplay::showValidMap()
-{
-  size_t width = current_map_.info.width;
-  size_t height = current_map_.info.height;
-
-  float resolution = current_map_.info.resolution;
-
-  resetSwatchesIfNecessary(width, height, resolution);
-
-  frame_ = current_map_.header.frame_id;
-  if (frame_.empty()) {
-    frame_ = "/map";
-  }
-
-  updateSwatches();
-
-  setStatus(rviz_common::properties::StatusProperty::Ok, "Map", "Map OK");
-  updatePalette();
-
-  resolution_property_->setValue(resolution);
-  width_property_->setValue(static_cast<unsigned int>(width));
-  height_property_->setValue(static_cast<unsigned int>(height));
-
-  position_property_->setVector(rviz_common::pointMsgToOgre(current_map_.info.origin.position));
-  orientation_property_->setQuaternion(
-    rviz_common::quaternionMsgToOgre(current_map_.info.origin.orientation));
-
-  transformMap();
-
-  updateDrawUnder();
-
-  context_->queueRender();
-}
-
-void MapDisplay::resetSwatchesIfNecessary(size_t width, size_t height, float resolution)
-{
-  if (width != width_ || height != height_ || resolution_ != resolution) {
-    createSwatches();
-    width_ = width;
-    height_ = height;
-    resolution_ = resolution;
-  }
-}
-
-void MapDisplay::updateSwatches() const
-{
-  for (const auto & swatch : swatches_) {
-    swatch->updateData(current_map_);
-
-    Ogre::Pass * pass = swatch->getTechniquePass();
-    Ogre::TextureUnitState * tex_unit = nullptr;
-    if (pass->getNumTextureUnitStates() > 0) {
-      tex_unit = pass->getTextureUnitState(0);
-    } else {
-      tex_unit = pass->createTextureUnitState();
-    }
-
-    tex_unit->setTextureName(swatch->getTextureName());
-    tex_unit->setTextureFiltering(Ogre::TFO_NONE);
-    swatch->setVisible(true);
-    swatch->resetOldTexture();
-  }
+  current_map_ = *msg;
+  loaded_ = true;
+  // updated via signal in case ros spinner is in a different thread
+  Q_EMIT q_helper_object_->mapUpdated();
 }
 
 void MapDisplay::updatePalette()
@@ -588,68 +171,23 @@ void MapDisplay::updatePalette()
   updateDrawUnder();
 }
 
-void MapDisplay::transformMap()
+std::shared_ptr<SwatchBase<nav_msgs::msg::OccupancyGrid>> MapDisplay::createSwatch(
+  Ogre::SceneManager * scene_manager,
+  Ogre::SceneNode * parent_scene_node,
+  size_t x,
+  size_t y,
+  size_t width,
+  size_t height,
+  float resolution,
+  bool draw_under)
 {
-  if (!loaded_) {
-    return;
-  }
-
-  rclcpp::Time transform_time = context_->getClock()->now();
-
-  if (transform_timestamp_property_->getBool()) {
-    transform_time = current_map_.header.stamp;
-  }
-
-  Ogre::Vector3 position;
-  Ogre::Quaternion orientation;
-  if (!context_->getFrameManager()->transform(
-      frame_, transform_time, current_map_.info.origin, position, orientation) &&
-    !context_->getFrameManager()->transform(
-      frame_, rclcpp::Time(0, 0, context_->getClock()->get_clock_type()),
-      current_map_.info.origin, position, orientation))
-  {
-    setMissingTransformToFixedFrame(frame_);
-    scene_node_->setVisible(false);
-  } else {
-    setTransformOk();
-
-    scene_node_->setPosition(position);
-    scene_node_->setOrientation(orientation);
-  }
-}
-
-void MapDisplay::fixedFrameChanged()
-{
-  transformMap();
-}
-
-void MapDisplay::reset()
-{
-  MFDClass::reset();
-  update_messages_received_ = 0;
-  clear();
-}
-
-void MapDisplay::update(float wall_dt, float ros_dt)
-{
-  (void) wall_dt;
-  (void) ros_dt;
-
-  transformMap();
-}
-
-void MapDisplay::onEnable()
-{
-  MFDClass::onEnable();
-  setStatus(rviz_common::properties::StatusProperty::Warn, "Message", "No map received");
-}
-
-void MapDisplay::updateMapUpdateTopic()
-{
-  unsubscribeToUpdateTopic();
-  reset();
-  subscribeToUpdateTopic();
-  context_->queueRender();
+  // make shared not possible due to abstract base class
+  return std::shared_ptr<SwatchBase<nav_msgs::msg::OccupancyGrid>>(
+    new Swatch(
+      scene_manager,
+      parent_scene_node,
+      x, y, width, height, resolution, draw_under
+  ));
 }
 
 }  // namespace displays

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/q_map_display_object.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/q_map_display_object.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * Copyright (c) 2018, Bosch Software Innovations GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rviz_default_plugins/displays/map/q_map_display_object.hpp"
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+
+QMapDisplayObject::QMapDisplayObject(rviz_common::properties::Property * parent)
+: QObject(static_cast<QObject *>(parent)), update_profile_(rclcpp::QoS(5))
+{
+  connect(this, SIGNAL(mapUpdated()), this, SLOT(showMap()));
+
+  update_topic_property_ = new rviz_common::properties::RosTopicProperty(
+    "Update Topic", "",
+    "",
+    "Topic where updates to this map display are received. "
+    "This topic is automatically determined by the map topic. "
+    "If the map is received on 'map_topic', the display assumes updates are received on "
+    "'map_topic_updates'."
+    "This can be overridden in the UI by clicking on the topic and setting the desired topic.",
+    parent, SLOT(updateMapUpdateTopic()), this);
+
+  update_profile_property_ = new rviz_common::properties::QosProfileProperty(
+    update_topic_property_);
+
+  alpha_property_ = new rviz_common::properties::FloatProperty(
+    "Alpha", 0.7f,
+    "Amount of transparency to apply to the map.",
+    parent, SLOT(updateAlpha()), this);
+  alpha_property_->setMin(0);
+  alpha_property_->setMax(1);
+
+
+  draw_under_property_ = new rviz_common::properties::BoolProperty(
+    "Draw Behind", false,
+    "Rendering option, controls whether or not the map is always"
+    " drawn behind everything else.",
+    parent, SLOT(updateDrawUnder()), this);
+
+  resolution_property_ = new rviz_common::properties::FloatProperty(
+    "Resolution", 0,
+    "Resolution of the map. (not editable)", parent);
+  resolution_property_->setReadOnly(true);
+
+  width_property_ = new rviz_common::properties::IntProperty(
+    "Width", 0,
+    "Width of the map, in meters. (not editable)", parent);
+  width_property_->setReadOnly(true);
+
+  height_property_ = new rviz_common::properties::IntProperty(
+    "Height", 0,
+    "Height of the map, in meters. (not editable)", parent);
+  height_property_->setReadOnly(true);
+
+  position_property_ = new rviz_common::properties::VectorProperty(
+    "Position", Ogre::Vector3::ZERO,
+    "Position of the bottom left corner of the map, in meters. (not editable)",
+    parent);
+  position_property_->setReadOnly(true);
+
+  orientation_property_ = new rviz_common::properties::QuaternionProperty(
+    "Orientation", Ogre::Quaternion::IDENTITY, "Orientation of the map. (not editable)", parent);
+  orientation_property_->setReadOnly(true);
+
+  transform_timestamp_property_ = new rviz_common::properties::BoolProperty(
+    "Use Timestamp", false,
+    "Use map header timestamp when transforming", parent, SLOT(transformMap()), this);
+}
+
+void QMapDisplayObject::showMap()
+{
+  if (showMap_) {
+    showMap_();
+  }
+}
+
+void QMapDisplayObject::updateAlpha()
+{
+  if (updateAlpha_) {
+    updateAlpha_();
+  }
+}
+
+void QMapDisplayObject::updateDrawUnder()
+{
+  if (updateDrawUnder_) {
+    updateDrawUnder_();
+  }
+}
+
+void QMapDisplayObject::transformMap()
+{
+  if (transformMap_) {
+    transformMap_();
+  }
+}
+
+void QMapDisplayObject::updateMapUpdateTopic()
+{
+  if (updateMapUpdateTopic_) {
+    updateMapUpdateTopic_();
+  }
+}
+
+}  // namespace displays
+}  // namespace rviz_default_plugins

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/swatch.cpp
@@ -49,73 +49,27 @@ namespace rviz_default_plugins
 {
 namespace displays
 {
+template<>
+size_t SwatchBase<nav_msgs::msg::OccupancyGrid>::material_count_ = 0;
+template<>
+size_t SwatchBase<nav_msgs::msg::OccupancyGrid>::map_count_ = 0;
+template<>
+size_t SwatchBase<nav_msgs::msg::OccupancyGrid>::node_count_ = 0;
+template<>
+size_t SwatchBase<nav_msgs::msg::OccupancyGrid>::texture_count_ = 0;
 
-// Helper class to set alpha parameter on all renderables.
-class AlphaSetter : public Ogre::Renderable::Visitor
-{
-public:
-  explicit AlphaSetter(float alpha)
-  : alpha_vec_(alpha, alpha, alpha, alpha)
-  {}
-
-  void
-  visit(Ogre::Renderable * rend, Ogre::ushort lodIndex, bool isDebug, Ogre::Any * pAny) override
-  {
-    (void) lodIndex;
-    (void) isDebug;
-    (void) pAny;
-
-    rend->setCustomParameter(RVIZ_RENDERING_ALPHA_PARAMETER, alpha_vec_);
-  }
-
-private:
-  Ogre::Vector4 alpha_vec_;
-};
-
-size_t Swatch::material_count_ = 0;
-size_t Swatch::map_count_ = 0;
-size_t Swatch::node_count_ = 0;
-size_t Swatch::texture_count_ = 0;
 
 Swatch::Swatch(
   Ogre::SceneManager * scene_manager,
   Ogre::SceneNode * parent_scene_node,
   size_t x, size_t y, size_t width, size_t height,
   float resolution, bool draw_under)
-: scene_manager_(scene_manager),
-  parent_scene_node_(parent_scene_node),
-  manual_object_(nullptr),
-  x_(x), y_(y), width_(width), height_(height)
-{
-  setupMaterial();
-  setupSceneNodeWithManualObject();
-
-  scene_node_->setPosition(x * resolution, y * resolution, 0);
-  scene_node_->setScale(width * resolution, height * resolution, 1.0);
-
-  if (draw_under) {
-    manual_object_->setRenderQueueGroup(Ogre::RENDER_QUEUE_4);
-  }
-
-  // don't show map until the plugin is actually enabled
-  manual_object_->setVisible(false);
-}
-
-Swatch::~Swatch()
-{
-  scene_manager_->destroyManualObject(manual_object_);
-}
-
-void Swatch::updateAlpha(
-  const Ogre::SceneBlendType & sceneBlending, bool depth_write, float alpha)
-{
-  material_->setSceneBlending(sceneBlending);
-  material_->setDepthWriteEnabled(depth_write);
-  if (manual_object_) {
-    AlphaSetter alpha_setter(alpha);
-    manual_object_->visitRenderables(&alpha_setter);
-  }
-}
+: SwatchBase<nav_msgs::msg::OccupancyGrid>(
+    scene_manager, parent_scene_node,
+    x, y, width, height,
+    resolution, draw_under
+)
+{}
 
 void Swatch::updateData(const nav_msgs::msg::OccupancyGrid & map)
 {
@@ -143,111 +97,5 @@ void Swatch::updateData(const nav_msgs::msg::OccupancyGrid & map)
   resetTexture(pixel_stream);
   resetOldTexture();
 }
-
-void Swatch::setVisible(bool visible)
-{
-  if (manual_object_) {
-    manual_object_->setVisible(visible);
-  }
-}
-
-void Swatch::resetOldTexture()
-{
-  if (old_texture_) {
-    Ogre::TextureManager::getSingleton().remove(old_texture_);
-    old_texture_.reset();
-  }
-}
-
-void Swatch::setRenderQueueGroup(uint8_t group)
-{
-  if (manual_object_) {
-    manual_object_->setRenderQueueGroup(group);
-  }
-}
-
-void Swatch::setDepthWriteEnabled(bool depth_write_enabled)
-{
-  if (material_) {
-    material_->setDepthWriteEnabled(depth_write_enabled);
-  }
-}
-
-Ogre::Pass * Swatch::getTechniquePass()
-{
-  if (material_) {
-    return material_->getTechnique(0)->getPass(0);
-  }
-  return nullptr;
-}
-
-std::string Swatch::getTextureName()
-{
-  if (texture_) {
-    return texture_->getName();
-  }
-  return "";
-}
-
-void Swatch::resetTexture(Ogre::DataStreamPtr & pixel_stream)
-{
-  old_texture_ = texture_;
-
-  texture_ = Ogre::TextureManager::getSingleton().loadRawData(
-    "MapTexture" + std::to_string(texture_count_++),
-    "rviz_rendering",
-    pixel_stream,
-    static_cast<uint16_t>(width_), static_cast<uint16_t>(height_),
-    Ogre::PF_L8, Ogre::TEX_TYPE_2D, 0);
-}
-
-void Swatch::setupMaterial()
-{
-  material_ = Ogre::MaterialManager::getSingleton().getByName("rviz/Indexed8BitImage");
-  material_ = material_->clone("MapMaterial" + std::to_string(material_count_++));
-
-  material_->setReceiveShadows(false);
-  material_->getTechnique(0)->setLightingEnabled(false);
-  material_->setDepthBias(-16.0f, 0.0f);
-  material_->setCullingMode(Ogre::CULL_NONE);
-  material_->setDepthWriteEnabled(false);
-}
-
-void Swatch::setupSceneNodeWithManualObject()
-{
-  manual_object_ = scene_manager_->createManualObject("MapObject" + std::to_string(map_count_++));
-
-  scene_node_ = parent_scene_node_->createChildSceneNode(
-    "NodeObject" + std::to_string(node_count_++));
-  scene_node_->attachObject(manual_object_);
-
-  setupSquareManualObject();
-}
-
-void Swatch::setupSquareManualObject()
-{
-  manual_object_->begin(
-    material_->getName(), Ogre::RenderOperation::OT_TRIANGLE_LIST, "rviz_rendering");
-
-  // first triangle
-  addPointWithPlaneCoordinates(0.0f, 0.0f);
-  addPointWithPlaneCoordinates(1.0f, 1.0f);
-  addPointWithPlaneCoordinates(0.0f, 1.0f);
-
-  // second triangle
-  addPointWithPlaneCoordinates(0.0f, 0.0f);
-  addPointWithPlaneCoordinates(1.0f, 0.0f);
-  addPointWithPlaneCoordinates(1.0f, 1.0f);
-
-  manual_object_->end();
-}
-
-void Swatch::addPointWithPlaneCoordinates(float x, float y)
-{
-  manual_object_->position(x, y, 0.0f);
-  manual_object_->textureCoord(x, y);
-  manual_object_->normal(0.0f, 0.0f, 1.0f);
-}
-
 }  // namespace displays
 }  // namespace rviz_default_plugins


### PR DESCRIPTION
This update separates the functionality of showing map content using swatches from the specific msg-type of an occupancy grid map.
A template base class takes care of the swatch handling and a child class implements the type-specific functions for the occupancy grid message.
Similarly, swatches are separated.

This feature allows for creating new map displays for different message types (or ogre materials) without copying large chunks of code every time.
Specifically, in a project, I have messages similar to the occupancy grid message for which additional displays are needed.
With this PR the overhead for each new display is minimized.

At the same time, the usage of the original map display does not change, i.e. all defined tests still succeed without any changes.

As I'm currently working on other derived displays, I noticed, that there are still some dependencies to nav_msgs::Occupancy.
Thus I have to rework this MR before a merge can be considered...
