### PR TITLE
use static QCoreApplication::processEvents() function without a QApplication instance

### DIFF
--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -251,9 +251,11 @@ void VisualizationFrame::initialize(
 
   loadPersistentSettings();
 
-  QDir app_icon_path(QString::fromStdString(package_path_) + "/icons/package.png");
-  QIcon app_icon(app_icon_path.absolutePath());
-  app_->setWindowIcon(app_icon);
+  if (app_) {
+    QDir app_icon_path(QString::fromStdString(package_path_) + "/icons/package.png");
+    QIcon app_icon(app_icon_path.absolutePath());
+    app_->setWindowIcon(app_icon);
+  }
 
   if (splash_path_ != "") {
     QPixmap splash_image(splash_path_);
@@ -265,10 +267,10 @@ void VisualizationFrame::initialize(
 
   // Periodically process events for the splash screen.
   // See: http://doc.qt.io/qt-5/qsplashscreen.html#details
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   QWidget * central_widget = new QWidget(this);
   QHBoxLayout * central_layout = new QHBoxLayout;
@@ -305,22 +307,22 @@ void VisualizationFrame::initialize(
   central_widget->setLayout(central_layout);
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   initMenus();
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   initToolbars();
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   setCentralWidget(central_widget);
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   // TODO(wjwwood): sort out the issue with initialization order between
   //                render_panel and VisualizationManager
@@ -332,12 +334,12 @@ void VisualizationFrame::initialize(
   panel_factory_ = new PanelFactory(rviz_ros_node_, manager_);
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   render_panel_->initialize(manager_);
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   ToolManager * tool_man = manager_->getToolManager();
 
@@ -350,7 +352,7 @@ void VisualizationFrame::initialize(
   manager_->initialize();
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   if (display_config_file != "") {
     loadDisplayConfig(display_config_file);
@@ -359,7 +361,7 @@ void VisualizationFrame::initialize(
   }
 
   // Periodically process events for the splash screen.
-  if (app_) {app_->processEvents();}
+  QCoreApplication::processEvents();
 
   delete splash_;
   splash_ = nullptr;

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -208,7 +208,7 @@ bool VisualizerApp::init(int argc, char ** argv)
 //  bool disable_anti_aliasing = false;
 //  bool disable_stereo = false;
 
-  if (app_) { parser.process(*app_); }
+  if (app_) {parser.process(*app_);}
 
   enable_ogre_log = parser.isSet(ogre_log_option);
 //    disable_stereo = parser.isSet(no_stereo_option);

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -208,7 +208,7 @@ bool VisualizerApp::init(int argc, char ** argv)
 //  bool disable_anti_aliasing = false;
 //  bool disable_stereo = false;
 
-  parser.process(*app_);
+  if (app_) { parser.process(*app_); }
 
   enable_ogre_log = parser.isSet(ogre_log_option);
 //    disable_stereo = parser.isSet(no_stereo_option);


### PR DESCRIPTION
This removes the need for the `setApp()` call.

As seen in the Qt [documentation](https://doc.qt.io/qt-5/qcoreapplication.html#processEvents) `processEvents` is a static function so no member of `QCoreApplication` is required. Removing this takes away the need for `setApp()` in `VisualizationFrame` and `VisualizerApp` which i have kept for now. I have encased the `setApplicationIcon()` call with an `if` to protect against unwanted segfaults (There is no need to crash, just because the application icon could not be set).

Why should the `VisualizationFrame` set the application-icon in the first place? 
This seems a bit of. What if i have an app with 2 frames? Maybe an app with many other things and its own application-icon dont want the icon overwritten? But i guess that is a discussion, that should be held elsewhere.

Removing this requirement of having a `QApplication*` help to ease integration rviz into other (possibly quite big) Qt-Applications.
