### PR TITLE
Make rviz1_to_rviz2.py accept configs with missing values

### DIFF
--- a/rviz2/scripts/rviz1_to_rviz2.py
+++ b/rviz2/scripts/rviz1_to_rviz2.py
@@ -73,18 +73,18 @@ def migrate_panel_time(panel_dict):
 
 def migrate_visualization_manager(vm_dict):
     vm_rviz2 = {
-        'Class': str(vm_dict['Class']),
+        'Class': str(vm_dict.get('Class', '')),
         'Displays': migrate_displays(vm_dict['Displays']),
-        'Enabled': bool(vm_dict['Enabled']),
-        'Name': str(vm_dict['Name']),
+        'Enabled': bool(vm_dict.get('Enabled', True)),
+        'Name': str(vm_dict.get('Name', 'root')),
         'Tools': migrate_visualization_manager_tools(vm_dict['Tools']),
-        'Value': bool(vm_dict['Value']),
+        'Value': bool(vm_dict.get('Value', True)),
         'Views': migrate_visualization_manager_views(vm_dict['Views']),
         'Transformation': {'Current': {'Class': 'rviz_default_plugins/TF'}},
         'Global Options': {
-            'Background Color': str(vm_dict['Global Options']['Background Color']),
-            'Fixed Frame': str(vm_dict['Global Options']['Fixed Frame']),
-            'Frame Rate': int(vm_dict['Global Options']['Frame Rate']),
+            'Background Color': str(vm_dict.get('Global Options', {}).get('Background Color', '48; 48; 48')),
+            'Fixed Frame': str(vm_dict.get('Global Options', {}).get('Fixed Frame', 'map')),
+            'Frame Rate': int(vm_dict.get('Global Options', {}).get('Frame Rate', 30)),
         }
     }
     return vm_rviz2
@@ -310,7 +310,7 @@ def migrate_visualization_manager_tools(tools_list):
         elif name == 'rviz/SetInitialPose':
             rviz2 = {
                 'Class': 'rviz_default_plugins/SetInitialPose',
-                'Topic': migrate_topic(name = tool_dict['Topic']),
+                'Topic': migrate_topic(name = tool_dict.get('Topic', '/initialpose')),
                 }
             if 'X std deviation' in tool_dict:
                 rviz2['Covariance x'] = float(tool_dict['X std deviation'])**2
@@ -323,15 +323,15 @@ def migrate_visualization_manager_tools(tools_list):
         elif name == 'rviz/SetGoal':
             rviz2 = {
                 'Class': 'rviz_default_plugins/SetGoal',
-                'Topic': migrate_topic(name = tool_dict['Topic']),
+                'Topic': migrate_topic(name = tool_dict.get('Topic', '/goal_pose')),
                 }
             del rviz2['Topic']['Filter size']
             tools_rviz2.append(rviz2)
         elif name == 'rviz/PublishPoint':
             rviz2 = {
                 'Class': 'rviz_default_plugins/PublishPoint',
-                'Single click': bool(tool_dict['Single click']),
-                'Topic': migrate_topic(name = tool_dict['Topic']),
+                'Single click': bool(tool_dict.get('Single click', True)),
+                'Topic': migrate_topic(name = tool_dict.get('Topic', '/clicked_point')),
                 }
             del rviz2['Topic']['Filter size']
             tools_rviz2.append(rviz2)

--- a/rviz2/test/tools/configs/fuse_simple_tutorial.rviz
+++ b/rviz2/test/tools/configs/fuse_simple_tutorial.rviz
@@ -1,0 +1,112 @@
+Panels:
+- Class: rviz/Displays
+  Name: Displays
+  Property Tree Widget:
+    Expanded:
+    - /Odometry1/Covariance1/Position1
+    - /Odometry1/Covariance1/Orientation1
+  Tree Height: 675
+- Class: rviz/Selection
+  Name: Selection
+- Class: rviz/Tool Properties
+  Expanded:
+  - /2D Pose Estimate1
+  - /2D Nav Goal1
+  - /Publish Point1
+  Name: Tool Properties
+- Class: rviz/Views
+  Expanded:
+  - /Current View1
+  Name: Views
+- Class: rviz/Time
+  Name: Time
+- Class: rviz/Displays
+  Help Height: 70
+  Name: Displays
+  Property Tree Widget:
+    Expanded: null
+  Tree Height: 371
+- Class: rviz/Views
+  Expanded:
+  - /Current View1
+  Name: Views
+Visualization Manager:
+  Displays:
+  - Alpha: 0.5
+    Cell Size: 1
+    Class: rviz/Grid
+    Color: 160; 160; 164
+    Enabled: true
+    Line Style:
+      Line Width: 0.029999999329447746
+      Value: Lines
+    Name: Grid
+    Normal Cell Count: 0
+    Offset:
+      X: 0
+      Y: 0
+      Z: 0
+    Plane: XY
+    Plane Cell Count: 100
+    Reference Frame: <Fixed Frame>
+    Value: true
+  - Angle Tolerance: 0.05000000074505806
+    Class: rviz/Odometry
+    Covariance:
+      Orientation:
+        Alpha: 0.20000000298023224
+        Color: 64; 84; 191
+        Color Style: Unique
+        Frame: Local
+        Offset: 1
+        Scale: 1
+        Value: true
+      Position:
+        Alpha: 0.10000000149011612
+        Color: 138; 226; 52
+        Scale: 1
+        Value: true
+      Value: false
+    Enabled: true
+    Keep: 10000
+    Name: Odometry
+    Position Tolerance: 0.10000000149011612
+    Queue Size: 10
+    Shape:
+      Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Color: 255; 25; 0
+      Head Length: 0.07500000298023224
+      Head Radius: 0.02500000037252903
+      Shaft Length: 0.25
+      Shaft Radius: 0.012500000186264515
+      Value: Arrow
+    Topic: /odom_filtered
+    Unreliable: false
+    Value: true
+  Global Options:
+    Fixed Frame: odom
+  Tools:
+  - Class: rviz/Interact
+  - Class: rviz/MoveCamera
+  - Class: rviz/Select
+  - Class: rviz/FocusCamera
+  - Class: rviz/Measure
+  - Class: rviz/SetInitialPose
+  - Class: rviz/SetGoal
+  - Class: rviz/PublishPoint
+  Views:
+    Current:
+      Angle: 0
+      Class: rviz/TopDownOrtho
+      Scale: 168.0491180419922
+      X: 2
+      Y: 0
+    Saved: null
+Window Geometry:
+  Height: 1201
+  QMainWindow State: 000000ff00000000fd00000003000000000000015600000413fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000032e000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000100044006900730070006c006100790073000000031c00000134000000c900fffffffb0000000a005600690065007700730100000371000000df000000a400ffffff000000010000010f00000413fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d00000413000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b2000000000000000000000003000007340000003efc0100000002fb0000000800540069006d0065010000000000000734000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004c30000041300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Width: 1844
+  X: 72
+  Y: 27

--- a/rviz2/test/tools/configs/range_sensor_tutorial.rviz
+++ b/rviz2/test/tools/configs/range_sensor_tutorial.rviz
@@ -1,0 +1,222 @@
+Panels:
+- Class: rviz/Displays
+  Help Height: 70
+  Name: Displays
+  Property Tree Widget:
+    Expanded:
+    - /True Robot Pose1/Shape1
+    - /Estimated Robot Pose1/Covariance1/Position1
+    Splitter Ratio: 0.6058823466300964
+  Tree Height: 757
+- Class: rviz/Selection
+  Name: Selection
+- Class: rviz/Tool Properties
+  Expanded:
+  - /2D Pose Estimate1
+  - /2D Nav Goal1
+  - /Publish Point1
+  Name: Tool Properties
+- Class: rviz/Views
+  Expanded:
+  - /Current View1
+  Name: Views
+- Class: rviz/Time
+  Name: Time
+  SyncSource: True Beacons
+Visualization Manager:
+  Displays:
+  - Alpha: 0.5
+    Cell Size: 1
+    Class: rviz/Grid
+    Color: 160; 160; 164
+    Enabled: false
+    Line Style:
+      Line Width: 0.029999999329447746
+      Value: Lines
+    Name: Grid
+    Normal Cell Count: 0
+    Offset:
+      X: 0
+      Y: 0
+      Z: 0
+    Plane: XY
+    Plane Cell Count: 100
+    Reference Frame: <Fixed Frame>
+    Value: false
+  - Alpha: 1
+    Autocompute Intensity Bounds: true
+    Autocompute Value Bounds:
+      Max Value: 10
+      Min Value: -10
+      Value: true
+    Axis: Z
+    Channel Name: intensity
+    Class: rviz/PointCloud2
+    Color: 255; 25; 0
+    Color Transformer: FlatColor
+    Decay Time: 0
+    Enabled: true
+    Invert Rainbow: false
+    Max Color: 239; 41; 41
+    Min Color: 0; 0; 0
+    Name: True Beacons
+    Position Transformer: XYZ
+    Queue Size: 10
+    Selectable: true
+    Size (Pixels): 3
+    Size (m): 1.5
+    Style: Spheres
+    Topic: /true_beacons
+    Unreliable: false
+    Use Fixed Frame: true
+    Use rainbow: true
+    Value: true
+  - Angle Tolerance: 0.10000000149011612
+    Class: rviz/Odometry
+    Covariance:
+      Orientation:
+        Alpha: 0.5
+        Color: 255; 255; 127
+        Color Style: Unique
+        Frame: Local
+        Offset: 1
+        Scale: 1
+        Value: true
+      Position:
+        Alpha: 0.30000001192092896
+        Color: 204; 51; 204
+        Scale: 1
+        Value: true
+      Value: false
+    Enabled: true
+    Keep: 1
+    Name: True Robot Pose
+    Position Tolerance: 0.10000000149011612
+    Queue Size: 10
+    Shape:
+      Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Color: 255; 25; 0
+      Head Length: 5
+      Head Radius: 3
+      Shaft Length: 8
+      Shaft Radius: 1
+      Value: Arrow
+    Topic: /ground_truth
+    Unreliable: false
+    Value: true
+  - Alpha: 1
+    Autocompute Intensity Bounds: true
+    Autocompute Value Bounds:
+      Max Value: 0
+      Min Value: 0
+      Value: true
+    Axis: Z
+    Channel Name: intensity
+    Class: rviz/PointCloud2
+    Color: 138; 226; 52
+    Color Transformer: FlatColor
+    Decay Time: 0
+    Enabled: false
+    Invert Rainbow: false
+    Max Color: 255; 255; 255
+    Min Color: 0; 0; 0
+    Name: Prior Beacons
+    Position Transformer: XYZ
+    Queue Size: 10
+    Selectable: true
+    Size (Pixels): 3
+    Size (m): 2
+    Style: Spheres
+    Topic: /prior_beacons
+    Unreliable: false
+    Use Fixed Frame: true
+    Use rainbow: true
+    Value: false
+  - Alpha: 1
+    Autocompute Intensity Bounds: true
+    Autocompute Value Bounds:
+      Max Value: 10
+      Min Value: -10
+      Value: true
+    Axis: Z
+    Channel Name: intensity
+    Class: rviz/PointCloud2
+    Color: 237; 212; 0
+    Color Transformer: FlatColor
+    Decay Time: 0
+    Enabled: true
+    Invert Rainbow: false
+    Max Color: 255; 255; 255
+    Min Color: 0; 0; 0
+    Name: Estimated Beacons
+    Position Transformer: XYZ
+    Queue Size: 10
+    Selectable: true
+    Size (Pixels): 3
+    Size (m): 2.5
+    Style: Spheres
+    Topic: /state_estimation/beacon_publisher/beacons
+    Unreliable: false
+    Use Fixed Frame: true
+    Use rainbow: true
+    Value: true
+  - Angle Tolerance: 0.10000000149011612
+    Class: rviz/Odometry
+    Covariance:
+      Orientation:
+        Alpha: 0.5
+        Color: 255; 255; 127
+        Color Style: Unique
+        Frame: Local
+        Offset: 1
+        Scale: 1
+        Value: true
+      Position:
+        Alpha: 0.5
+        Color: 237; 212; 0
+        Scale: 10
+        Value: true
+      Value: true
+    Enabled: true
+    Keep: 1
+    Name: Estimated Robot Pose
+    Position Tolerance: 0.10000000149011612
+    Queue Size: 10
+    Shape:
+      Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Color: 237; 212; 0
+      Head Length: 5
+      Head Radius: 5
+      Shaft Length: 8
+      Shaft Radius: 1.5
+      Value: Arrow
+    Topic: /odom_filtered
+    Unreliable: false
+    Value: true
+  Tools:
+  - Class: rviz/Interact
+  - Class: rviz/MoveCamera
+  - Class: rviz/Select
+  - Class: rviz/FocusCamera
+  - Class: rviz/Measure
+  - Class: rviz/SetInitialPose
+  - Class: rviz/SetGoal
+  - Class: rviz/PublishPoint
+  Views:
+    Current:
+      Angle: 0
+      Class: rviz/TopDownOrtho
+      Scale: 5.1059746742248535
+      X: 10.475910186767578
+      Y: -13.87234878540039
+    Saved: null
+Window Geometry:
+  Height: 1376
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000004befc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003f0000037b000000cc00fffffffb0000000a0056006900650077007301000003c00000013d000000a900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000004befc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005000000003efc0100000002fb0000000800540069006d00650100000000000005000000027500fffffffb0000000800540069006d00650100000000000004500000000000000000000003a4000004be00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Width: 1280
+  X: 1280
+  Y: 27

--- a/rviz2/test/tools/rviz1_to_2_check.py
+++ b/rviz2/test/tools/rviz1_to_2_check.py
@@ -30,6 +30,37 @@ def test_convert_all_supported_configs():
     assert 'Panels' in yaml_output.keys()
 
 
+def test_convert_fuse_simple_tutorial_config():
+    result = subprocess.run(
+        [sys.executable, script(), config('fuse_simple_tutorial.rviz'), '-'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True)
+
+    output = result.stdout.decode()
+    assert len(output) > 0
+    assert len(result.stderr) == 0
+
+    yaml_output = yaml.safe_load(output)
+    assert 'Background Color' in yaml_output['Visualization Manager']['Global Options'].keys()
+
+
+def test_convert_range_sensor_tutorial_config():
+    result = subprocess.run(
+        [sys.executable, script(), config('range_sensor_tutorial.rviz'), '-'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True)
+
+    output = result.stdout.decode()
+    assert len(output) > 0
+    assert len(result.stderr) == 0
+
+    yaml_output = yaml.safe_load(output)
+    assert 'Panels' in yaml_output.keys()
+    assert 'Background Color' in yaml_output['Visualization Manager']['Global Options'].keys()
+
+
 def test_convert_all_ros1():
     result = subprocess.run(
         [sys.executable, script(), config('all_ros1.rviz'), '-'],


### PR DESCRIPTION
In support of https://github.com/locusrobotics/fuse/pull/309

There were a couple RViz configs in the fuse repository that could not be converted using the conversion script because they were missing some values. This PR includes those two RViz configs as test cases, and makes the conversion tool more leinent about missing options by adding defaults for them.