### PR TITLE
Disable class-memaccess warnings for Eigen.

### DIFF
--- a/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
@@ -39,9 +39,16 @@
 // GCC 11 has a false positive warning about uninitialized variables in Eigen.  There is an open
 // issue about it at https://gitlab.com/libeigen/eigen/-/issues/2304 .  Just disable the warning
 // for Eigen for now.
+// Also Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 #include <Eigen/Dense>  // NOLINT: cpplint cannot handle correct include here
 #ifdef __GNUC__


### PR DESCRIPTION
The added comment explains why we are doing this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>