### PR TITLE
Remove YAML_CPP_DLL define

### DIFF
--- a/rviz_common/src/rviz_common/yaml_config_reader.cpp
+++ b/rviz_common/src/rviz_common/yaml_config_reader.cpp
@@ -38,9 +38,6 @@
 #define RVIZ_HAVE_YAMLCPP_05 1
 
 #ifdef RVIZ_HAVE_YAMLCPP_05
-#ifdef _WIN32
-#define YAML_CPP_DLL
-#endif
 #include <yaml-cpp/yaml.h>
 #else
 #include <yaml-cpp/node.h>

--- a/rviz_common/src/rviz_common/yaml_config_writer.cpp
+++ b/rviz_common/src/rviz_common/yaml_config_writer.cpp
@@ -32,9 +32,6 @@
 
 #include <fstream>
 
-#ifdef _WIN32
-#define YAML_CPP_DLL
-#endif
 #include "yaml-cpp/emitter.h"
 
 namespace rviz_common


### PR DESCRIPTION
Since https://github.com/ros2/yaml_cpp_vendor/issues/10 is fixed, the explicit `YAML_CPP_DLL` define is no longer needed and needs to be removed to prevent the macro redefinition warnings.

This should be backported to foxy and galactic.