### PR TITLE
Document getTransform() time behavior

### DIFF
--- a/rviz_common/include/rviz_common/frame_manager_iface.hpp
+++ b/rviz_common/include/rviz_common/frame_manager_iface.hpp
@@ -130,7 +130,7 @@ public:
   rclcpp::Time
   getTime() = 0;
 
-  /// Return the pose for a header, relative to the fixed frame, in Ogre classes.
+  /// Return the pose for a header, relative to the fixed frame, in Ogre classes, at a given time.
   /**
    * \param[in] header The source of the frame name and time.
    * \param[out] position The position of the header frame relative to the
@@ -149,7 +149,8 @@ public:
     return getTransform(header.frame_id, header.stamp, position, orientation);
   }
 
-  /// Return the pose for a frame relative to the fixed frame, in Ogre classes, at a given time.
+  /// Return the pose for a frame relative to the fixed frame, in Ogre classes, at the most recent
+  /// time there is data for.
   /**
    * \param[in] frame The frame to find the pose of.
    * \param[out] position The position of the frame relative to the fixed frame.


### PR DESCRIPTION
This fixes the documentation on two `getTransform()` overloads to say at what time the transform data is looked up. When using a `Header` the time is looked up at the timestamp in the header message. When passing only a frame name the latest available transform data is used.