### PR TITLE
Add Map Display binary option

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -125,7 +125,6 @@ protected Q_SLOTS:
   void transformMap();
   void updateMapUpdateTopic();
 
-
 protected:
   void updateTopic() override;
   void update(float wall_dt, float ros_dt) override;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -120,9 +120,11 @@ protected Q_SLOTS:
   void updateAlpha();
   void updateDrawUnder() const;
   void updatePalette();
+  void updateBinaryThreshold();
   /** @brief Show current_map_ in the scene. */
   void transformMap();
   void updateMapUpdateTopic();
+
 
 protected:
   void updateTopic() override;
@@ -161,7 +163,7 @@ protected:
   void updateSwatches() const;
 
   std::vector<std::shared_ptr<Swatch>> swatches_;
-  std::vector<Ogre::TexturePtr> palette_textures_;
+  std::vector<Ogre::TexturePtr> palette_textures_, palette_textures_binary_;
   std::vector<bool> color_scheme_transparency_;
   bool loaded_;
 
@@ -185,6 +187,8 @@ protected:
   rviz_common::properties::Property * draw_under_property_;
   rviz_common::properties::EnumProperty * color_scheme_property_;
   rviz_common::properties::BoolProperty * transform_timestamp_property_;
+  rviz_common::properties::BoolProperty * binary_view_property_;
+  rviz_common::properties::IntProperty * binary_threshold_property_;
 
   uint32_t update_messages_received_;
 };

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
@@ -40,9 +40,9 @@ namespace rviz_default_plugins
 namespace displays
 {
 
-std::vector<unsigned char> makeRawPalette();
-std::vector<unsigned char> makeMapPalette();
-std::vector<unsigned char> makeCostmapPalette();
+std::vector<unsigned char> makeRawPalette(bool binary=false, int threshold = 100);
+std::vector<unsigned char> makeMapPalette(bool binary=false, int threshold = 100);
+std::vector<unsigned char> makeCostmapPalette(bool binary=false, int threshold = 100);
 
 class PaletteBuilder : public
   std::enable_shared_from_this<PaletteBuilder>

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
@@ -40,9 +40,9 @@ namespace rviz_default_plugins
 namespace displays
 {
 
-std::vector<unsigned char> makeRawPalette(bool binary=false, int threshold = 100);
-std::vector<unsigned char> makeMapPalette(bool binary=false, int threshold = 100);
-std::vector<unsigned char> makeCostmapPalette(bool binary=false, int threshold = 100);
+std::vector<unsigned char> makeRawPalette(bool binary = false, int threshold = 100);
+std::vector<unsigned char> makeMapPalette(bool binary = false, int threshold = 100);
+std::vector<unsigned char> makeCostmapPalette(bool binary = false, int threshold = 100);
 
 class PaletteBuilder : public
   std::enable_shared_from_this<PaletteBuilder>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -137,6 +137,23 @@ MapDisplay::MapDisplay()
   transform_timestamp_property_ = new rviz_common::properties::BoolProperty(
     "Use Timestamp", false,
     "Use map header timestamp when transforming", this, SLOT(transformMap()));
+
+  binary_view_property_ = new rviz_common::properties::BoolProperty(
+    "Binary representation", 
+    false,
+    "Allows to represent the map value as either free or occupied, considering the user-defined threshold",
+    this, 
+    SLOT(updatePalette()));
+
+  binary_threshold_property_ = new rviz_common::properties::IntProperty(
+    "Binary threshold", 
+    100,
+    "Minimum value to mark cells as obstacle in the binary representation of the map", 
+    this,
+    SLOT(updateBinaryThreshold()));
+   binary_threshold_property_->setMin(0);
+   binary_threshold_property_->setMax(100);
+
 }
 
 MapDisplay::~MapDisplay()
@@ -184,11 +201,21 @@ void MapDisplay::onInitialize()
     });
   // Order of palette textures here must match option indices for color_scheme_property_ above.
   palette_textures_.push_back(makePaletteTexture(makeMapPalette()));
+  palette_textures_binary_.push_back(makePaletteTexture(makeMapPalette(true, binary_threshold_property_->getInt())));
   color_scheme_transparency_.push_back(false);
   palette_textures_.push_back(makePaletteTexture(makeCostmapPalette()));
+  palette_textures_binary_.push_back(makePaletteTexture(makeCostmapPalette(true, binary_threshold_property_->getInt())));
   color_scheme_transparency_.push_back(true);
   palette_textures_.push_back(makePaletteTexture(makeRawPalette()));
+  palette_textures_binary_.push_back(makePaletteTexture(makeRawPalette(true, binary_threshold_property_->getInt())));
   color_scheme_transparency_.push_back(true);
+}
+
+void MapDisplay::updateBinaryThreshold()
+{
+  palette_textures_binary_[0] = makePaletteTexture(makeMapPalette(true, binary_threshold_property_->getInt()));
+  palette_textures_binary_[1] = makePaletteTexture(makeCostmapPalette(true, binary_threshold_property_->getInt()));
+  palette_textures_binary_[2] = makePaletteTexture(makeRawPalette(true, binary_threshold_property_->getInt()));
 }
 
 void MapDisplay::updateTopic()
@@ -571,6 +598,8 @@ void MapDisplay::updateSwatches() const
 
 void MapDisplay::updatePalette()
 {
+  bool binary = binary_view_property_->getBool();
+
   int palette_index = color_scheme_property_->getOptionInt();
 
   for (const auto & swatch : swatches_) {
@@ -581,7 +610,11 @@ void MapDisplay::updatePalette()
     } else {
       palette_tex_unit = pass->createTextureUnitState();
     }
-    palette_tex_unit->setTexture(palette_textures_[palette_index]);
+    if (binary){
+      palette_tex_unit->setTexture(palette_textures_binary_[palette_index]);
+    } else {
+      palette_tex_unit->setTexture(palette_textures_[palette_index]);
+    }
     palette_tex_unit->setTextureFiltering(Ogre::TFO_NONE);
   }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -151,8 +151,8 @@ MapDisplay::MapDisplay()
     "Minimum value to mark cells as obstacle in the binary representation of the map",
     this,
     SLOT(updateBinaryThreshold()));
-   binary_threshold_property_->setMin(0);
-   binary_threshold_property_->setMax(100);
+  binary_threshold_property_->setMin(0);
+  binary_threshold_property_->setMax(100);
 }
 
 MapDisplay::~MapDisplay()
@@ -611,7 +611,7 @@ void MapDisplay::updatePalette()
     } else {
       palette_tex_unit = pass->createTextureUnitState();
     }
-    if (binary){
+    if (binary) {
       palette_tex_unit->setTexture(palette_textures_binary_[palette_index]);
     } else {
       palette_tex_unit->setTexture(palette_textures_[palette_index]);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -215,8 +215,8 @@ void MapDisplay::updateBinaryThreshold()
 {
   int threshold = binary_threshold_property_->getInt();
   palette_textures_binary_[0] = makePaletteTexture(makeMapPalette(true, threshold));
-  palette_textures_binary_[1] = makePaletteTexture(makeCostmapPalette(true,  threshold));
-  palette_textures_binary_[2] = makePaletteTexture(makeRawPalette(true,  threshold));
+  palette_textures_binary_[1] = makePaletteTexture(makeCostmapPalette(true, threshold));
+  palette_textures_binary_[2] = makePaletteTexture(makeRawPalette(true, threshold));
 }
 
 void MapDisplay::updateTopic()

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -139,21 +139,20 @@ MapDisplay::MapDisplay()
     "Use map header timestamp when transforming", this, SLOT(transformMap()));
 
   binary_view_property_ = new rviz_common::properties::BoolProperty(
-    "Binary representation", 
+    "Binary representation",
     false,
-    "Allows to represent the map value as either free or occupied, considering the user-defined threshold",
-    this, 
+    "Represent the map value as either free or occupied, considering the user-defined threshold",
+    this,
     SLOT(updatePalette()));
 
   binary_threshold_property_ = new rviz_common::properties::IntProperty(
-    "Binary threshold", 
+    "Binary threshold",
     100,
-    "Minimum value to mark cells as obstacle in the binary representation of the map", 
+    "Minimum value to mark cells as obstacle in the binary representation of the map",
     this,
     SLOT(updateBinaryThreshold()));
    binary_threshold_property_->setMin(0);
    binary_threshold_property_->setMax(100);
-
 }
 
 MapDisplay::~MapDisplay()
@@ -199,23 +198,25 @@ void MapDisplay::onInitialize()
       this->update_profile_ = profile;
       updateMapUpdateTopic();
     });
+  int threshold = binary_threshold_property_->getInt();
   // Order of palette textures here must match option indices for color_scheme_property_ above.
   palette_textures_.push_back(makePaletteTexture(makeMapPalette()));
-  palette_textures_binary_.push_back(makePaletteTexture(makeMapPalette(true, binary_threshold_property_->getInt())));
+  palette_textures_binary_.push_back(makePaletteTexture(makeMapPalette(true, threshold)));
   color_scheme_transparency_.push_back(false);
   palette_textures_.push_back(makePaletteTexture(makeCostmapPalette()));
-  palette_textures_binary_.push_back(makePaletteTexture(makeCostmapPalette(true, binary_threshold_property_->getInt())));
+  palette_textures_binary_.push_back(makePaletteTexture(makeCostmapPalette(true, threshold)));
   color_scheme_transparency_.push_back(true);
   palette_textures_.push_back(makePaletteTexture(makeRawPalette()));
-  palette_textures_binary_.push_back(makePaletteTexture(makeRawPalette(true, binary_threshold_property_->getInt())));
+  palette_textures_binary_.push_back(makePaletteTexture(makeRawPalette(true, threshold)));
   color_scheme_transparency_.push_back(true);
 }
 
 void MapDisplay::updateBinaryThreshold()
 {
-  palette_textures_binary_[0] = makePaletteTexture(makeMapPalette(true, binary_threshold_property_->getInt()));
-  palette_textures_binary_[1] = makePaletteTexture(makeCostmapPalette(true, binary_threshold_property_->getInt()));
-  palette_textures_binary_[2] = makePaletteTexture(makeRawPalette(true, binary_threshold_property_->getInt()));
+  int threshold = binary_threshold_property_->getInt();
+  palette_textures_binary_[0] = makePaletteTexture(makeMapPalette(true, threshold));
+  palette_textures_binary_[1] = makePaletteTexture(makeCostmapPalette(true,  threshold));
+  palette_textures_binary_[2] = makePaletteTexture(makeRawPalette(true,  threshold));
 }
 
 void MapDisplay::updateTopic()

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/palette_builder.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/palette_builder.cpp
@@ -110,7 +110,7 @@ std::vector<unsigned char> makeMapPalette(bool binary, int threshold)
 std::vector<unsigned char> makeCostmapPalette(bool binary, int threshold)
 {
   auto palette_builder = std::make_shared<PaletteBuilder>();
-    if (binary) {
+  if (binary) {
     for (unsigned char i = 0; i < threshold; i++) {
       palette_builder->setColorForValue(i, 0, 0, 255, 255);
     }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/palette_builder.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/palette_builder.cpp
@@ -84,13 +84,22 @@ std::vector<unsigned char> PaletteBuilder::buildPalette()
   return palette_;
 }
 
-std::vector<unsigned char> makeMapPalette()
+std::vector<unsigned char> makeMapPalette(bool binary, int threshold)
 {
   auto palette_builder = std::make_shared<PaletteBuilder>();
-  for (unsigned char i = 0; i <= 100; i++) {
-    // Standard gray map palette values
-    unsigned char v = 255 - (255 * i) / 100;
-    palette_builder->setColorForValue(i, v, v, v, 255);
+  if (binary) {
+    for (unsigned char i = 0; i < threshold; i++) {
+      palette_builder->setColorForValue(i, 255, 255, 255, 255);
+    }
+    for (unsigned char i = threshold; i <= 100; i++) {
+      palette_builder->setColorForValue(i, 0, 0, 0, 255);
+    }
+  } else {
+    for (unsigned char i = 0; i <= 100; i++) {
+      // Standard gray map palette values
+      unsigned char v = 255 - (255 * i) / 100;
+      palette_builder->setColorForValue(i, v, v, v, 255);
+    }
   }
   return palette_builder->setColorForIllegalPositiveValues(0, 255, 0)
          ->setRedYellowColorsForIllegalNegativeValues()
@@ -98,16 +107,25 @@ std::vector<unsigned char> makeMapPalette()
          ->buildPalette();
 }
 
-std::vector<unsigned char> makeCostmapPalette()
+std::vector<unsigned char> makeCostmapPalette(bool binary, int threshold)
 {
   auto palette_builder = std::make_shared<PaletteBuilder>();
-  palette_builder->setColorForValue(0, 0, 0, 0, 0);
-  for (unsigned char i = 1; i <= 98; i++) {
-    unsigned char v = (255 * i) / 100;
-    palette_builder->setColorForValue(i, v, 0, 255 - v, 255);
+    if (binary) {
+    for (unsigned char i = 0; i < threshold; i++) {
+      palette_builder->setColorForValue(i, 0, 0, 255, 255);
+    }
+    for (unsigned char i = threshold; i <= 100; i++) {
+      palette_builder->setColorForValue(i, 255, 0, 0, 255);
+    }
+  } else {
+    palette_builder->setColorForValue(0, 0, 0, 0, 0);
+    for (unsigned char i = 1; i <= 98; i++) {
+      unsigned char v = (255 * i) / 100;
+      palette_builder->setColorForValue(i, v, 0, 255 - v, 255);
+    }
+    palette_builder->setColorForValue(99, 0, 255, 255, 255);  // obstacle values in cyan
+    palette_builder->setColorForValue(100, 255, 0, 255, 255);  // lethal obstacle values in purple
   }
-  palette_builder->setColorForValue(99, 0, 255, 255, 255);  // obstacle values in cyan
-  palette_builder->setColorForValue(100, 255, 0, 255, 255);  // lethal obstacle values in purple
 
   return palette_builder->setColorForIllegalPositiveValues(0, 255, 0)
          ->setRedYellowColorsForIllegalNegativeValues()
@@ -115,11 +133,20 @@ std::vector<unsigned char> makeCostmapPalette()
          ->buildPalette();
 }
 
-std::vector<unsigned char> makeRawPalette()
+std::vector<unsigned char> makeRawPalette(bool binary, int threshold)
 {
   auto palette_builder = std::make_shared<PaletteBuilder>();
-  for (int i = 0; i < 256; i++) {
-    palette_builder->setColorForValue(i, i, i, i, 255);
+  if (binary) {
+    for (unsigned char i = 0; i < threshold; i++) {
+      palette_builder->setColorForValue(i, 0, 0, 0, 255);
+    }
+    for (int i = threshold; i < 256; i++) {
+      palette_builder->setColorForValue(i, 255, 255, 255, 255);
+    }
+  } else {
+    for (int i = 0; i < 256; i++) {
+      palette_builder->setColorForValue(i, i, i, i, 255);
+    }
   }
   return palette_builder->buildPalette();
 }


### PR DESCRIPTION
Adds #798. 
The Map display now has a flag and a settable threshold to represent the map as binary. 
Useful to inspect maps or in combination with planners that have a settable traversability threshold.

See screenshots for demo.

![Screenshot from 2022-03-31 16-52-16](https://user-images.githubusercontent.com/13013812/161084816-23294449-5a82-426f-8e7a-1ff94adbeb2d.png)

![Screenshot from 2022-03-31 16-51-12](https://user-images.githubusercontent.com/13013812/161084633-9434ca10-f849-4254-8061-d55d2decebe4.png)

![Screenshot from 2022-03-31 16-51-49](https://user-images.githubusercontent.com/13013812/161084701-0dcbfcb5-976b-4349-aa93-02478d630f5a.png)
