### PR TITLE
Make sure not to dereference a null Renderable pointer.

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_renderer.cpp
@@ -301,7 +301,10 @@ Ogre::Technique * SelectionRenderer::handleSchemeNotFound(
   }
 
   // find out if the renderable has the picking param set
-  bool has_pick_param = rend->getUserObjectBindings().getUserAny("pick_handle").has_value();
+  bool has_pick_param = false;
+  if (rend != nullptr) {
+    has_pick_param = rend->getUserObjectBindings().getUserAny("pick_handle").has_value();
+  }
 
   // NOTE: it is important to avoid changing the culling mode of the
   // fallback techniques here, because that change then propagates to


### PR DESCRIPTION
SelectionRenderer is a child class of Ogre::MaterialManager::Listener.
As such, it overrides the virtual method handleSchemeNotFound.
The last argument of handleSchemeNotFound is rend; the OGRE
documentation for that parameter says the following:

@param rend Pointer to the Renderable that is requesting this technique
     to be used, so this may influence your choice of Technique. May be
     null if the technique isn't being requested in that context.

Note that it may be null in certain circumstances, but the
implementation in SelectionRenderer was always expecting it to be not
null.  This could lead to a crash in certain situations.  Make sure to
check rend against nullptr before doing any work with it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>