### PR TITLE
Add far plane distance property to camera

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -194,6 +194,7 @@ private:
   rviz_common::properties::FloatProperty * alpha_property_;
   rviz_common::properties::EnumProperty * image_position_property_;
   rviz_common::properties::FloatProperty * zoom_property_;
+  rviz_common::properties::FloatProperty * far_plane_property_;
   rviz_common::properties::DisplayGroupVisibilityProperty * visibility_property_;
 
   sensor_msgs::msg::CameraInfo::ConstSharedPtr current_caminfo_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -122,6 +122,13 @@ CameraDisplay::CameraDisplay()
     this);
   zoom_property_->setMin(0.00001f);
   zoom_property_->setMax(100000.0f);
+
+  far_plane_property_ = new rviz_common::properties::FloatProperty(
+    "Far Plane Distance", 100.0f,
+    "Geometry beyond the camera's far plane will not be rendered.",
+    this);
+  far_plane_property_->setMin(0.00001f);
+  far_plane_property_->setMax(100000.0f);
 }
 
 CameraDisplay::~CameraDisplay()
@@ -593,7 +600,7 @@ Ogre::Matrix4 CameraDisplay::calculateProjectionMatrix(
   auto fx = static_cast<float>(info->p[0]);
   auto fy = static_cast<float>(info->p[5]);
 
-  float far_plane = 100.0f;
+  float far_plane = far_plane_property_->getFloat();
   float near_plane = 0.01f;
 
   Ogre::Matrix4 proj_matrix;


### PR DESCRIPTION
Adds a property for configuring the camera plugin's far plane distance, allowing geometry > 100 m away to be rendered by the camera plugin. (see #842).

@jacobperron Could you take a quick look?