### PR TITLE
Use make_shared to construct PointCloud2

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_to_point_cloud2.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_to_point_cloud2.cpp
@@ -40,8 +40,7 @@ uint32_t size(size_t value)
 sensor_msgs::msg::PointCloud2::ConstSharedPtr rviz_default_plugins::convertPointCloudToPointCloud2(
   const sensor_msgs::msg::PointCloud::ConstSharedPtr input)
 {
-  sensor_msgs::msg::PointCloud2::SharedPtr output(
-    new sensor_msgs::msg::PointCloud2_<std::allocator<void>>());
+  auto output = std::make_shared<sensor_msgs::msg::PointCloud2>();
   output->header = input->header;
   output->width = size(input->points.size());
   output->height = 1;


### PR DESCRIPTION
This is just a trivial change to use `make_shared` instead of the `new` operator for constructing a PointCloud2.

I also dropped the `std::allocator<void>` here, since it is not needed.


Signed-off-by: Hunter L. Allen <hunter.allen@apex.ai>