### PR TITLE
Add rviz1_to_rviz2.py conversion script

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -81,6 +81,7 @@ endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})
+install(PROGRAMS scripts/rviz1_to_rviz2.py DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rviz2/package.xml
+++ b/rviz2/package.xml
@@ -40,10 +40,12 @@
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>geometry_msgs</test_depend>
+  <test_depend>python3-yaml</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>sensor_msgs</test_depend>
 

--- a/rviz2/package.xml
+++ b/rviz2/package.xml
@@ -30,6 +30,9 @@
   <!-- this ensures some basic plugins are available when installing just rviz2 -->
   <exec_depend>rviz_default_plugins</exec_depend>
 
+  <!-- For RViz 1 to 2 conversion script -->
+  <exec_depend>python3</exec_depend>
+
   <depend>rviz_common</depend>
   <depend>rviz_ogre_vendor</depend>
 

--- a/rviz2/scripts/rviz1_to_rviz2.py
+++ b/rviz2/scripts/rviz1_to_rviz2.py
@@ -474,8 +474,11 @@ def parse_yaml_file(path):
 
 
 def write_yaml_file(output, yaml_dict):
-    with open(output, 'w') as fout:
-        yaml.dump(yaml_dict, stream=fout)
+    if '-' == output:
+        yaml.dump(yaml_dict, stream=sys.stdout)
+    else:
+        with open(output, 'w') as fout:
+            yaml.dump(yaml_dict, stream=fout)
 
 
 def main():

--- a/rviz2/scripts/rviz1_to_rviz2.py
+++ b/rviz2/scripts/rviz1_to_rviz2.py
@@ -339,8 +339,6 @@ def migrate_visualization_manager_tools(tools_list):
 
 
 def migrate_visualization_manager_views(view_dict):
-    if view_dict['Saved']:
-        print('Skipping migration of saved views', file=sys.stderr)
     rviz2 = {
             'Current': migrate_view(view_dict['Current']),
             'Saved': [],

--- a/rviz2/scripts/rviz1_to_rviz2.py
+++ b/rviz2/scripts/rviz1_to_rviz2.py
@@ -7,6 +7,11 @@ import warnings
 import yaml
 
 
+def del_maybe(dictionary, key):
+    if key in dictionary:
+        del dictionary[key]
+
+
 def migrate_panels(panels):
     panels_rviz2 = []
 
@@ -142,7 +147,7 @@ def auto_migrate_display(display_dict):
 
 def migrate_display_axes(display_dict):
     rviz2 = auto_migrate_display(display_dict)
-    del rviz2['Alpha']
+    del_maybe(rviz2, 'Alpha')
     return rviz2
 
 
@@ -157,7 +162,7 @@ def migrate_display_camera(display_dict):
     del rviz2['Queue Size']
     del rviz2['Unreliable']
     # TODO(sloretz) what is the ROS 2 equivalent to Transport Hint?
-    del rviz2['Transport Hint']
+    del_maybe(rviz2, 'Transport Hint')
     del rviz2['Topic']['Filter size']
     rviz2['Far Plane Distance'] = 100
     # Not sure all plugins that wil be migrated, so clear visibility
@@ -183,7 +188,7 @@ def migrate_display_image(display_dict):
     del rviz2['Queue Size']
     del rviz2['Unreliable']
     # TODO(sloretz) what is the ROS 2 equivalent to Transport Hint?
-    del rviz2['Transport Hint']
+    del_maybe(rviz2, 'Transport Hint')
     del rviz2['Topic']['Filter size']
     return rviz2
 
@@ -268,7 +273,7 @@ def migrate_display_robot_model(display_dict):
 
 def migrate_display_tf(display_dict):
     rviz2 = auto_migrate_display(display_dict)
-    del rviz2['Marker Alpha']
+    del_maybe(rviz2, 'Marker Alpha')
     return rviz2
 
 
@@ -282,7 +287,7 @@ def migrate_display_wrench_stamped(display_dict):
     del rviz2['Queue Size']
     del rviz2['Unreliable']
     rviz2['Accept NaN Values'] = False
-    del rviz2['Hide Small Values']
+    del_maybe(rviz2, 'Hide Small Values')
     return rviz2
 
 
@@ -302,11 +307,14 @@ def migrate_visualization_manager_tools(tools_list):
         elif name == 'rviz/SetInitialPose':
             rviz2 = {
                 'Class': 'rviz_default_plugins/SetInitialPose',
-                'Covariance x': float(tool_dict['X std deviation'])**2,
-                'Covariance y': float(tool_dict['Y std deviation'])**2,
-                'Covariance yaw': float(tool_dict['Theta std deviation'])**2,
                 'Topic': migrate_topic(name = tool_dict['Topic']),
                 }
+            if 'X std deviation' in tool_dict:
+                rviz2['Covariance x'] = float(tool_dict['X std deviation'])**2
+            if 'Y std deviation' in tool_dict:
+                rviz2['Covariance y'] = float(tool_dict['Y std deviation'])**2
+            if 'Theta std deviation' in tool_dict:
+                rviz2['Covariance yaw'] = float(tool_dict['Theta std deviation'])**2
             del rviz2['Topic']['Filter size']
             tools_rviz2.append(rviz2)
         elif name == 'rviz/SetGoal':
@@ -366,7 +374,7 @@ def migrate_view_orbit(view_dict):
     rviz2_view = copy.deepcopy(view_dict)
     rviz2_view['Class'] = 'rviz_default_plugins/Orbit'
     rviz2_view['Value'] = 'Orbit (rviz)'
-    del rviz2_view['Field of View']
+    del_maybe(rviz2_view, 'Field of View')
     return rviz2_view
 
 
@@ -374,7 +382,7 @@ def migrate_view_fps(view_dict):
     rviz2_view = copy.deepcopy(view_dict)
     rviz2_view['Class'] = 'rviz_default_plugins/FPS'
     rviz2_view['Value'] = 'FPS (rviz_default_plugins)'
-    del rviz2_view['Roll']
+    del_maybe(rviz2_view, 'Roll')
     return rviz2_view
 
 
@@ -382,7 +390,7 @@ def migrate_view_third_person_follower(view_dict):
     rviz2_view = copy.deepcopy(view_dict)
     rviz2_view['Class'] = 'rviz_default_plugins/ThirdPersonFollower'
     rviz2_view['Value'] = 'ThirdPersonFollower (rviz_default_plugins)'
-    del rviz2_view['Field of View']
+    del_maybe(rviz2_view, 'Field of View')
     return rviz2_view
 
 
@@ -397,7 +405,7 @@ def migrate_view_xy_orbit(view_dict):
     rviz2_view = copy.deepcopy(view_dict)
     rviz2_view['Class'] = 'rviz_default_plugins/XYOrbit'
     rviz2_view['Value'] = 'XYOrbit (rviz_default_plugins)'
-    del rviz2_view['Field of View']
+    del_maybe(rviz2_view, 'Field of View')
     return rviz2_view
 
 

--- a/rviz2/scripts/rviz1_to_rviz2.py
+++ b/rviz2/scripts/rviz1_to_rviz2.py
@@ -17,7 +17,7 @@ def migrate_panels(panels):
 
     for panel_dict in panels:
         if 'Class' not in panel_dict:
-            print('Uknown panel format, skipping:' + repr(panel_dict), file=sys.stderr)
+            print('Unknown panel format, skipping:' + repr(panel_dict), file=sys.stderr)
             continue
 
         if 'rviz/Displays' == panel_dict['Class']:
@@ -333,7 +333,7 @@ def migrate_visualization_manager_tools(tools_list):
             del rviz2['Topic']['Filter size']
             tools_rviz2.append(rviz2)
         else:
-            print(f"Uknown tool {tool_dict['Class']}, skipping", file=sys.stderr)
+            print(f"Unknown tool {tool_dict['Class']}, skipping", file=sys.stderr)
 
     return tools_rviz2
 

--- a/rviz2/scripts/rviz1_to_rviz2.py
+++ b/rviz2/scripts/rviz1_to_rviz2.py
@@ -30,6 +30,9 @@ def migrate_panels(panels):
             panels_rviz2.append(migrate_panel_views(panel_dict))
         elif 'rviz/Time' == panel_dict['Class']:
             panels_rviz2.append(migrate_panel_time(panel_dict))
+        else:
+            print('Unknown panel type, skipping:' + panel_dict['Class'], file=sys.stderr)
+
 
     return panels_rviz2
 

--- a/rviz2/scripts/rviz1_to_rviz2.py
+++ b/rviz2/scripts/rviz1_to_rviz2.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import sys
+import warnings
+import yaml
+
+
+def migrate_panels(panels):
+    panels_rviz2 = []
+
+    for panel_dict in panels:
+        if 'Class' not in panel_dict:
+            print('Uknown panel format, skipping:' + repr(panel_dict), file=sys.stderr)
+            continue
+
+        if 'rviz/Displays' == panel_dict['Class']:
+            panels_rviz2.append(migrate_panel_displays(panel_dict))
+        elif 'rviz/Selection' == panel_dict['Class']:
+            panels_rviz2.append(migrate_panel_selection(panel_dict))
+        elif 'rviz/Tool Properties' == panel_dict['Class']:
+            panels_rviz2.append(migrate_panel_tool_properties(panel_dict))
+        elif 'rviz/Views' == panel_dict['Class']:
+            panels_rviz2.append(migrate_panel_views(panel_dict))
+        elif 'rviz/Time' == panel_dict['Class']:
+            panels_rviz2.append(migrate_panel_time(panel_dict))
+
+    return panels_rviz2
+
+
+def migrate_panel_displays(panel_dict):
+    panel_rviz2 = copy.deepcopy(panel_dict)
+    panel_rviz2['Class'] = 'rviz_common/Displays'
+    # Not sure all display plugins will be present, so clear 'expanded'
+    panel_rviz2['Property Tree Widget']['Expanded'] = None
+    return panel_rviz2
+
+
+def migrate_panel_selection(panel_dict):
+    panel_rviz2 = copy.deepcopy(panel_dict)
+    panel_rviz2['Class'] = 'rviz_common/Selection'
+    return panel_rviz2
+
+
+def migrate_panel_tool_properties(panel_dict):
+    panel_rviz2 = copy.deepcopy(panel_dict)
+    panel_rviz2['Class'] = 'rviz_common/Tool Properties'
+    # Not sure all tools will be present, so clear 'expanded'
+    panel_rviz2['Expanded'] = None
+    return panel_rviz2
+
+
+def migrate_panel_views(panel_dict):
+    panel_rviz2 = copy.deepcopy(panel_dict)
+    panel_rviz2['Class'] = 'rviz_common/Views'
+    return panel_rviz2
+
+
+def migrate_panel_time(panel_dict):
+    panel_rviz2 = copy.deepcopy(panel_dict)
+    panel_rviz2['Class'] = 'rviz_common/Time'
+    return panel_rviz2
+
+
+def migrate_visualization_manager(vm_dict):
+    vm_rviz2 = {
+        'Class': str(vm_dict['Class']),
+        'Displays': migrate_displays(vm_dict['Displays']),
+        'Enabled': bool(vm_dict['Enabled']),
+        'Name': str(vm_dict['Name']),
+        'Tools': migrate_visualization_manager_tools(vm_dict['Tools']),
+        'Value': bool(vm_dict['Value']),
+        'Views': migrate_visualization_manager_views(vm_dict['Views']),
+        'Transformation': {'Current': {'Class': 'rviz_default_plugins/TF'}},
+        'Global Options': {
+            'Background Color': str(vm_dict['Global Options']['Background Color']),
+            'Fixed Frame': str(vm_dict['Global Options']['Fixed Frame']),
+            'Frame Rate': int(vm_dict['Global Options']['Frame Rate']),
+        }
+    }
+    return vm_rviz2
+
+
+def migrate_displays(displays_list):
+    migration_functions = {
+        'rviz/Grid': auto_migrate_display,
+        'rviz/Axes': migrate_display_axes,
+        'rviz/Camera': migrate_display_camera,
+        'rviz/FluidPressure': auto_migrate_display,
+        'rviz/GridCells': auto_migrate_display,
+        'rviz/Group': migrate_display_group,
+        'rviz/Illuminance': auto_migrate_display,
+        'rviz/Image': migrate_display_image,
+        'rviz/InteractiveMarkers': migrate_display_interactive_markers,
+        'rviz/LaserScan': migrate_display_laser_scan,
+        'rviz/Map': migrate_display_map,
+        'rviz/Marker': migrate_display_marker,
+        'rviz/MarkerArray': migrate_display_marker_array,
+        'rviz/Odometry': auto_migrate_display,
+        'rviz/Path': auto_migrate_display,
+        'rviz/PointCloud': migrate_display_point_cloud,
+        'rviz/PointCloud2': migrate_display_point_cloud2,
+        'rviz/PointStamped': auto_migrate_display,
+        'rviz/Polygon': auto_migrate_display,
+        'rviz/Pose': auto_migrate_display,
+        'rviz/PoseArray': auto_migrate_display,
+        'rviz/PoseWithCovariance': auto_migrate_display,
+        'rviz/Range': auto_migrate_display,
+        'rviz/RelativeHumidity': auto_migrate_display,
+        'rviz/RobotModel': migrate_display_robot_model,
+        'rviz/TF': migrate_display_tf,
+        'rviz/Temperature': auto_migrate_display,
+        'rviz/WrenchStamped': migrate_display_wrench_stamped,
+    }
+
+    displays_rviz2 = []
+    for display_dict in displays_list:
+        if display_dict['Class'] in migration_functions:
+            displays_rviz2.append(migration_functions[display_dict['Class']](display_dict))
+        else:
+            print(f"Cannot migrate display {display_dict['Class']} - skipping", file=sys.stderr)
+    return displays_rviz2 if displays_rviz2 else None
+
+
+def auto_migrate_display(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    assert display_dict['Class'].startswith('rviz/')
+    rviz2['Class'] = 'rviz_default_plugins' + display_dict['Class'][4:]
+    if 'Topic' in display_dict:
+        kwargs = {'name': display_dict['Topic']}
+        if 'Queue Size' in display_dict:
+            kwargs['depth'] = display_dict['Queue Size']
+            del rviz2['Queue Size']
+        if 'Unreliable' in display_dict:
+            kwargs['reliable'] = not display_dict['Unreliable']
+            del rviz2['Unreliable']
+
+        rviz2['Topic'] = migrate_topic(**kwargs)
+    return rviz2
+
+
+def migrate_display_axes(display_dict):
+    rviz2 = auto_migrate_display(display_dict)
+    del rviz2['Alpha']
+    return rviz2
+
+
+def migrate_display_camera(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/Camera'
+    rviz2['Topic'] = migrate_topic(
+        name=display_dict['Image Topic'],
+        depth=display_dict['Queue Size'],
+        reliable=not display_dict['Unreliable'])
+    del rviz2['Image Topic']
+    del rviz2['Queue Size']
+    del rviz2['Unreliable']
+    # TODO(sloretz) what is the ROS 2 equivalent to Transport Hint?
+    del rviz2['Transport Hint']
+    del rviz2['Topic']['Filter size']
+    rviz2['Far Plane Distance'] = 100
+    # Not sure all plugins that wil be migrated, so clear visibility
+    rviz2['Visibility'] = {}
+    return rviz2
+
+
+def migrate_display_group(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_common/Group'
+    rviz2['Displays'] = migrate_displays(display_dict['Displays'])
+    return rviz2
+
+
+def migrate_display_image(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/Image'
+    rviz2['Topic'] = migrate_topic(
+        name=display_dict['Image Topic'],
+        depth=display_dict['Queue Size'],
+        reliable=not display_dict['Unreliable'])
+    del rviz2['Image Topic']
+    del rviz2['Queue Size']
+    del rviz2['Unreliable']
+    # TODO(sloretz) what is the ROS 2 equivalent to Transport Hint?
+    del rviz2['Transport Hint']
+    del rviz2['Topic']['Filter size']
+    return rviz2
+
+
+def migrate_display_interactive_markers(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/InteractiveMarkers'
+    rviz2['Interactive Markers Namespace'] = display_dict['Update Topic']
+    del rviz2['Update Topic']
+    return rviz2
+
+
+def migrate_display_laser_scan(display_dict):
+    rviz2 = auto_migrate_display(display_dict)
+    rviz2['Max Intensity'] = 4096
+    rviz2['Min Intensity'] = 0
+    return rviz2
+
+
+def migrate_display_map(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/Map'
+    rviz2['Topic'] = migrate_topic(
+        name=display_dict['Topic'],
+        reliable=not display_dict['Unreliable'])
+    rviz2['Update Topic'] = migrate_topic(
+        name=display_dict['Topic'] + '_updates',
+        reliable=not display_dict['Unreliable'])
+    del rviz2['Update Topic']['Filter size']
+    del rviz2['Unreliable']
+    return rviz2
+
+
+def migrate_display_marker(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/Marker'
+    rviz2['Topic'] = migrate_topic(
+        name=display_dict['Marker Topic'],
+        depth=display_dict['Queue Size'])
+    del rviz2['Marker Topic']
+    del rviz2['Queue Size']
+    return rviz2
+
+
+def migrate_display_marker_array(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/MarkerArray'
+    rviz2['Topic'] = migrate_topic(
+        name=display_dict['Marker Topic'],
+        depth=display_dict['Queue Size'])
+    del rviz2['Marker Topic']
+    del rviz2['Queue Size']
+    del rviz2['Topic']['Filter size']
+    return rviz2
+
+
+def migrate_display_point_cloud(display_dict):
+    rviz2 = auto_migrate_display(display_dict)
+    rviz2['Max Intensity'] = 4096
+    rviz2['Min Intensity'] = 0
+    return rviz2
+
+
+def migrate_display_point_cloud2(display_dict):
+    rviz2 = auto_migrate_display(display_dict)
+    rviz2['Max Intensity'] = 4096
+    rviz2['Min Intensity'] = 0
+    return rviz2
+
+
+def migrate_display_robot_model(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/RobotModel'
+    del rviz2['Robot Description']
+    rviz2['Description File'] = ""
+    rviz2['Description Source'] = "Topic"
+    rviz2['Description Topic'] = migrate_topic(name="robot_description")
+    del rviz2['Description Topic']['Filter size']
+    rviz2['Mass Properties'] = {'Inertia': False, 'Mass': False}
+    return rviz2
+
+
+def migrate_display_tf(display_dict):
+    rviz2 = auto_migrate_display(display_dict)
+    del rviz2['Marker Alpha']
+    return rviz2
+
+
+def migrate_display_wrench_stamped(display_dict):
+    rviz2 = copy.deepcopy(display_dict)
+    rviz2['Class'] = 'rviz_default_plugins/Wrench'
+    rviz2['Topic'] = migrate_topic(
+        name=display_dict['Topic'],
+        depth=display_dict['Queue Size'],
+        reliable=not display_dict['Unreliable'])
+    del rviz2['Queue Size']
+    del rviz2['Unreliable']
+    rviz2['Accept NaN Values'] = False
+    del rviz2['Hide Small Values']
+    return rviz2
+
+
+def migrate_visualization_manager_tools(tools_list):
+    tools_rviz2 = []
+    for tool_dict in tools_list:
+        name = tool_dict['Class']
+        if name in ('rviz/Interact', 'rviz/MoveCamera', 'rviz/Select', 'rviz/FocusCamera'):
+           rviz2_dict = copy.deepcopy(tool_dict)
+           rviz2_dict['Class'] = 'rviz_default_plugins' + name[4:]
+           tools_rviz2.append(rviz2_dict)
+        elif name == 'rviz/Measure':
+            tools_rviz2.append({
+                'Class': 'rviz_default_plugins/Measure',
+                'Line color': '128; 128; 0'
+                })
+        elif name == 'rviz/SetInitialPose':
+            rviz2 = {
+                'Class': 'rviz_default_plugins/SetInitialPose',
+                'Covariance x': float(tool_dict['X std deviation'])**2,
+                'Covariance y': float(tool_dict['Y std deviation'])**2,
+                'Covariance yaw': float(tool_dict['Theta std deviation'])**2,
+                'Topic': migrate_topic(name = tool_dict['Topic']),
+                }
+            del rviz2['Topic']['Filter size']
+            tools_rviz2.append(rviz2)
+        elif name == 'rviz/SetGoal':
+            rviz2 = {
+                'Class': 'rviz_default_plugins/SetGoal',
+                'Topic': migrate_topic(name = tool_dict['Topic']),
+                }
+            del rviz2['Topic']['Filter size']
+            tools_rviz2.append(rviz2)
+        elif name == 'rviz/PublishPoint':
+            rviz2 = {
+                'Class': 'rviz_default_plugins/PublishPoint',
+                'Single click': bool(tool_dict['Single click']),
+                'Topic': migrate_topic(name = tool_dict['Topic']),
+                }
+            del rviz2['Topic']['Filter size']
+            tools_rviz2.append(rviz2)
+        else:
+            print(f"Uknown tool {tool_dict['Class']}, skipping", file=sys.stderr)
+
+    return tools_rviz2
+
+
+def migrate_visualization_manager_views(view_dict):
+    if view_dict['Saved']:
+        print('Skipping migration of saved views', file=sys.stderr)
+    rviz2 = {
+            'Current': migrate_view(view_dict['Current']),
+            'Saved': [],
+        }
+    if view_dict['Saved']:
+        for saved_view in view_dict['Saved']:
+            rviz2_view = migrate_view(saved_view)
+            if rviz2_view:
+                rviz2['Saved'].append(rviz2_view)
+    if not rviz2['Saved']:
+        rviz2['Saved'] = None
+    return rviz2
+
+
+def migrate_view(view_dict):
+    rviz2_view = {}
+    if 'rviz/Orbit' == view_dict['Class']:
+        return migrate_view_orbit(view_dict)
+    elif 'rviz/FPS' == view_dict['Class']:
+        return migrate_view_fps(view_dict)
+    elif 'rviz/ThirdPersonFollower' == view_dict['Class']:
+        return migrate_view_third_person_follower(view_dict)
+    elif 'rviz/TopDownOrtho' == view_dict['Class']:
+        return migrate_view_top_down_ortho(view_dict)
+    elif 'rviz/XYOrbit' == view_dict['Class']:
+        return migrate_view_xy_orbit(view_dict)
+    print(f"Unable to migrate view type {view_dict['Class']} - skipping", file=sys.stderr)
+
+
+def migrate_view_orbit(view_dict):
+    rviz2_view = copy.deepcopy(view_dict)
+    rviz2_view['Class'] = 'rviz_default_plugins/Orbit'
+    rviz2_view['Value'] = 'Orbit (rviz)'
+    del rviz2_view['Field of View']
+    return rviz2_view
+
+
+def migrate_view_fps(view_dict):
+    rviz2_view = copy.deepcopy(view_dict)
+    rviz2_view['Class'] = 'rviz_default_plugins/FPS'
+    rviz2_view['Value'] = 'FPS (rviz_default_plugins)'
+    del rviz2_view['Roll']
+    return rviz2_view
+
+
+def migrate_view_third_person_follower(view_dict):
+    rviz2_view = copy.deepcopy(view_dict)
+    rviz2_view['Class'] = 'rviz_default_plugins/ThirdPersonFollower'
+    rviz2_view['Value'] = 'ThirdPersonFollower (rviz_default_plugins)'
+    del rviz2_view['Field of View']
+    return rviz2_view
+
+
+def migrate_view_top_down_ortho(view_dict):
+    rviz2_view = copy.deepcopy(view_dict)
+    rviz2_view['Class'] = 'rviz_default_plugins/TopDownOrtho'
+    rviz2_view['Value'] = 'TopDownOrtho (rviz_default_plugins)'
+    return rviz2_view
+
+
+def migrate_view_xy_orbit(view_dict):
+    rviz2_view = copy.deepcopy(view_dict)
+    rviz2_view['Class'] = 'rviz_default_plugins/XYOrbit'
+    rviz2_view['Value'] = 'XYOrbit (rviz_default_plugins)'
+    del rviz2_view['Field of View']
+    return rviz2_view
+
+
+def migrate_topic(name, depth=5, reliable=False):
+    return {
+        'Depth': depth,
+        'Durability Policy': 'Volatile',
+        'Filter size': 10,
+        'History Policy': 'Keep Last',
+        'Reliability Policy': 'Reliable' if reliable else 'Best Effort',
+        'Value': str(name),
+    }
+
+
+def migrate_window_geometry(window_geometry):
+    # Return unmodified
+    return copy.deepcopy(window_geometry)
+
+
+def migrate_to_rviz2(rviz1_config):
+    """Given an RViz 1 config dictionary, return an RViz 2 config dictionary."""
+
+    rviz1_sections = {
+        'Panels',
+        'Preferences',
+        'Toolbars',
+        'Visualization Manager',
+        'Window Geometry'}
+
+    unknown_top_level = set(rviz1_config.keys()).difference(rviz1_sections)
+    if unknown_top_level:
+        print(
+            "I don't know how to convert these sections - skipping" + repr(
+                unknown_top_level), file=sys.stderr)
+
+    rviz2_config = {}
+
+    p_key = 'Panels'
+    assert p_key in rviz1_sections
+    rviz2_config[p_key] = migrate_panels(rviz1_config[p_key])
+
+    vm_key = 'Visualization Manager'
+    assert vm_key in rviz1_sections
+    rviz2_config[vm_key] = migrate_visualization_manager(rviz1_config[vm_key])
+
+    wg_key = 'Window Geometry'
+    assert wg_key in rviz1_sections
+    rviz2_config[wg_key] = migrate_window_geometry(rviz1_config[wg_key])
+
+    return rviz2_config
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Convert RViz 1 files to 2')
+    parser.add_argument('input', metavar='INPUT', help='Path to RViz 1 config')
+    parser.add_argument(
+        'output', metavar='OUTPUT', help='Path to write RViz 2 config')
+
+    return parser.parse_args()
+
+
+def parse_yaml_file(path):
+    with open(path, 'r') as fin:
+        return yaml.safe_load(fin)
+
+
+def write_yaml_file(output, yaml_dict):
+    with open(output, 'w') as fout:
+        yaml.dump(yaml_dict, stream=fout)
+
+
+def main():
+    args = parse_arguments()
+    rviz1_config = parse_yaml_file(args.input)
+    rviz2_config = migrate_to_rviz2(rviz1_config)
+    write_yaml_file(args.output, rviz2_config)
+
+
+if __name__ == '__main__':
+    main()

--- a/rviz2/test/tools/CMakeLists.txt
+++ b/rviz2/test/tools/CMakeLists.txt
@@ -4,3 +4,11 @@ find_package(sensor_msgs REQUIRED)
 
 add_executable(send_lots_of_points_node send_lots_of_points_node.cpp)
 ament_target_dependencies(send_lots_of_points_node rclcpp sensor_msgs geometry_msgs)
+
+get_filename_component(script_path "${PROJECT_SOURCE_DIR}/scripts/rviz1_to_rviz2.py" ABSOLUTE)
+get_filename_component(config_path "${CMAKE_CURRENT_SOURCE_DIR}/configs" ABSOLUTE BASE_DIR)
+ament_add_pytest_test(rviz1_to_2_check rviz1_to_2_check.py
+  ENV "_SCRIPT_PATH=${script_path}"
+  ENV "_CONFIG_PATH=${config_path}"
+  TIMEOUT 10
+)

--- a/rviz2/test/tools/configs/all_ros1.rviz
+++ b/rviz2/test/tools/configs/all_ros1.rviz
@@ -1,0 +1,853 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /DepthCloud1/Auto Size1
+        - /InteractiveMarkers1/Status1
+      Splitter Ratio: 0.5
+    Tree Height: 434
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Angular Arrow Scale: 2
+      Angular Color: 204; 204; 51
+      Arrow Width: 0.5
+      Class: rviz/AccelStamped
+      Enabled: true
+      Hide Small Values: true
+      History Length: 1
+      Linear Arrow Scale: 2
+      Linear Color: 204; 51; 51
+      Name: AccelStamped
+      Queue Size: 10
+      Topic: some/topic
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/Axes
+      Enabled: true
+      Length: 1
+      Name: Axes
+      Radius: 0.10000000149011612
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Camera
+      Enabled: true
+      Image Rendering: background and overlay
+      Image Topic: some/topic/camera
+      Name: Camera
+      Overlay Alpha: 0.5
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+      Visibility:
+        AccelStamped: true
+        Axes: true
+        DepthCloud: true
+        Effort: true
+        FluidPressure: true
+        Grid: true
+        GridCells: true
+        Group:
+          Axes: true
+          Value: true
+        Illuminance: true
+        Image: true
+        Imu: true
+        InteractiveMarkers: true
+        LaserScan: true
+        Map: true
+        Marker: true
+        MarkerArray: true
+        Odometry: true
+        Path: true
+        PointCloud: true
+        PointCloud2: true
+        PointStamped: true
+        Polygon: true
+        Pose: true
+        PoseArray: true
+        PoseWithCovariance: true
+        Range: true
+        RelativeHumidity: true
+        RobotModel: true
+        TF: true
+        Temperature: true
+        TwistStamped: true
+        Value: true
+        WrenchStamped: true
+      Zoom Factor: 1
+    - Alpha: 1
+      Auto Size:
+        Auto Size Factor: 1
+        Value: true
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/DepthCloud
+      Color: 255; 255; 255
+      Color Image Topic: some/topic/depth_color
+      Color Transformer: RGB8
+      Color Transport Hint: raw
+      Decay Time: 0
+      Depth Map Topic: some/topic/depth_map
+      Depth Map Transport Hint: raw
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: DepthCloud
+      Occlusion Compensation:
+        Occlusion Time-Out: 30
+        Value: false
+      Position Transformer: ""
+      Queue Size: 5
+      Selectable: true
+      Size (Pixels): 3
+      Style: Flat Squares
+      Topic Filter: true
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: rviz/Effort
+      Enabled: true
+      History Length: 1
+      Joints:
+        {}
+      Name: Effort
+      Queue Size: 10
+      Robot Description: robot_description
+      Scale: 1
+      TF Prefix: ""
+      Topic: some/topic/effort
+      Unreliable: false
+      Value: true
+      Width: 0.019999999552965164
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: fluid_pressure
+      Class: rviz/FluidPressure
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 105000
+      Min Color: 0; 0; 0
+      Min Intensity: 98000
+      Name: FluidPressure
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/fluid_pressure
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: rviz/GridCells
+      Color: 25; 255; 0
+      Enabled: true
+      Name: GridCells
+      Queue Size: 10
+      Topic: some/topic/grid_cells
+      Unreliable: false
+      Value: true
+    - Class: rviz/Group
+      Displays:
+        - Alpha: 1
+          Class: rviz/Axes
+          Enabled: true
+          Length: 1
+          Name: Axes
+          Radius: 0.10000000149011612
+          Reference Frame: <Fixed Frame>
+          Value: true
+      Enabled: true
+      Name: Group
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: illuminance
+      Class: rviz/Illuminance
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 1000
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Illuminance
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/illuminance
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: some/topic/image
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: true
+      Name: InteractiveMarkers
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: interactive_markers
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: LaserScan
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/laser_scan
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic: some/topic/map
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: visualization_marker
+      Name: Marker
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: visualization_marker_array
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 100
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: some/topic/odometry
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: some/topic/path
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: PointCloud
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/point_cloud
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: PointCloud2
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/point_cloud2
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: rviz/PointStamped
+      Color: 204; 41; 204
+      Enabled: true
+      History Length: 1
+      Name: PointStamped
+      Queue Size: 10
+      Radius: 0.20000000298023224
+      Topic: some/topic/point_stamped
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/Polygon
+      Color: 25; 255; 0
+      Enabled: true
+      Name: Polygon
+      Queue Size: 10
+      Topic: some/topic/polygon
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
+      Name: Pose
+      Queue Size: 10
+      Shaft Length: 1
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic: some/topic/pose
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Arrow Length: 0.30000001192092896
+      Axes Length: 0.30000001192092896
+      Axes Radius: 0.009999999776482582
+      Class: rviz/PoseArray
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.07000000029802322
+      Head Radius: 0.029999999329447746
+      Name: PoseArray
+      Queue Size: 10
+      Shaft Length: 0.23000000417232513
+      Shaft Radius: 0.009999999776482582
+      Shape: Arrow (Flat)
+      Topic: some/topic/pose_array
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz/PoseWithCovariance
+      Color: 255; 25; 0
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
+      Name: PoseWithCovariance
+      Queue Size: 10
+      Shaft Length: 1
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic: some/topic/pose_with_covariance
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Range
+      Queue Size: 10
+      Topic: some/topic/range
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: relative_humidity
+      Class: rviz/RelativeHumidity
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 1
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: RelativeHumidity
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/humidity
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: ""
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Alpha: 1
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: temperature
+      Class: rviz/Temperature
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: true
+      Max Color: 255; 255; 255
+      Max Intensity: 100
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Temperature
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/temperature
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Angular Arrow Scale: 2
+      Angular Color: 204; 204; 51
+      Arrow Width: 0.5
+      Class: rviz/TwistStamped
+      Enabled: true
+      Hide Small Values: true
+      History Length: 1
+      Linear Arrow Scale: 2
+      Linear Color: 204; 51; 51
+      Name: TwistStamped
+      Queue Size: 10
+      Topic: some/topic/twisted
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Arrow Width: 0.5
+      Class: rviz/WrenchStamped
+      Enabled: true
+      Force Arrow Scale: 2
+      Force Color: 204; 51; 51
+      Hide Small Values: true
+      History Length: 1
+      Name: WrenchStamped
+      Queue Size: 10
+      Topic: some/topic/wrench
+      Torque Arrow Scale: 2
+      Torque Color: 204; 204; 51
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz_plugin_tutorials/Imu
+      Color: 204; 51; 204
+      Enabled: true
+      History Length: 1
+      Name: Imu
+      Queue Size: 10
+      Topic: some/topic/imu
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: sentinel_frame
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/XYOrbit
+      Distance: 12.543999671936035
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.7853981852531433
+      Target Frame: <Fixed Frame>
+      Yaw: 0.7853981852531433
+    Saved:
+      - Class: rviz/FPS
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Name: FPS
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 2.356194496154785
+        Position:
+          X: 5.600001811981201
+          Y: 5.599999904632568
+          Z: 7.9195942878723145
+        Roll: 3.141592502593994
+        Target Frame: <Fixed Frame>
+        Yaw: 0.7853978276252747
+      - Class: rviz/FrameAligned
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Lock Camera: false
+        Name: FrameAligned
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 2.356194496154785
+        Point towards: arbitrary
+        Position:
+          X: 5.600001811981201
+          Y: 5.599999904632568
+          Z: 7.9195942878723145
+        Roll: 3.141592502593994
+        Target Frame: <Fixed Frame>
+        Yaw: 0.7853978276252747
+      - Class: rviz/Orbit
+        Distance: 11.199999809265137
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Field of View: 0.7853981852531433
+        Focal Point:
+          X: 4.76837158203125e-07
+          Y: 4.76837158203125e-07
+          Z: -9.5367431640625e-07
+        Focal Shape Fixed Size: true
+        Focal Shape Size: 0.05000000074505806
+        Invert Z Axis: false
+        Name: Orbit
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.7853980660438538
+        Target Frame: <Fixed Frame>
+        Yaw: 0.785398006439209
+      - Class: rviz/ThirdPersonFollower
+        Distance: 9.333332061767578
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Field of View: 0.7853981852531433
+        Focal Point:
+          X: 1.8666682243347168
+          Y: 1.8666672706604004
+          Z: 0
+        Focal Shape Fixed Size: true
+        Focal Shape Size: 0.05000000074505806
+        Invert Z Axis: false
+        Name: ThirdPersonFollower
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.7853980660438538
+        Target Frame: <Fixed Frame>
+        Yaw: 0.7853980660438538
+      - Angle: 0
+        Class: rviz/TopDownOrtho
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Name: TopDownOrtho
+        Near Clip Distance: 0.009999999776482582
+        Scale: 10
+        Target Frame: <Fixed Frame>
+        X: 5.600001335144043
+        Y: 5.599999904632568
+      - Class: rviz/XYOrbit
+        Distance: 10
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Field of View: 0.7853981852531433
+        Focal Point:
+          X: 0
+          Y: 0
+          Z: 0
+        Focal Shape Fixed Size: true
+        Focal Shape Size: 0.05000000074505806
+        Invert Z Axis: false
+        Name: XYOrbit
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.7853981852531433
+        Target Frame: <Fixed Frame>
+        Yaw: 0.7853981852531433
+Window Geometry:
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 1108
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000003b4fc020000000cfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003e0000023e000000ca00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006100000002eb000001070000000000000000fb0000000a0049006d00610067006500000002f0000001020000000000000000fb0000000c00430061006d00650072006101000002820000009e0000001600fffffffb0000000a0049006d0061006700650100000326000000cc0000001600ffffff000000010000010f000003b4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003e000003b4000000a600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006d30000003efc0100000002fb0000000800540069006d00650100000000000006d3000002b900fffffffb0000000800540069006d0065010000000000000450000000000000000000000462000003b400000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1747
+  X: 881
+  Y: 583

--- a/rviz2/test/tools/configs/all_supported_configs.rviz
+++ b/rviz2/test/tools/configs/all_supported_configs.rviz
@@ -1,0 +1,743 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /DepthCloud1/Auto Size1
+        - /InteractiveMarkers1/Status1
+      Splitter Ratio: 0.5
+    Tree Height: 434
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/Axes
+      Enabled: true
+      Length: 1
+      Name: Axes
+      Radius: 0.10000000149011612
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Camera
+      Enabled: true
+      Image Rendering: background and overlay
+      Image Topic: some/topic/camera
+      Name: Camera
+      Overlay Alpha: 0.5
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+      Visibility:
+        AccelStamped: true
+        Axes: true
+        DepthCloud: true
+        Effort: true
+        FluidPressure: true
+        Grid: true
+        GridCells: true
+        Group:
+          Axes: true
+          Value: true
+        Illuminance: true
+        Image: true
+        Imu: true
+        InteractiveMarkers: true
+        LaserScan: true
+        Map: true
+        Marker: true
+        MarkerArray: true
+        Odometry: true
+        Path: true
+        PointCloud: true
+        PointCloud2: true
+        PointStamped: true
+        Polygon: true
+        Pose: true
+        PoseArray: true
+        PoseWithCovariance: true
+        Range: true
+        RelativeHumidity: true
+        RobotModel: true
+        TF: true
+        Temperature: true
+        TwistStamped: true
+        Value: true
+        WrenchStamped: true
+      Zoom Factor: 1
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: fluid_pressure
+      Class: rviz/FluidPressure
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 105000
+      Min Color: 0; 0; 0
+      Min Intensity: 98000
+      Name: FluidPressure
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/fluid_pressure
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: rviz/GridCells
+      Color: 25; 255; 0
+      Enabled: true
+      Name: GridCells
+      Queue Size: 10
+      Topic: some/topic/grid_cells
+      Unreliable: false
+      Value: true
+    - Class: rviz/Group
+      Displays:
+        - Alpha: 1
+          Class: rviz/Axes
+          Enabled: true
+          Length: 1
+          Name: Axes
+          Radius: 0.10000000149011612
+          Reference Frame: <Fixed Frame>
+          Value: true
+      Enabled: true
+      Name: Group
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: illuminance
+      Class: rviz/Illuminance
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 1000
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Illuminance
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/illuminance
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: some/topic/image
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: true
+      Name: InteractiveMarkers
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: interactive_markers
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: LaserScan
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/laser_scan
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic: some/topic/map
+      Unreliable: false
+      Use Timestamp: false
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: visualization_marker
+      Name: Marker
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: visualization_marker_array
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Angle Tolerance: 0.10000000149011612
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Keep: 100
+      Name: Odometry
+      Position Tolerance: 0.10000000149011612
+      Queue Size: 10
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.10000000149011612
+        Color: 255; 25; 0
+        Head Length: 0.30000001192092896
+        Head Radius: 0.10000000149011612
+        Shaft Length: 1
+        Shaft Radius: 0.05000000074505806
+        Value: Arrow
+      Topic: some/topic/odometry
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Queue Size: 10
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: some/topic/path
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: PointCloud
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/point_cloud
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: PointCloud2
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/point_cloud2
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: rviz/PointStamped
+      Color: 204; 41; 204
+      Enabled: true
+      History Length: 1
+      Name: PointStamped
+      Queue Size: 10
+      Radius: 0.20000000298023224
+      Topic: some/topic/point_stamped
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/Polygon
+      Color: 25; 255; 0
+      Enabled: true
+      Name: Polygon
+      Queue Size: 10
+      Topic: some/topic/polygon
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
+      Name: Pose
+      Queue Size: 10
+      Shaft Length: 1
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic: some/topic/pose
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Arrow Length: 0.30000001192092896
+      Axes Length: 0.30000001192092896
+      Axes Radius: 0.009999999776482582
+      Class: rviz/PoseArray
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.07000000029802322
+      Head Radius: 0.029999999329447746
+      Name: PoseArray
+      Queue Size: 10
+      Shaft Length: 0.23000000417232513
+      Shaft Radius: 0.009999999776482582
+      Shape: Arrow (Flat)
+      Topic: some/topic/pose_array
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz/PoseWithCovariance
+      Color: 255; 25; 0
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.30000001192092896
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: true
+      Enabled: true
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
+      Name: PoseWithCovariance
+      Queue Size: 10
+      Shaft Length: 1
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic: some/topic/pose_with_covariance
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Range
+      Queue Size: 10
+      Topic: some/topic/range
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: relative_humidity
+      Class: rviz/RelativeHumidity
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 1
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: RelativeHumidity
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/humidity
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: ""
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Alpha: 1
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: temperature
+      Class: rviz/Temperature
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: true
+      Max Color: 255; 255; 255
+      Max Intensity: 100
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Temperature
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: some/topic/temperature
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Arrow Width: 0.5
+      Class: rviz/WrenchStamped
+      Enabled: true
+      Force Arrow Scale: 2
+      Force Color: 204; 51; 51
+      Hide Small Values: true
+      History Length: 1
+      Name: WrenchStamped
+      Queue Size: 10
+      Topic: some/topic/wrench
+      Torque Arrow Scale: 2
+      Torque Color: 204; 204; 51
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: sentinel_frame
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/XYOrbit
+      Distance: 12.543999671936035
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Field of View: 0.7853981852531433
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.7853981852531433
+      Target Frame: <Fixed Frame>
+      Yaw: 0.7853981852531433
+    Saved:
+      - Class: rviz/FPS
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Name: FPS
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 2.356194496154785
+        Position:
+          X: 5.600001811981201
+          Y: 5.599999904632568
+          Z: 7.9195942878723145
+        Roll: 3.141592502593994
+        Target Frame: <Fixed Frame>
+        Yaw: 0.7853978276252747
+      - Class: rviz/Orbit
+        Distance: 11.199999809265137
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Field of View: 0.7853981852531433
+        Focal Point:
+          X: 4.76837158203125e-07
+          Y: 4.76837158203125e-07
+          Z: -9.5367431640625e-07
+        Focal Shape Fixed Size: true
+        Focal Shape Size: 0.05000000074505806
+        Invert Z Axis: false
+        Name: Orbit
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.7853980660438538
+        Target Frame: <Fixed Frame>
+        Yaw: 0.785398006439209
+      - Class: rviz/ThirdPersonFollower
+        Distance: 9.333332061767578
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Field of View: 0.7853981852531433
+        Focal Point:
+          X: 1.8666682243347168
+          Y: 1.8666672706604004
+          Z: 0
+        Focal Shape Fixed Size: true
+        Focal Shape Size: 0.05000000074505806
+        Invert Z Axis: false
+        Name: ThirdPersonFollower
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.7853980660438538
+        Target Frame: <Fixed Frame>
+        Yaw: 0.7853980660438538
+      - Angle: 0
+        Class: rviz/TopDownOrtho
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Invert Z Axis: false
+        Name: TopDownOrtho
+        Near Clip Distance: 0.009999999776482582
+        Scale: 10
+        Target Frame: <Fixed Frame>
+        X: 5.600001335144043
+        Y: 5.599999904632568
+      - Class: rviz/XYOrbit
+        Distance: 10
+        Enable Stereo Rendering:
+          Stereo Eye Separation: 0.05999999865889549
+          Stereo Focal Distance: 1
+          Swap Stereo Eyes: false
+          Value: false
+        Field of View: 0.7853981852531433
+        Focal Point:
+          X: 0
+          Y: 0
+          Z: 0
+        Focal Shape Fixed Size: true
+        Focal Shape Size: 0.05000000074505806
+        Invert Z Axis: false
+        Name: XYOrbit
+        Near Clip Distance: 0.009999999776482582
+        Pitch: 0.7853981852531433
+        Target Frame: <Fixed Frame>
+        Yaw: 0.7853981852531433
+Window Geometry:
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 1108
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000003b4fc020000000cfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003e0000023e000000ca00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006100000002eb000001070000000000000000fb0000000a0049006d00610067006500000002f0000001020000000000000000fb0000000c00430061006d00650072006101000002820000009e0000001600fffffffb0000000a0049006d0061006700650100000326000000cc0000001600ffffff000000010000010f000003b4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003e000003b4000000a600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006d30000003efc0100000002fb0000000800540069006d00650100000000000006d3000002b900fffffffb0000000800540069006d0065010000000000000450000000000000000000000462000003b400000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1747
+  X: 881
+  Y: 583

--- a/rviz2/test/tools/rviz1_to_2_check.py
+++ b/rviz2/test/tools/rviz1_to_2_check.py
@@ -43,14 +43,16 @@ def test_convert_all_ros1():
 
     actual_stderr = result.stderr.decode()
     expected_stderr = (
-        "Cannot migrate display rviz/AccelStamped - skipping\n"
-        "Cannot migrate display rviz/DepthCloud - skipping\n"
-        "Cannot migrate display rviz/Effort - skipping\n"
-        "Cannot migrate display rviz/TwistStamped - skipping\n"
-        "Cannot migrate display rviz_plugin_tutorials/Imu - skipping\n"
-        "Unable to migrate view type rviz/FrameAligned - skipping\n")
+        "Cannot migrate display rviz/AccelStamped - skipping",
+        "Cannot migrate display rviz/DepthCloud - skipping",
+        "Cannot migrate display rviz/Effort - skipping",
+        "Cannot migrate display rviz/TwistStamped - skipping",
+        "Cannot migrate display rviz_plugin_tutorials/Imu - skipping",
+        "Unable to migrate view type rviz/FrameAligned - skipping")
 
-    assert expected_stderr == actual_stderr
+    for expected_line, line in zip(expected_stderr, actual_stderr.split('\n')):
+        # Strip line endings for Linux/Windows compatibility
+        assert expected_line.strip() == line.strip()
 
     yaml_output = yaml.safe_load(output)
     assert 'Panels' in yaml_output.keys()

--- a/rviz2/test/tools/rviz1_to_2_check.py
+++ b/rviz2/test/tools/rviz1_to_2_check.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+
+import yaml
+
+
+def script():
+    return os.environ['_SCRIPT_PATH']
+
+
+def config(name):
+    return os.path.join(os.environ['_CONFIG_PATH'], name)
+
+
+def test_convert_all_supported_configs():
+    result = subprocess.run(
+        [sys.executable, script(), config('all_supported_configs.rviz'), '-'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True)
+
+    output = result.stdout.decode()
+    assert len(output) > 0
+    assert len(result.stderr) == 0
+
+    yaml_output = yaml.load(output)
+    assert 'Panels' in yaml_output.keys()
+
+
+def test_convert_all_ros1():
+    result = subprocess.run(
+        [sys.executable, script(), config('all_ros1.rviz'), '-'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True)
+
+    output = result.stdout.decode()
+    assert len(output) > 0
+    assert len(result.stderr) != 0
+
+    actual_stderr = result.stderr.decode()
+    expected_stderr = (
+        "Cannot migrate display rviz/AccelStamped - skipping\n"
+        "Cannot migrate display rviz/DepthCloud - skipping\n"
+        "Cannot migrate display rviz/Effort - skipping\n"
+        "Cannot migrate display rviz/TwistStamped - skipping\n"
+        "Cannot migrate display rviz_plugin_tutorials/Imu - skipping\n"
+        "Unable to migrate view type rviz/FrameAligned - skipping\n")
+
+    assert expected_stderr == actual_stderr
+
+    yaml_output = yaml.load(output)
+    assert 'Panels' in yaml_output.keys()

--- a/rviz2/test/tools/rviz1_to_2_check.py
+++ b/rviz2/test/tools/rviz1_to_2_check.py
@@ -26,7 +26,7 @@ def test_convert_all_supported_configs():
     assert len(output) > 0
     assert len(result.stderr) == 0
 
-    yaml_output = yaml.load(output)
+    yaml_output = yaml.safe_load(output)
     assert 'Panels' in yaml_output.keys()
 
 
@@ -52,5 +52,5 @@ def test_convert_all_ros1():
 
     assert expected_stderr == actual_stderr
 
-    yaml_output = yaml.load(output)
+    yaml_output = yaml.safe_load(output)
     assert 'Panels' in yaml_output.keys()


### PR DESCRIPTION
The current way to port ROS 1 RViz files is to open RViz 1 and RViz 2 side by side and then manually add displays to RViz 2 to match. This PR adds a script that converts RViz 1 config files to RViz 2 files, skipping any displays or tools that it doesn't know about.

Example

Input: [all_displays_ros1.rviz.txt](https://github.com/ros2/rviz/files/9246321/all_displays_ros1.rviz.txt)

```console
$ ros2 run rviz2 rviz1_to_rviz2.py all_displays_ros1.rviz all_displays_ros2.rviz 
Cannot migrate display rviz/AccelStamped - skipping
Cannot migrate display rviz/DepthCloud - skipping
Cannot migrate display rviz/Effort - skipping
Cannot migrate display rviz/TwistStamped - skipping
Cannot migrate display rviz_plugin_tutorials/Imu - skipping
Unable to migrate view type rviz/FrameAligned - skipping
```

Output: [all_displays_ros2.rviz.txt](https://github.com/ros2/rviz/files/9246323/all_displays_ros2.rviz.txt)
