### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ament_cmake REQUIRED)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
 if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 macro(build_assimp)

--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -9,6 +9,11 @@ option(FORCE_BUILD_VENDOR_PKG
 
 find_package(ament_cmake REQUIRED)
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 macro(build_assimp)
   set(extra_cmake_args)
   if(DEFINED CMAKE_BUILD_TYPE)

--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -10,7 +10,7 @@ option(FORCE_BUILD_VENDOR_PKG
 find_package(ament_cmake REQUIRED)
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
-if (POLICY CMP0135)
+if(POLICY CMP0135)
   cmake_policy(SET CMP0135 OLD)
 endif()
 

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -6,6 +6,11 @@ find_package(ament_cmake REQUIRED)
 
 set(PACKAGE_VERSION "1.0.0")
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 if(WIN32)
   set(BUILDING_FREETYPE_LOCALLY ON)
   set(BUILDING_ZLIB_LOCALLY ON)

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -7,8 +7,8 @@ find_package(ament_cmake REQUIRED)
 set(PACKAGE_VERSION "1.0.0")
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
-if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

Reference build: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy in `CMakeLists.txt`

CI launch:
* Linux [![Build Status](https://ci.ros2.org/job/ci_linux/17254/badge/icon)](https://ci.ros2.org/job/ci_linux/17254/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11793)](http://ci.ros2.org/job/ci_linux-aarch64/11793/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17734)](http://ci.ros2.org/job/ci_windows/17734/)