### PR TITLE
Delete frame_locked_markers when reusing marker

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -294,6 +294,7 @@ MarkerBasePtr MarkerCommon::createOrGetOldMarker(
   if (it != markers_.end()) {
     marker = it->second;
     markers_with_expiration_.erase(marker);
+    frame_locked_markers_.erase(marker);
     if (message->type != marker->getMessage()->type) {
       markers_.erase(it);
       marker = createMarker(message);


### PR DESCRIPTION
Fixes #906

This makes sure to delete the marker from `frame_locked_markers_` when reusing an old marker.

If a existing Marker is frame locked, but a new marker uses the same ID and is not frame locked then the marker in `markers_` gets deleted, but the `frame_locked_markers_` entry was not. That was causing RViz to try to update markers that didn't exist.


Separately, keeping separate `std::set` for `markers_with_expiration_` and `frame_locked_markers_` seems like it's keeping state in two places. It might be worth refactoring this code in the future to iterate over `markers_` instead of trying to keep three containers in sync.

This PR is backportable