### PR TITLE
Drop ignition-math6 from rviz_default_plugins link interface

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -231,6 +231,9 @@ target_include_directories(rviz_default_plugins PUBLIC
 target_link_libraries(rviz_default_plugins PUBLIC
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
+)
+
+target_link_libraries(rviz_default_plugins PRIVATE
   ignition-math6
 )
 


### PR DESCRIPTION
None of the rviz_default_plugins ABI relies on consumers linking against ignition-math6 directly.

The alternative is to add the ignition-math6 link directory to the rviz_default_plugins link interface so that consumers can reliably find the library.

This isn't a problem on Ubuntu where the vendor package isn't built, but on RHEL, packages downstream of `rviz_default_plugins` fail to link because they can't find `-lignition-math6`.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16222)](http://ci.ros2.org/job/ci_linux/16222/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10847)](http://ci.ros2.org/job/ci_linux-aarch64/10847/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=186)](http://ci.ros2.org/job/ci_linux-rhel/186/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16577)](http://ci.ros2.org/job/ci_windows/16577/)