### PR TITLE
Fixed "pragma-patch.diff" on MacOS Ventura 13.1 / Xcode 14.2 (#925)

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -188,7 +188,7 @@ macro(build_ogre)
       ${extra_cmake_args}
       -Wno-dev
     PATCH_COMMAND
-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff &&
+      ${Patch_EXECUTABLE} -p1 -N -l < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff &&
       ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/fix-arm64.diff
     COMMAND
       ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.1-prefix/src/ogre-v1.12.1/CMake/Packages/FindFreetype.cmake

--- a/rviz_ogre_vendor/pragma-patch.diff
+++ b/rviz_ogre_vendor/pragma-patch.diff
@@ -1814,14 +1814,14 @@ diff --git a/PlugIns/OctreeZone/CMakeLists.txt b/PlugIns/OctreeZone/CMakeLists.t
 @@ -23,6 +23,11 @@ generate_export_header(Plugin_OctreeZone
      EXPORT_MACRO_NAME _OgreOctreeZonePluginExport
      EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreOctreeZonePrerequisites.h)
-
+ 
 +if (UNIX)
 +  set_property(TARGET Plugin_OctreeZone APPEND PROPERTY
 +    INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}/OGRE)
 +endif ()
 +
  ogre_config_framework(Plugin_OctreeZone)
-
+ 
  ogre_config_plugin(Plugin_OctreeZone)
 diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
 --- a/OgreMain/include/OgreTimer.h	2019-06-24 16:04:20.000000000 -0700


### PR DESCRIPTION
Work-around the problems that are most probably caused by the use of Windows new-line characters in the patch file.