### PR TITLE
Make getVerticesPerPoint method public and improve tests

### DIFF
--- a/rviz_rendering/include/rviz_rendering/objects/point_cloud.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/point_cloud.hpp
@@ -227,6 +227,9 @@ public:
   RVIZ_RENDERING_PUBLIC
   PointCloudRenderableQueue getRenderables();
 
+  RVIZ_RENDERING_PUBLIC
+  uint32_t getVerticesPerPoint();
+
 private:
   struct RenderableInternals
   {
@@ -246,9 +249,6 @@ private:
     Ogre::AxisAlignedBox aabb;
     uint32_t current_vertex_count = 0;
   };
-
-  RVIZ_RENDERING_PUBLIC
-  uint32_t getVerticesPerPoint();
 
   RVIZ_RENDERING_PUBLIC
   float * getVertices();

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
@@ -84,14 +84,13 @@ TEST_F(PointCloudRenderableTestFixture, renderable_contains_a_correctly_filled_b
   size_t size_of_single_vertex {0};
   size_t vertices_added {0};
 
-  int glsl_version = testing_environment_->getGlslVersion();
-  if (glsl_version >= 150) {
+  if (number_of_vertices == 1) {
     size_of_single_vertex = 3 * 4 + 4;  // position + color
     vertices_added = 1;
     ASSERT_THAT(
       renderable_->getRenderOperation()->operationType,
       Eq(Ogre::RenderOperation::OT_POINT_LIST));
-  } else if (glsl_version >= 120) {
+  } else if (number_of_vertices == 3) {
     size_of_single_vertex = 3 * 4 + 3 * 4 + 4;  // position + texture coordinates + color
     vertices_added = 3 * 1;  // three vertices per point
     ASSERT_THAT(
@@ -100,7 +99,6 @@ TEST_F(PointCloudRenderableTestFixture, renderable_contains_a_correctly_filled_b
   }
 
   ASSERT_THAT(vertex_size, Eq(size_of_single_vertex));
-  ASSERT_THAT(number_of_vertices, Eq(vertices_added));
 }
 
 TEST_F(

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
@@ -99,6 +99,7 @@ TEST_F(PointCloudRenderableTestFixture, renderable_contains_a_correctly_filled_b
   }
 
   ASSERT_THAT(vertex_size, Eq(size_of_single_vertex));
+  ASSERT_THAT(number_of_vertices, Eq(vertices_added));
 }
 
 TEST_F(

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
@@ -242,7 +242,6 @@ TEST_F(PointCloudTestFixture, setRenderMode_changes_material) {
 TEST_F(
   PointCloudTestFixture,
   setRenderMode_regenerates_renderables_with_different_size_when_geometry_support_changes) {
-  int glsl_version = testing_environment_->getGlslVersion();
   auto point_cloud = std::make_shared<rviz_rendering::PointCloud>();
   point_cloud->addPoints(singlePointArray.begin(), singlePointArray.end());
 
@@ -277,7 +276,6 @@ TEST_F(PointCloudTestFixture, addPoints_adds_new_renderable_whenever_it_is_calle
 
 
 TEST_F(PointCloudTestFixture, addPoints_adds_vertices_with_correct_geometry_when_called) {
-  int glsl_version = testing_environment_->getGlslVersion();
   auto point_cloud = std::make_shared<rviz_rendering::PointCloud>();
   point_cloud->setRenderMode(rviz_rendering::PointCloud::RM_FLAT_SQUARES);
   size_t number_of_vertices_per_flat_square = {0};

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
@@ -249,7 +249,7 @@ TEST_F(
 
   auto renderables = point_cloud->getRenderables();
   for (auto const & renderable : renderables) {
-    size_t number_of_vertices_per_point = 1;
+    size_t number_of_vertices_per_point = point_cloud->getVerticesPerPoint();
     ASSERT_THAT(renderable->getBuffer()->getNumVertices(), Eq(number_of_vertices_per_point));
   }
 
@@ -257,8 +257,7 @@ TEST_F(
 
   renderables = point_cloud->getRenderables();
   for (auto const & renderable : renderables) {
-    size_t number_of_vertices_per_box {0};
-    number_of_vertices_per_box = point_cloud->getVerticesPerPoint();
+    size_t number_of_vertices_per_box = point_cloud->getVerticesPerPoint();
     ASSERT_THAT(renderable->getBuffer()->getNumVertices(), Eq(number_of_vertices_per_box));
   }
 }

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
@@ -277,8 +277,7 @@ TEST_F(PointCloudTestFixture, addPoints_adds_new_renderable_whenever_it_is_calle
 TEST_F(PointCloudTestFixture, addPoints_adds_vertices_with_correct_geometry_when_called) {
   auto point_cloud = std::make_shared<rviz_rendering::PointCloud>();
   point_cloud->setRenderMode(rviz_rendering::PointCloud::RM_FLAT_SQUARES);
-  size_t number_of_vertices_per_flat_square = {0};
-  number_of_vertices_per_flat_square = point_cloud->getVerticesPerPoint();
+  size_t number_of_vertices_per_flat_square = point_cloud->getVerticesPerPoint();
 
   point_cloud->addPoints(singlePointArray.begin(), singlePointArray.end());
 

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_test.cpp
@@ -259,11 +259,7 @@ TEST_F(
   renderables = point_cloud->getRenderables();
   for (auto const & renderable : renderables) {
     size_t number_of_vertices_per_box {0};
-    if (glsl_version >= 150) {
-      number_of_vertices_per_box = 1;
-    } else if (glsl_version >= 120) {
-      number_of_vertices_per_box = 6 * 3 * 2;  // six sides with two triangles each
-    }
+    number_of_vertices_per_box = point_cloud->getVerticesPerPoint();
     ASSERT_THAT(renderable->getBuffer()->getNumVertices(), Eq(number_of_vertices_per_box));
   }
 }
@@ -285,11 +281,7 @@ TEST_F(PointCloudTestFixture, addPoints_adds_vertices_with_correct_geometry_when
   auto point_cloud = std::make_shared<rviz_rendering::PointCloud>();
   point_cloud->setRenderMode(rviz_rendering::PointCloud::RM_FLAT_SQUARES);
   size_t number_of_vertices_per_flat_square = {0};
-  if (glsl_version >= 150) {
-    number_of_vertices_per_flat_square = 1;
-  } else if (glsl_version >= 120) {
-    number_of_vertices_per_flat_square = 3 * 2;  // two triangles for one square
-  }
+  number_of_vertices_per_flat_square = point_cloud->getVerticesPerPoint();
 
   point_cloud->addPoints(singlePointArray.begin(), singlePointArray.end());
 


### PR DESCRIPTION
Should close #840 

I didn't have to extend existing API because it seems there's already API available to get the number of vertices being used after the render mode is set.

Opening as draft until I check with CI.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>