### PR TITLE
Fix the build for Ubuntu Jammy arm64.

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -183,7 +183,8 @@ macro(build_ogre)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff &&
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/fix-arm64.diff
     COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.1-prefix/src/ogre-v1.12.1/CMake/Packages/FindFreetype.cmake
   )

--- a/rviz_ogre_vendor/fix-arm64.diff
+++ b/rviz_ogre_vendor/fix-arm64.diff
@@ -1,0 +1,21 @@
+commit 8ec086e9bc2e24fab373b514c572483b69071d69
+Author: Jonathan Wakely <jwakely@redhat.com>
+Date:   Thu May 28 22:37:19 2020 +0100
+
+    Only include <sys/sysctl.h> for iOS
+    
+    This file includes <sys/sysctl.h> if the CPU is ARM, which breaks compilation with the upcoming glibc 2.32 release because that header has been removed. The header only seems to be needed for sysctlbyname, which is only used on iOS. Change the #ifdef to avoid including it when not needed.
+
+diff --git a/OgreMain/src/OgrePlatformInformation.cpp b/OgreMain/src/OgrePlatformInformation.cpp
+index 9d1a39bc8..ad8beee35 100644
+--- a/OgreMain/src/OgrePlatformInformation.cpp
++++ b/OgreMain/src/OgrePlatformInformation.cpp
+@@ -36,7 +36,7 @@ THE SOFTWARE.
+ 
+     #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID
+         #include <cpu-features.h>
+-    #elif OGRE_CPU == OGRE_CPU_ARM 
++    #elif OGRE_CPU == OGRE_CPU_ARM && OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS
+         #include <sys/sysctl.h>
+         #if __MACH__
+             #include <mach/machine.h>


### PR DESCRIPTION
It turns out that on newer glibc, the sys/sysctl.h header does
not exist.  This caused the build to fail on Ubuntu Jammy.
There is an upstream one-line fix for this, so apply it here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Longer term (hopefully for Humble), we should try to switch to OGRE 1.12.7 or newer, at which point we can drop this patch.