### PR TITLE
Disable a warning when including Eigen.

### DIFF
--- a/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
@@ -42,7 +42,9 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include <Eigen/Dense>  // NOLINT: cpplint cannot handle correct include here
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 

--- a/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
@@ -36,7 +36,15 @@
 #include <sstream>  // needed for Eigen until https://gitlab.com/libeigen/eigen/-/merge_requests/65
 #include <vector>
 
+// GCC 11 has a false positive warning about uninitialized variables in Eigen.  There is an open
+// issue about it at https://gitlab.com/libeigen/eigen/-/issues/2304 .  Just disable the warning
+// for Eigen for now.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #include <Eigen/Dense>  // NOLINT: cpplint cannot handle correct include here
+#pragma GCC diagnostic pop
+#endif
 
 #include <OgreVector3.h>
 #include <OgreColourValue.h>


### PR DESCRIPTION
As mentioned in the comment here, this is an issue in upstream
Eigen (and in the version shipped in Ubuntu 22.04), so just
disable the warning for now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>