### PR TITLE
Fix issue with high-frequency messages

### DIFF
--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -400,7 +400,7 @@ void VisualizationManager::onUpdate()
     resetTime();
   }
 
-  executor_->spin_some(std::chrono::milliseconds(10));
+  executor_->spin_all(std::chrono::milliseconds(10));
 
   Q_EMIT preUpdate();
 


### PR DESCRIPTION
This pull request fixes an issue with frequent messages. As far as I understand, `spin_some` only processes the oldest messages in the queue. So when a message for a particular subscriber arrives more frequently than the update rate of rviz, then the queue gets longer and longer. See ros2/rclcpp#1156 for comparison between `spin_some` and `spin_all`.

I am not sure whether `spin_all` introduces disadvantages in some cases compared to `spin_some`... 

Maybe @ivanpauno and @roger-strain have some opinions on this, as they proposed ros2/rclcpp#1156.