### PR TITLE
Switch to using Qt::MiddleButton for RViz.

### DIFF
--- a/rviz_common/src/rviz_common/viewport_mouse_event.cpp
+++ b/rviz_common/src/rviz_common/viewport_mouse_event.cpp
@@ -80,7 +80,7 @@ bool ViewportMouseEvent::left()
 
 bool ViewportMouseEvent::middle()
 {
-  return buttons_down & Qt::MidButton;
+  return buttons_down & Qt::MiddleButton;
 }
 
 bool ViewportMouseEvent::right()
@@ -110,7 +110,7 @@ bool ViewportMouseEvent::leftUp()
 
 bool ViewportMouseEvent::middleUp()
 {
-  return type == QEvent::MouseButtonRelease && acting_button == Qt::MidButton;
+  return type == QEvent::MouseButtonRelease && acting_button == Qt::MiddleButton;
 }
 
 bool ViewportMouseEvent::rightUp()
@@ -125,7 +125,7 @@ bool ViewportMouseEvent::leftDown()
 
 bool ViewportMouseEvent::middleDown()
 {
-  return type == QEvent::MouseButtonPress && acting_button == Qt::MidButton;
+  return type == QEvent::MouseButtonPress && acting_button == Qt::MiddleButton;
 }
 
 bool ViewportMouseEvent::rightDown()

--- a/rviz_default_plugins/include/rviz_default_plugins/tools/interaction/interaction_tool.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/tools/interaction/interaction_tool.hpp
@@ -80,7 +80,7 @@ protected:
   {
     // We are dragging if a button was down and is still down
     Qt::MouseButtons buttons = event.buttons_down &
-      (Qt::LeftButton | Qt::RightButton | Qt::MidButton);
+      (Qt::LeftButton | Qt::RightButton | Qt::MiddleButton);
     if (event.type == QEvent::MouseButtonPress) {
       buttons &= ~event.acting_button;
     }


### PR DESCRIPTION
The old Qt::MidButton causes a deprecation warning on Qt 5.15.
Luckily the alias of Qt::MiddleButton still works as far back
as 5.12, so this should be a transparent change.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>