### PR TITLE
Revert usage of tf listener node in favor of callback group

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/transformation/tf_wrapper.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/transformation/tf_wrapper.cpp
@@ -130,16 +130,8 @@ void TFWrapper::initialize(
   bool using_dedicated_thread)
 {
   initializeBuffer(clock, rviz_ros_node.lock()->get_raw_node(), using_dedicated_thread);
-  if (using_dedicated_thread) {
-    // TODO(pull/551): The TransformListener needs very quick spinning so it uses its own node
-    // here. Remove this in favor of a multithreaded spinner and ensure that the listener callback
-    // queue does not fill up.
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(
-      *buffer_, true);
-  } else {
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(
-      *buffer_, rviz_ros_node.lock()->get_raw_node(), false);
-  }
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(
+    *buffer_, rviz_ros_node.lock()->get_raw_node(), using_dedicated_thread);
 }
 
 void TFWrapper::initializeBuffer(


### PR DESCRIPTION
Reverts the changes from #551 as https://github.com/ros2/rclcpp/pull/1218 is now merged.

The parallelism and performance should be unaffected because tf uses a callback group which is spon by its own executor instance for the tf topics. See PR https://github.com/ros2/geometry2/pull/442 for the addition of this behavior.

This PR reduces the overhead from having more nodes. In addition to that, it also reduces the number of nodes in the rqt node graph and makes the subscriptions more visible, as the subscription can be directly associated with the parent node which is otherwise not the case (only something like tf_listener_xxxxx is shown, with no indication regarding the real node that creates the tf listener).