### PR TITLE
Make resource file paths relative

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -184,7 +184,8 @@ macro(build_ogre)
       -Wno-dev
     PATCH_COMMAND
       ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff &&
-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/fix-arm64.diff
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/fix-arm64.diff &&
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/relocatable.patch
     COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.1-prefix/src/ogre-v1.12.1/CMake/Packages/FindFreetype.cmake
   )

--- a/rviz_ogre_vendor/relocatable.patch
+++ b/rviz_ogre_vendor/relocatable.patch
@@ -1,0 +1,24 @@
+diff -uNr a/CMake/InstallResources.cmake b/CMake/InstallResources.cmake
+--- a/CMake/InstallResources.cmake	2022-05-09 17:30:13.273565553 -0700
++++ b/CMake/InstallResources.cmake	2022-05-09 17:29:53.013345872 -0700
+@@ -44,6 +44,20 @@
+   set(OGRE_CFG_INSTALL_PATH "share/OGRE")
+ endif ()
+ 
++# ensure installation is relocatable
++if (IS_ABSOLUTE "${OGRE_MEDIA_DIR_REL}")
++  file(RELATIVE_PATH OGRE_MEDIA_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_CFG_INSTALL_PATH}" "${OGRE_MEDIA_DIR_REL}")
++endif ()
++if (IS_ABSOLUTE "${OGRE_TEST_MEDIA_DIR_REL}")
++  file(RELATIVE_PATH OGRE_TEST_MEDIA_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_CFG_INSTALL_PATH}" "${OGRE_TEST_MEDIA_DIR_REL}")
++endif ()
++if (IS_ABSOLUTE "${OGRE_PLUGIN_DIR_REL}")
++  file(RELATIVE_PATH OGRE_PLUGIN_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_CFG_INSTALL_PATH}" "${OGRE_PLUGIN_DIR_REL}")
++endif ()
++if (IS_ABSOLUTE "${OGRE_SAMPLES_DIR_REL}")
++  file(RELATIVE_PATH OGRE_SAMPLES_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_CFG_INSTALL_PATH}" "${OGRE_SAMPLES_DIR_REL}")
++endif ()
++
+ # generate OgreConfigPaths.h
+ configure_file(${OGRE_TEMPLATES_DIR}/OgreConfigPaths.h.in ${PROJECT_BINARY_DIR}/include/OgreConfigPaths.h @ONLY)
+ 

--- a/rviz_ogre_vendor/relocatable.patch
+++ b/rviz_ogre_vendor/relocatable.patch
@@ -1,9 +1,9 @@
 diff -uNr a/CMake/InstallResources.cmake b/CMake/InstallResources.cmake
 --- a/CMake/InstallResources.cmake	2022-05-09 17:30:13.273565553 -0700
 +++ b/CMake/InstallResources.cmake	2022-05-09 17:29:53.013345872 -0700
-@@ -44,6 +44,20 @@
-   set(OGRE_CFG_INSTALL_PATH "share/OGRE")
- endif ()
+@@ -59,6 +59,20 @@
+   endif()
+ endif()
  
 +# ensure installation is relocatable
 +if (IS_ABSOLUTE "${OGRE_MEDIA_DIR_REL}")
@@ -19,6 +19,6 @@ diff -uNr a/CMake/InstallResources.cmake b/CMake/InstallResources.cmake
 +  file(RELATIVE_PATH OGRE_SAMPLES_DIR_REL "${CMAKE_INSTALL_PREFIX}/${OGRE_CFG_INSTALL_PATH}" "${OGRE_SAMPLES_DIR_REL}")
 +endif ()
 +
- # generate OgreConfigPaths.h
- configure_file(${OGRE_TEMPLATES_DIR}/OgreConfigPaths.h.in ${PROJECT_BINARY_DIR}/include/OgreConfigPaths.h @ONLY)
- 
+ # configure plugins.cfg
+ if (NOT OGRE_BUILD_RENDERSYSTEM_D3D9)
+   set(OGRE_COMMENT_RENDERSYSTEM_D3D9 "#")


### PR DESCRIPTION
These resource files support relative paths from their directory, so we should override the default paths for UNIX and WIN32 to act like APPLE, where relative paths are used by default.

This should be a pretty safe thing to do because the absolute paths currently in these locations are actually to the staging in the project's build directory, which isn't available unless building from source.

Here is the official documentation which discusses relative path support for `resources.cfg` and `plugins.cfg`: https://ogrecave.github.io/ogre/api/1.12/setup.html

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=16674)](http://ci.ros2.org/job/ci_linux/16674/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11260)](http://ci.ros2.org/job/ci_linux-aarch64/11260/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=228)](http://ci.ros2.org/job/ci_linux-rhel/228/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17069)](http://ci.ros2.org/job/ci_windows/17069/)