### PR TITLE
Make sure to pass compiler and flags down to assimp.

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -9,8 +9,6 @@ option(FORCE_BUILD_VENDOR_PKG
 
 find_package(ament_cmake REQUIRED)
 
-set(PACKAGE_VERSION "1.0.0")
-
 macro(build_assimp)
   set(extra_cmake_args)
   if(DEFINED CMAKE_BUILD_TYPE)
@@ -21,13 +19,15 @@ macro(build_assimp)
     list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=/w /EHsc")
     list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=/w")
   else()
-    list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=-std=c++14 -w")
-    list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=-w")
+    list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -std=c++14 -w")
+    list(APPEND extra_cmake_args "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -w")
   endif()
 
   list(APPEND extra_cmake_args "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF")
   list(APPEND extra_cmake_args "-DASSIMP_BUILD_TESTS=OFF")
   list(APPEND extra_cmake_args "-DASSIMP_BUILD_SAMPLES=OFF")
+  list(APPEND extra_cmake_args "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
+  list(APPEND extra_cmake_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
 
   if(WIN32 AND NOT ${CMAKE_VERBOSE_MAKEFILE})
     set(should_log ON)  # prevent warnings in Windows CI


### PR DESCRIPTION
That way, if we rebuild it for clang it actually uses the
correct compiler and ABI.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should get us one step closer to fixing https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/ (though we still need further work to make that build succeed).