### PR TITLE
Fix ItemIdentityException

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -715,7 +715,7 @@ void RobotLink::assignMaterialsToEntities(
     default_material_ = getMaterialForLink(link);
 
     std::string cloned_name =
-      default_material_->getName() + std::to_string(material_count++) + "Robot";
+      default_material_->getName() + "_" + std::to_string(material_count++) + "Robot";
 
     default_material_ = default_material_->clone(cloned_name);
     default_material_name_ = default_material_->getName();
@@ -724,7 +724,7 @@ void RobotLink::assignMaterialsToEntities(
   for (uint32_t i = 0; i < entity->getNumSubEntities(); ++i) {
     default_material_ = getMaterialForLink(link, material_name);
     std::string cloned_name =
-      default_material_->getName() + std::to_string(material_count++) + "Robot";
+      default_material_->getName() + "_" + std::to_string(material_count++) + "Robot";
 
     default_material_ = default_material_->clone(cloned_name);
     default_material_name_ = default_material_->getName();
@@ -741,7 +741,7 @@ void RobotLink::assignMaterialsToEntities(
       // Once selection id is done per object and not per material,
       // this can go away
       std::string sub_cloned_name =
-        sub_material_name + std::to_string(material_count++) + "Robot";
+        sub_material_name + "_" + std::to_string(material_count++) + "Robot";
       sub->getMaterial()->clone(sub_cloned_name);
       sub->setMaterialName(sub_cloned_name);
     }


### PR DESCRIPTION
This PR fixes an ItemIdentityException I encountered while working through [this tutorial](https://moveit.picknik.ai/foxy/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) (more details [here](https://github.com/ros-planning/moveit2_tutorials/issues/193)).

I found that two different materials were being given the same name.  It looks like the material name gets set in two places.  [Here](https://github.com/ros2/rviz/blob/bbf18421f9143d6c399d8ca051b197c434e3d8c3/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp#L250), the name gets created by appending the word "Material" and an integer i to the path to the file containing the material.  Then, [here](https://github.com/ros2/rviz/blob/bbf18421f9143d6c399d8ca051b197c434e3d8c3/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp#L744), that name is changed by appending another integer, material_count, and the word "Robot".  The problem is that the digits in i and material_name run together, so some combinations of i and material_count result in exactly the same string.

In the issue I linked to, the file package://moveit_resources_panda_description/meshes/visual/link6.dae contained (at least) 15 different materials, so AssimpLoader::loadMaterials named them:

package://moveit_resources_panda_description/meshes/visual/link6.daeMaterial0
package://moveit_resources_panda_description/meshes/visual/link6.daeMaterial1
...
package://moveit_resources_panda_description/meshes/visual/link6.daeMaterial14

Material14 was added when material_count=1120, resulting in the name
package://moveit_resources_panda_description/meshes/visual/link6.daeMaterial141120Robot

Later, Material1 was added when material_count=41120, which resulted in the same name, hence the ItemIdentityException.  To fix this, I added an underscore before appending material_count to the material name, so for the preceding example we get two different names:
package://moveit_resources_panda_description/meshes/visual/link6.daeMaterial14_1120Robot
package://moveit_resources_panda_description/meshes/visual/link6.daeMaterial1_41120Robot