### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -228,7 +228,7 @@ add_library(rviz_common SHARED
 target_include_directories(rviz_common
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 target_link_libraries(rviz_common
@@ -259,7 +259,6 @@ ament_target_dependencies(rviz_common
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(rviz_common PRIVATE "RVIZ_COMMON_BUILDING_LIBRARY")
 
-ament_export_targets(rviz_common)
 ament_export_dependencies(
   rviz_rendering
   geometry_msgs
@@ -273,8 +272,13 @@ ament_export_dependencies(
   urdf
   yaml_cpp_vendor
 )
-ament_export_include_directories(include)
+
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(rviz_common)
+
+# Export modern CMake targets
+ament_export_targets(rviz_common)
 
 install(
   TARGETS rviz_common
@@ -282,12 +286,11 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
 )
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(FILES default.rviz

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -224,7 +224,7 @@ add_library(rviz_default_plugins SHARED
 
 target_include_directories(rviz_default_plugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   ${Qt5Widgets_INCLUDE_DIRS}
 )
 
@@ -260,8 +260,12 @@ ament_target_dependencies(rviz_default_plugins
   visualization_msgs
 )
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+# Export modern CMake targets
 ament_export_targets(rviz_default_plugins HAS_LIBRARY_TARGET)
+
 ament_export_dependencies(
   geometry_msgs
   image_transport
@@ -287,12 +291,11 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
 )
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -107,14 +107,13 @@ target_link_libraries(rviz_rendering
 target_include_directories(rviz_rendering
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
     ${Eigen3_INCLUDE_DIRS}
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(rviz_rendering PRIVATE "RVIZ_RENDERING_BUILDING_LIBRARY")
 
-ament_export_targets(rviz_rendering)
 ament_target_dependencies(rviz_rendering
   SYSTEM PUBLIC
   rviz_assimp_vendor
@@ -127,21 +126,24 @@ ament_export_dependencies(
   resource_retriever
   ament_index_cpp)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(rviz_rendering)
+
+# Export modern CMake targets
+ament_export_targets(rviz_rendering)
 
 install(
   TARGETS rviz_rendering
   EXPORT rviz_rendering
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
-  INCLUDES DESTINATION include
   RUNTIME DESTINATION bin
 )
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 set(rviz_rendering_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake")

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -81,17 +81,21 @@ add_library(rviz_visual_testing_framework STATIC ${visual_test_framework_source_
 target_include_directories(rviz_visual_testing_framework
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
     ${GTEST_INCLUDE_DIRS})
 
 target_link_libraries(rviz_visual_testing_framework
   ${visual_tests_target_libaries})
 
 # export information to downstream packages
-ament_export_targets(rviz_visual_testing_framework)
 ament_export_dependencies(Qt5)
 ament_export_dependencies(rviz_common)
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
+# Export modern CMake targets
+ament_export_targets(rviz_visual_testing_framework)
 
 install(
   TARGETS rviz_visual_testing_framework
@@ -99,12 +103,11 @@ install(
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
 )
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1150 - this installs headers to a unique include directory to prevent include directory search order issues when overriding packages from a merged workspace.