### PR TITLE
points_marker: fix bug where points are never cleared

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
@@ -88,9 +88,9 @@ void PointsMarker::onNewMessage(
   setPosition(pose);
   setOrientation(orientation);
 
-  setRenderModeAndDimensions(new_message, scale);
+  points_->clearAndRemoveAllPoints();
 
-  points_->clear();
+  setRenderModeAndDimensions(new_message, scale);
 
   if (new_message->points.empty()) {
     return;


### PR DESCRIPTION
Hello,

this fixes a bug where a vector of points is never cleared. With each step more and more points are added. This fixes  #790 and maybe other issues with Marker in rviz. The example node in #790 works fine after this pull request.