### PR TITLE
Remove definition of PLUGINLIB_DISABLE_BOOST.

### DIFF
--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -32,8 +32,6 @@ Refer to the documentation of the relevant base class for a detailed API descrip
 ```
 * You need to link and compile against the `pluginlib` package. Further CMake options that might be relevant (see `rviz_default_plugins` CMakeLists):
 ```
-# prevent pluginlib from using boost
-target_compile_definitions(rviz_default_plugins PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 # Causes the visibility macros to use dllexport rather than dllimport (for Windows, when your plugin should be used as library)
 target_compile_definitions(rviz_default_plugins PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 ```

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -257,8 +257,6 @@ ament_target_dependencies(rviz_common
   urdf
   yaml_cpp_vendor
 )
-# prevent pluginlib from using boost
-target_compile_definitions(rviz_common PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(rviz_common PRIVATE "RVIZ_COMMON_BUILDING_LIBRARY")

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -238,9 +238,6 @@ target_link_libraries(rviz_default_plugins PUBLIC
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(rviz_default_plugins PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 
-# prevent pluginlib from using boost
-target_compile_definitions(rviz_default_plugins PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
-
 pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 
 ament_target_dependencies(rviz_default_plugins


### PR DESCRIPTION
This hasn't been necessary for almost 2 years now, so remove
it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>