### PR TITLE
fix: issue #918

### DIFF
--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -400,9 +400,6 @@ void Display::setAssociatedWidget(QWidget * widget)
     WindowManagerInterface * wm = context_->getWindowManager();
     if (wm) {
       associated_widget_panel_ = wm->addPane(getName(), associated_widget_);
-      connect(
-        associated_widget_panel_, SIGNAL(visibilityChanged(bool)), this,
-        SLOT(associatedPanelVisibilityChange(bool)));
       connect(associated_widget_panel_, SIGNAL(closed()), this, SLOT(disable()));
       associated_widget_panel_->setIcon(getIcon());
     } else {


### PR DESCRIPTION
Image and Camera plugins disable automatically on rviz2 window minimization. This behavior is really annoying in particular when you have the plugin nested into groups (each time you minimize the rviz window you need to traverse the tree and enable to plugin again).
In rviz (ROS1) this is not the case, correct me if I am wrong.

This pull request aims to solve this "undesired" behavior taking the cue from the solution proposed by @kudoukidd in #918.
With this change the plugin does not disable automatically on window minimization.