### PR TITLE
fix issue #810

### DIFF
--- a/rviz_ogre_vendor/package.xml
+++ b/rviz_ogre_vendor/package.xml
@@ -23,8 +23,10 @@
   <build_depend>pkg-config</build_depend>
 
   <build_depend>libfreetype6-dev</build_depend>
+  <build_depend>libfreeimage-dev</build_depend>
   <build_export_depend>libfreetype6-dev</build_export_depend>
   <exec_depend>libfreetype6</exec_depend>
+  <exec_depend>libfreeimage</exec_depend>
 
   <depend>libx11-dev</depend>
   <depend>libxaw</depend>

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -234,6 +234,7 @@ RenderSystem::loadOgrePlugins()
   ogre_root_->loadPlugin(plugin_prefix + "RenderSystem_GL");
 #endif
   ogre_root_->loadPlugin(plugin_prefix + "Codec_STBI");
+  ogre_root_->loadPlugin(plugin_prefix + "Codec_FreeImage");
 // #if __APPLE__
 // #else
 // ogre_root_->loadPlugin(plugin_prefix + "RenderSystem_GL3Plus");


### PR DESCRIPTION
to solve the error
<pre>
[rviz2-3] [ERROR] [1652204061.476182910] [rviz2]: ItemIdentityException: Can not find codec for 'tif' image format.
[rviz2-3] Supported formats are: bmp dds gif hdr jpeg jpg ktx pgm pic pkm png ppm psd tga. in Codec::getCodec at /Users/xlla/ros2_foxy/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src/ogre-v1.12.1/OgreMain/src/OgreCodec.cpp (line 66)
</pre>