### PR TITLE
Pass CMAKE_PREFIX_PATH to Ogre and disable precompiled header to compile Ogre on macOS

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -120,6 +120,10 @@ macro(build_ogre)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   endif()
 
+  if(DEFINED CMAKE_PREFIX_PATH)
+    list(APPEND extra_cmake_args "-DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}")
+  endif()
+
   if(WIN32)
     set(OGRE_C_FLAGS "${OGRE_C_FLAGS} /w /EHsc")
     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} /w /EHsc")

--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -147,6 +147,11 @@ macro(build_ogre)
   # These next lines can be used to disable some of the components or plugins for OGRE
   list(APPEND extra_cmake_args "-DOGRE_CONFIG_ENABLE_ZIP:BOOL=ON")
 
+  # Need to disable precompiled header on macOS according to https://forums.ogre3d.org/viewtopic.php?t=95843
+  if(APPLE)
+    list(APPEND extra_cmake_args "-DOGRE_ENABLE_PRECOMPILED_HEADERS:BOOL=FALSE")
+  endif()
+
   if(BUILDING_FREETYPE_LOCALLY)
     list(APPEND extra_cmake_args
       "-DFREETYPE_HOME=${CMAKE_CURRENT_BINARY_DIR}/freetype_install")


### PR DESCRIPTION
Passing CMAKE_PREFIX_PATH (set by user via `colcon --cmake-args`) so Ogre can use locally built libraries.