### PR TITLE
[FIX] rviz_default_plugins package deps

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -281,6 +281,7 @@ ament_export_dependencies(
   tf2_ros
   urdf
   visualization_msgs
+  image_transport
 )
 
 install(


### PR DESCRIPTION
image_transport switched to modern CMake style.
by this change, a missing dependency export led to errors while linking the rviz_default_plugin package to other custom rviz_plugins.
I.e., the linker was not able to find `-limage_transport::image_transport`.
CMake resolves the issue and finds the package if it is added to the dependency list of rviz_default_plugins.