### PR TITLE
Stop using glsl150 resources for now.

### DIFF
--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -377,12 +377,7 @@ RenderSystem::setupResources()
   // Unfortunately, Ogre doesn't have a notion of glsl versions so we can't go
   // the 'official' way of defining multiple schemes per material and let Ogre
   // decide which one to use.
-  if (getGlslVersion() >= 150) {
-    Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
-      rviz_path + "/ogre_media/materials/glsl150", "FileSystem", "rviz_rendering");
-    Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
-      rviz_path + "/ogre_media/materials/scripts150", "FileSystem", "rviz_rendering");
-  } else if (getGlslVersion() >= 120) {
+  if (getGlslVersion() >= 120) {
     Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
       rviz_path + "/ogre_media/materials/scripts120", "FileSystem", "rviz_rendering");
   } else {


### PR DESCRIPTION
While testing out rviz, we noticed that a bunch of the GLSL150
resources could not be properly loaded by rviz_rendering/OGRE.
This was particularly noticeable by inserting a LaserScan plugin,
then trying to run the dummy_robot_bringup.launch.py .

At the moment I honestly don't understand why this is a problem, but
disable GLSL 150 for now so we can have working laser scan
visualization.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This essentially undoes the main thrust of #668 ; FYI @pijaro .  With this fix in place, this should close #805 .