### PR TITLE
[humble] Add time jump handler (#791)

### DIFF
--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -213,9 +213,6 @@ public:
    */
   void handleMouseEvent(const ViewportMouseEvent & event) override;
 
-  /// Resets the wall and ROS elapsed time to zero and calls resetDisplays().
-  void resetTime();
-
   /// Return a pointer to the HandlerManager
   std::shared_ptr<rviz_common::interaction::HandlerManagerIface> getHandlerManager() const override;
 
@@ -302,7 +299,14 @@ public:
 
   rclcpp::Clock::SharedPtr getClock() override;
 
+public Q_SLOTS:
+  /// Resets the wall and ROS elapsed time to zero and calls resetDisplays().
+  void resetTime();
+
 Q_SIGNALS:
+  /// Emitted after time jump was detected.
+  void timeJumped();
+
   /// Emitted before updating all Displays.
   void preUpdate();
 
@@ -328,6 +332,9 @@ protected Q_SLOTS:
   void onToolChanged(Tool *);
 
 protected:
+  /// Called when ROS detects a time jump.
+  void onTimeJump(const rcl_time_jump_t & time_jump);
+
   void updateTime();
 
   void updateFrames();
@@ -385,6 +392,7 @@ protected:
   OgreRenderQueueClearer * ogre_render_queue_clearer_;
 
   rclcpp::Clock::SharedPtr clock_;
+  rclcpp::JumpHandler::SharedPtr clock_jump_handler_;
 
 private Q_SLOTS:
   void updateFixedFrame();


### PR DESCRIPTION
Backport #791 

This fixes a bug where displays are not reset properly when a ROS time jumps.

---

I'm not sure if marking an existing method as a Qt slot breaks API, let me know what you think. Technically, we could workaround it by just adding a new method, but it'd be nice to keep the change consistent with Rolling.