### PR TITLE
Fix tolerance calculation precision

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -64,8 +64,7 @@ void LaserScanDisplay::onInitialize()
 void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPtr scan)
 {
 //  Compute tolerance necessary for this scan
-  rclcpp::Duration tolerance(static_cast<int32_t>(static_cast<rcl_duration_value_t>(
-      scan->time_increment * scan->ranges.size())), 0);
+  rclcpp::Duration tolerance = rclcpp::Duration::from_seconds(static_cast<double>(scan->ranges.size() - 1) * static_cast<double>(scan->time_increment));
   if (tolerance > filter_tolerance_) {
     filter_tolerance_ = tolerance;
     tf_filter_->setTolerance(filter_tolerance_);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -64,7 +64,11 @@ void LaserScanDisplay::onInitialize()
 void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPtr scan)
 {
 //  Compute tolerance necessary for this scan
-  rclcpp::Duration tolerance = rclcpp::Duration::from_seconds(static_cast<double>(scan->ranges.size() - 1) * static_cast<double>(scan->time_increment));
+  rclcpp::Duration tolerance =
+    rclcpp::Duration::from_seconds(
+    static_cast<double>(scan->ranges.size() - 1) *
+    static_cast<double>(scan->time_increment));
+
   if (tolerance > filter_tolerance_) {
     filter_tolerance_ = tolerance;
     tf_filter_->setTolerance(filter_tolerance_);


### PR DESCRIPTION
Currently there is an open issue https://github.com/ros2/rviz/issues/852 that laser scan error flickers and warns about `extrapolation` errors. I've found myself hitting on this issue as well, so i tracked it down a bit and found probably the culprit.

According to https://github.com/ros-perception/laser_geometry/pull/83 fix (it has been merged despite the wrong icon) there is some precision lost due to the multiplication `float32` and `int64` leading to some other errors on their repo. 

So, i incorporated the same fix in `laser_scan_display.cpp` as well, and the flickering has gone for me as well and no more extrapolation errors.

`rclcpp::Duration::from_seconds(double)` was introduced from `eloquent` distro, so this fix should apply for all currently available distros.
 
Give it a try and pull it if it does indeed solve the issue! :) 