### PR TITLE
Fix ODR errors with gmock

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -371,15 +371,6 @@ if(BUILD_TESTING)
     rclcpp::rclcpp
     ${sensor_msgs_TARGETS})
 
-  # This code is used by many tests, so compile it just once
-  add_library(point_cloud_common_page_object
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp)
-  target_include_directories(point_cloud_common_page_object PUBLIC
-    test/page_objects
-    ${TEST_INCLUDE_DIRS})
-  target_link_libraries(point_cloud_common_page_object PUBLIC
-    rviz_visual_testing_framework::rviz_visual_testing_framework)
-
   ament_add_gmock(fps_view_controller_test
     test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
@@ -713,6 +704,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
     test/rviz_default_plugins/publishers/camera_info_publisher.hpp
     test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/image_publisher.hpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
@@ -720,26 +712,27 @@ if(BUILD_TESTING)
     TIMEOUT 180)
   if(TARGET camera_display_visual_test)
     target_include_directories(camera_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(camera_display_visual_test
-      point_cloud_common_page_object
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET fluid_pressure_display_visual_test)
     target_include_directories(fluid_pressure_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(fluid_pressure_display_visual_test
-      point_cloud_common_page_object
       pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
@@ -777,16 +770,17 @@ if(BUILD_TESTING)
 
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/illuminance_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET illuminance_display_visual_test)
     target_include_directories(illuminance_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(illuminance_display_visual_test
-      point_cloud_common_page_object
       pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
@@ -822,15 +816,16 @@ if(BUILD_TESTING)
 
   ament_add_gtest(laser_scan_display_visual_test
     test/rviz_default_plugins/displays/laser_scan/laser_scan_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET laser_scan_display_visual_test)
     target_include_directories(laser_scan_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(laser_scan_display_visual_test
-      point_cloud_common_page_object
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -936,32 +931,34 @@ if(BUILD_TESTING)
 
   ament_add_gtest(point_cloud_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud_display_visual_test)
     target_include_directories(point_cloud_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud_display_visual_test
-      point_cloud_common_page_object
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/point_cloud2_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud2_display_visual_test)
     target_include_directories(point_cloud2_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud2_display_visual_test
-      point_cloud_common_page_object
       pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
@@ -1033,16 +1030,17 @@ if(BUILD_TESTING)
 
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET relative_humidity_display_visual_test)
     target_include_directories(relative_humidity_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(relative_humidity_display_visual_test
-      point_cloud_common_page_object
       pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
@@ -1066,16 +1064,17 @@ if(BUILD_TESTING)
 
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/publishers/temperature_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET temperature_display_visual_test)
     target_include_directories(temperature_display_visual_test PUBLIC
+      test/page_objects
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(temperature_display_visual_test
-      point_cloud_common_page_object
       pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -701,6 +701,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(axes_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -720,6 +721,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(camera_display_visual_test
       point_cloud_common_page_object
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -737,6 +739,7 @@ if(BUILD_TESTING)
     target_link_libraries(fluid_pressure_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -752,6 +755,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(grid_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -767,6 +771,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(grid_cells_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -784,6 +789,7 @@ if(BUILD_TESTING)
     target_link_libraries(illuminance_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -800,6 +806,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(image_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -811,6 +818,7 @@ if(BUILD_TESTING)
     target_include_directories(interactive_marker_namespace_property_test PUBLIC
       ${TEST_INCLUDE_DIRS})
     target_link_libraries(interactive_marker_namespace_property_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES})
     ament_target_dependencies(interactive_marker_namespace_property_test
       ${TEST_TARGET_DEPENDENCIES})
@@ -827,6 +835,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(laser_scan_display_visual_test
       point_cloud_common_page_object
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -845,6 +854,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(map_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -862,6 +872,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(marker_array_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -878,6 +889,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(marker_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -894,6 +906,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(odometry_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -910,6 +923,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(path_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -926,6 +940,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -942,6 +957,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud_display_visual_test
       point_cloud_common_page_object
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -959,6 +975,7 @@ if(BUILD_TESTING)
     target_link_libraries(point_cloud2_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -976,6 +993,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(pose_array_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -992,6 +1010,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(pose_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1005,11 +1024,12 @@ if(BUILD_TESTING)
     TIMEOUT 180)
   if(TARGET pose_with_covariance_display_visual_test)
     target_include_directories(pose_with_covariance_display_visual_test PUBLIC
-            ${TEST_INCLUDE_DIRS}
-            ${rviz_visual_testing_framework_INCLUDE_DIRS})
+      ${TEST_INCLUDE_DIRS}
+      ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(pose_with_covariance_display_visual_test
-            ${TEST_LINK_LIBRARIES}
-            rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${GMOCK_LIBRARIES}
+      ${TEST_LINK_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
   ament_add_gtest(range_display_visual_test
@@ -1023,6 +1043,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(range_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1040,6 +1061,7 @@ if(BUILD_TESTING)
     target_link_libraries(relative_humidity_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1055,6 +1077,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(robot_model_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       ament_index_cpp::ament_index_cpp
       rviz_visual_testing_framework::rviz_visual_testing_framework)
@@ -1073,6 +1096,7 @@ if(BUILD_TESTING)
     target_link_libraries(temperature_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1088,6 +1112,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(tf_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1103,6 +1128,7 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(wrench_display_visual_test
+      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -348,7 +348,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/scene_graph_introspection.cpp
   )
   target_include_directories(display_test_fixture PRIVATE ${GMOCK_INCLUDE_DIRS} ${TEST_INCLUDE_DIRS})
-  target_link_libraries(display_test_fixture ${GMOCK_LIBRARIES})
   ament_target_dependencies(display_test_fixture ${TEST_TARGET_DEPENDENCIES} rviz_rendering rviz_common)
 
   set(TEST_LINK_LIBRARIES
@@ -1054,4 +1053,3 @@ endif()
 ament_package(
   CONFIG_EXTRAS "rviz_default_plugins-extras.cmake"
 )
-

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -325,6 +325,7 @@ if(BUILD_TESTING)
   # This is needed for the fixture sources down below...
   ament_find_gmock()
   set(TEST_INCLUDE_DIRS
+    test
     ${GMOCK_INCLUDE_DIRS}
     ${OGRE_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
@@ -362,14 +363,6 @@ if(BUILD_TESTING)
     rviz_default_plugins
     Qt5::Widgets
   )
-
-  # This code is used by many tests, so compile it just once
-  add_library(pointcloud_messages
-    test/rviz_default_plugins/pointcloud_messages.cpp)
-  target_include_directories(pointcloud_messages PUBLIC test)
-  target_link_libraries(pointcloud_messages PUBLIC
-    rclcpp::rclcpp
-    ${sensor_msgs_TARGETS})
 
   ament_add_gmock(fps_view_controller_test
     test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
@@ -533,25 +526,25 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud2_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
+    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud2_display_test)
     target_include_directories(point_cloud2_display_test PUBLIC ${TEST_INCLUDE_DIRS})
     target_link_libraries(point_cloud2_display_test
-      ${TEST_LINK_LIBRARIES}
-      pointcloud_messages)
+      ${TEST_LINK_LIBRARIES})
     ament_target_dependencies(point_cloud2_display_test ${TEST_TARGET_DEPENDENCIES})
   endif()
 
   ament_add_gmock(point_cloud_common_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
+    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_common_test)
     target_include_directories(point_cloud_common_test PUBLIC ${TEST_INCLUDE_DIRS})
     target_link_libraries(point_cloud_common_test
-      ${TEST_LINK_LIBRARIES}
-      pointcloud_messages)
+      ${TEST_LINK_LIBRARIES})
     ament_target_dependencies(point_cloud_common_test ${TEST_TARGET_DEPENDENCIES})
   endif()
 
@@ -566,6 +559,7 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(point_cloud_transformers_test
+    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
@@ -577,8 +571,7 @@ if(BUILD_TESTING)
   if(TARGET point_cloud_transformers_test)
     target_include_directories(point_cloud_transformers_test PUBLIC ${TEST_INCLUDE_DIRS})
     target_link_libraries(point_cloud_transformers_test
-      ${TEST_LINK_LIBRARIES}
-      pointcloud_messages)
+      ${TEST_LINK_LIBRARIES})
     ament_target_dependencies(point_cloud_transformers_test ${TEST_TARGET_DEPENDENCIES})
   endif()
 
@@ -723,6 +716,7 @@ if(BUILD_TESTING)
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
+    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
@@ -733,7 +727,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(fluid_pressure_display_visual_test
-      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -771,6 +764,7 @@ if(BUILD_TESTING)
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
+    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/illuminance_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
@@ -781,7 +775,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(illuminance_display_visual_test
-      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -949,6 +942,7 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
+    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/point_cloud2_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
@@ -959,7 +953,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud2_display_visual_test
-      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1031,6 +1024,7 @@ if(BUILD_TESTING)
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
+    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
@@ -1041,7 +1035,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(relative_humidity_display_visual_test
-      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1065,6 +1058,7 @@ if(BUILD_TESTING)
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
+    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/publishers/temperature_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
@@ -1075,7 +1069,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(temperature_display_visual_test
-      pointcloud_messages
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 # mocs_compilation.cpp file that takes a lot of memory to compile.  Instead
 # we create individual moc files that can be compiled separately.
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
@@ -322,7 +322,10 @@ if(BUILD_TESTING)
     DESTINATION "share/rviz_default_plugins"
     USE_SOURCE_PERMISSIONS)
 
+  # This is needed for the fixture sources down below...
+  ament_find_gmock()
   set(TEST_INCLUDE_DIRS
+    ${GMOCK_INCLUDE_DIRS}
     ${OGRE_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
   )
@@ -332,26 +335,26 @@ if(BUILD_TESTING)
     map_msgs
     nav_msgs
     rclcpp
+    rviz_common
+    rviz_rendering
     sensor_msgs
     urdf
     visualization_msgs
   )
 
-  # display_test_fixture.cpp is a piece of code that is used by every test.
-  # Instead of recompiling it for every test, just compile it once as a library
-  # and reuse it.  Note that we need to call ament_find_gmock() by hand here to
-  # find GMOCK_INCLUDE_DIRS and GMOCK_LIBRARIES so we can compile this file.
-  ament_find_gmock()
-  add_library(display_test_fixture
+  # We can't compile the fixtures into a library to be used by every test because that would require
+  # linking against gtest/gmock libraries, which would cause ODR violations down the line with
+  # ament_add_gmock.
+  #
+  # There are also issues even if we manage to defer the linking, because the fixture class inherits
+  # from gtest classes, which are not exported.
+  set(display_test_fixture_sources
     test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/ogre_testing_environment.cpp
     test/rviz_default_plugins/scene_graph_introspection.cpp
   )
-  target_include_directories(display_test_fixture PRIVATE ${GMOCK_INCLUDE_DIRS} ${TEST_INCLUDE_DIRS})
-  ament_target_dependencies(display_test_fixture ${TEST_TARGET_DEPENDENCIES} rviz_rendering rviz_common)
 
   set(TEST_LINK_LIBRARIES
-    display_test_fixture
     rviz_default_plugins
     Qt5::Widgets
   )
@@ -376,6 +379,7 @@ if(BUILD_TESTING)
   ament_add_gmock(fps_view_controller_test
     test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET fps_view_controller_test)
     target_include_directories(fps_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -385,6 +389,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(frame_info_test
     test/rviz_default_plugins/displays/tf/frame_info_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_info_test)
     target_include_directories(frame_info_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -393,7 +398,8 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(get_transport_from_topic_test
-    test/rviz_default_plugins/displays/image/get_transport_from_topic_test.cpp)
+    test/rviz_default_plugins/displays/image/get_transport_from_topic_test.cpp
+    ${display_test_fixture_sources})
   if(TARGET get_transport_from_topic_test)
     target_include_directories(get_transport_from_topic_test PUBLIC ${TEST_INCLUDE_DIRS} ${rviz_common_INCLUDE_DIRS})
     target_link_libraries(get_transport_from_topic_test ${TEST_LINK_LIBRARIES} ${rviz_common})
@@ -401,6 +407,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(grid_cells_display_test
     test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET grid_cells_display_test)
     target_include_directories(grid_cells_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -410,6 +417,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(image_display_test
     test/rviz_default_plugins/displays/image/image_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET image_display_test)
     target_include_directories(image_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -427,6 +435,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker/markers/triangle_list_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
     test/rviz_default_plugins/displays/marker/marker_messages.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_test)
     target_include_directories(marker_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -437,6 +446,7 @@ if(BUILD_TESTING)
   ament_add_gmock(marker_common_test
     test/rviz_default_plugins/displays/marker/marker_common_test.cpp
     test/rviz_default_plugins/displays/marker/marker_messages.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_common_test)
     target_include_directories(marker_common_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -445,6 +455,7 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(map_display_test
+    ${display_test_fixture_sources}
     test/rviz_default_plugins/displays/map/map_display_test.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET map_display_test)
@@ -455,6 +466,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(measure_tool_test
     test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET measure_tool_test)
     target_include_directories(measure_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -464,6 +476,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(odometry_display_test
     test/rviz_default_plugins/displays/odometry/odometry_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_display_test)
     target_include_directories(odometry_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -473,6 +486,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(odometry_ogre_helper_test
     test/rviz_default_plugins/displays/odometry/quaternion_helper_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_ogre_helper_test)
     target_include_directories(odometry_ogre_helper_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -483,6 +497,7 @@ if(BUILD_TESTING)
   ament_add_gmock(orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET orbit_view_controller_test)
     target_include_directories(orbit_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -493,6 +508,7 @@ if(BUILD_TESTING)
   ament_add_gmock(ortho_view_controller_test
     test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ortho_view_controller_test)
     target_include_directories(ortho_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -502,6 +518,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(palette_builder_test
     test/rviz_default_plugins/displays/map/palette_builder_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET palette_builder_test)
     target_include_directories(palette_builder_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -511,6 +528,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(path_display_test
     test/rviz_default_plugins/displays/path/path_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET path_display_test)
     target_include_directories(path_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -520,6 +538,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud2_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud2_display_test)
     target_include_directories(point_cloud2_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -531,6 +550,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud_common_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_common_test)
     target_include_directories(point_cloud_common_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -542,6 +562,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud_scalar_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_scalar_display_test)
     target_include_directories(point_cloud_scalar_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -556,6 +577,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgb8_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgbf32_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/xyz_pc_transformer_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_transformers_test)
     target_include_directories(point_cloud_transformers_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -567,6 +589,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_display_test
     test/rviz_default_plugins/displays/point/point_stamped_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_display_test)
     target_include_directories(point_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -576,6 +599,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(pose_array_display_test
     test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_array_display_test)
     target_include_directories(pose_array_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -585,6 +609,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(pose_tool_test
     test/rviz_default_plugins/tools/pose/pose_tool_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_tool_test)
     target_include_directories(pose_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -594,6 +619,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(range_display_test
     test/rviz_default_plugins/displays/range/range_display_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET range_display_test)
     target_include_directories(range_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -603,6 +629,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(robot_test
     test/rviz_default_plugins/robot/robot_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET robot_test)
     target_include_directories(robot_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -614,6 +641,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(ros_image_texture_test
     test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ros_image_texture_test)
     target_include_directories(ros_image_texture_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -623,6 +651,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(selection_tool_test
     test/rviz_default_plugins/tools/select/selection_tool_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET selection_tool_test)
     target_include_directories(selection_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -633,6 +662,7 @@ if(BUILD_TESTING)
   ament_add_gmock(xy_orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET xy_orbit_view_controller_test)
     target_include_directories(xy_orbit_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -642,6 +672,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(frame_transformer_tf_test
     test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_transformer_tf_test)
     target_include_directories(frame_transformer_tf_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -651,6 +682,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(transformer_guard_test
     test/rviz_default_plugins/transformation/transformer_guard_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET transformer_guard_test)
     target_include_directories(transformer_guard_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -661,6 +693,7 @@ if(BUILD_TESTING)
   ament_add_gtest(axes_display_visual_test
     test/rviz_default_plugins/displays/axes/axes_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/axes_display_page_object.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET axes_display_visual_test)
@@ -678,6 +711,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
     test/rviz_default_plugins/publishers/image_publisher.hpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET camera_display_visual_test)
@@ -693,6 +727,7 @@ if(BUILD_TESTING)
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
     test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET fluid_pressure_display_visual_test)
@@ -709,6 +744,7 @@ if(BUILD_TESTING)
   ament_add_gtest(grid_display_visual_test
     test/rviz_default_plugins/displays/grid/grid_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/grid_display_page_object.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_display_visual_test)
@@ -723,6 +759,7 @@ if(BUILD_TESTING)
   ament_add_gtest(grid_cells_display_visual_test
     test/rviz_default_plugins/displays/grid_cells/grid_cells_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/grid_cells_display_page_object.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_cells_display_visual_test)
@@ -737,6 +774,7 @@ if(BUILD_TESTING)
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
     test/rviz_default_plugins/publishers/illuminance_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET illuminance_display_visual_test)
@@ -754,6 +792,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/image/image_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/image_display_page_object.cpp
     test/rviz_default_plugins/publishers/image_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET image_display_visual_test)
@@ -766,7 +805,8 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gtest(interactive_marker_namespace_property_test
-    test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp)
+    test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp
+    ${display_test_fixture_sources})
   if(TARGET interactive_marker_namespace_property_test)
     target_include_directories(interactive_marker_namespace_property_test PUBLIC
       ${TEST_INCLUDE_DIRS})
@@ -778,6 +818,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(laser_scan_display_visual_test
     test/rviz_default_plugins/displays/laser_scan/laser_scan_display_visual_test.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET laser_scan_display_visual_test)
@@ -796,6 +837,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     test/rviz_default_plugins/publishers/map_publisher.hpp
     test/rviz_default_plugins/publishers/single_marker_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET map_display_visual_test)
@@ -812,6 +854,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/marker_array_display_page_object.cpp
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     test/rviz_default_plugins/publishers/marker_array_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_array_display_visual_test)
@@ -827,6 +870,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker/marker_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     test/rviz_default_plugins/publishers/marker_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_display_visual_test)
@@ -842,6 +886,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/odometry/odometry_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/odometry_display_page_object.cpp
     test/rviz_default_plugins/publishers/odometry_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET odometry_display_visual_test)
@@ -857,6 +902,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/path/path_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/path_display_page_object.cpp
     test/rviz_default_plugins/publishers/path_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET path_display_visual_test)
@@ -872,6 +918,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/point/point_stamped_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_display_page_object.cpp
     test/rviz_default_plugins/publishers/point_stamped_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_display_visual_test)
@@ -886,6 +933,7 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_display_visual_test.cpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud_display_visual_test)
@@ -901,6 +949,7 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
     test/rviz_default_plugins/publishers/point_cloud2_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud2_display_visual_test)
@@ -919,6 +968,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/pose_array_display_page_object.cpp
     test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
     test/rviz_default_plugins/publishers/pose_array_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_array_display_visual_test)
@@ -934,6 +984,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/pose/pose_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
     test/rviz_default_plugins/publishers/pose_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_display_visual_test)
@@ -946,11 +997,12 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gtest(pose_with_covariance_display_visual_test
-          test/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display_visual_test.cpp
-          test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.cpp
-          test/rviz_default_plugins/publishers/pose_with_covariance_publisher.hpp
-          ${SKIP_VISUAL_TESTS}
-          TIMEOUT 180)
+    test/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display_visual_test.cpp
+    test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.cpp
+    test/rviz_default_plugins/publishers/pose_with_covariance_publisher.hpp
+    ${display_test_fixture_sources}
+    ${SKIP_VISUAL_TESTS}
+    TIMEOUT 180)
   if(TARGET pose_with_covariance_display_visual_test)
     target_include_directories(pose_with_covariance_display_visual_test PUBLIC
             ${TEST_INCLUDE_DIRS}
@@ -963,6 +1015,7 @@ if(BUILD_TESTING)
   ament_add_gtest(range_display_visual_test
     test/rviz_default_plugins/displays/range/range_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/range_display_page_object.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET range_display_visual_test)
@@ -977,6 +1030,7 @@ if(BUILD_TESTING)
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
     test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET relative_humidity_display_visual_test)
@@ -993,6 +1047,7 @@ if(BUILD_TESTING)
   ament_add_gtest(robot_model_display_visual_test
     test/rviz_default_plugins/displays/robot_model/robot_model_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/robot_model_display_page_object.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET robot_model_display_visual_test)
@@ -1008,6 +1063,7 @@ if(BUILD_TESTING)
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
     test/rviz_default_plugins/publishers/temperature_publisher.hpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET temperature_display_visual_test)
@@ -1024,6 +1080,7 @@ if(BUILD_TESTING)
   ament_add_gtest(tf_display_visual_test
     test/rviz_default_plugins/displays/tf/tf_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/tf_display_page_object.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET tf_display_visual_test)
@@ -1038,6 +1095,7 @@ if(BUILD_TESTING)
   ament_add_gtest(wrench_display_visual_test
     test/rviz_default_plugins/displays/wrench/wrench_stamped_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/wrench_display_page_object.cpp
+    ${display_test_fixture_sources}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET wrench_display_visual_test)

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -348,10 +348,14 @@ if(BUILD_TESTING)
   #
   # There are also issues even if we manage to defer the linking, because the fixture class inherits
   # from gtest classes, which are not exported.
-  set(display_test_fixture_sources
-    test/rviz_default_plugins/displays/display_test_fixture.cpp
+  set(TEST_FIXTURE_SOURCES
     test/rviz_default_plugins/ogre_testing_environment.cpp
+  )
+
+  set(TEST_FIXTURE_SOURCES_WITH_MOCK
+    test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection.cpp
+    ${TEST_FIXTURE_SOURCES}
   )
 
   set(TEST_LINK_LIBRARIES
@@ -379,7 +383,7 @@ if(BUILD_TESTING)
   ament_add_gmock(fps_view_controller_test
     test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET fps_view_controller_test)
     target_include_directories(fps_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -389,7 +393,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(frame_info_test
     test/rviz_default_plugins/displays/tf/frame_info_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_info_test)
     target_include_directories(frame_info_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -399,7 +403,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(get_transport_from_topic_test
     test/rviz_default_plugins/displays/image/get_transport_from_topic_test.cpp
-    ${display_test_fixture_sources})
+  ${TEST_FIXTURE_SOURCES_WITH_MOCK})
   if(TARGET get_transport_from_topic_test)
     target_include_directories(get_transport_from_topic_test PUBLIC ${TEST_INCLUDE_DIRS} ${rviz_common_INCLUDE_DIRS})
     target_link_libraries(get_transport_from_topic_test ${TEST_LINK_LIBRARIES} ${rviz_common})
@@ -407,7 +411,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(grid_cells_display_test
     test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET grid_cells_display_test)
     target_include_directories(grid_cells_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -417,7 +421,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(image_display_test
     test/rviz_default_plugins/displays/image/image_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET image_display_test)
     target_include_directories(image_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -435,7 +439,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker/markers/triangle_list_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
     test/rviz_default_plugins/displays/marker/marker_messages.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_test)
     target_include_directories(marker_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -446,7 +450,7 @@ if(BUILD_TESTING)
   ament_add_gmock(marker_common_test
     test/rviz_default_plugins/displays/marker/marker_common_test.cpp
     test/rviz_default_plugins/displays/marker/marker_messages.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_common_test)
     target_include_directories(marker_common_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -455,7 +459,7 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(map_display_test
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     test/rviz_default_plugins/displays/map/map_display_test.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET map_display_test)
@@ -466,7 +470,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(measure_tool_test
     test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET measure_tool_test)
     target_include_directories(measure_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -476,7 +480,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(odometry_display_test
     test/rviz_default_plugins/displays/odometry/odometry_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_display_test)
     target_include_directories(odometry_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -486,7 +490,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(odometry_ogre_helper_test
     test/rviz_default_plugins/displays/odometry/quaternion_helper_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_ogre_helper_test)
     target_include_directories(odometry_ogre_helper_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -497,7 +501,7 @@ if(BUILD_TESTING)
   ament_add_gmock(orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET orbit_view_controller_test)
     target_include_directories(orbit_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -508,7 +512,7 @@ if(BUILD_TESTING)
   ament_add_gmock(ortho_view_controller_test
     test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ortho_view_controller_test)
     target_include_directories(ortho_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -518,7 +522,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(palette_builder_test
     test/rviz_default_plugins/displays/map/palette_builder_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET palette_builder_test)
     target_include_directories(palette_builder_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -528,7 +532,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(path_display_test
     test/rviz_default_plugins/displays/path/path_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET path_display_test)
     target_include_directories(path_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -538,7 +542,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud2_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud2_display_test)
     target_include_directories(point_cloud2_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -550,7 +554,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud_common_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_common_test)
     target_include_directories(point_cloud_common_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -562,7 +566,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_cloud_scalar_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_scalar_display_test)
     target_include_directories(point_cloud_scalar_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -577,7 +581,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgb8_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgbf32_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/xyz_pc_transformer_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_transformers_test)
     target_include_directories(point_cloud_transformers_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -589,7 +593,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(point_display_test
     test/rviz_default_plugins/displays/point/point_stamped_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_display_test)
     target_include_directories(point_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -599,7 +603,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(pose_array_display_test
     test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_array_display_test)
     target_include_directories(pose_array_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -609,7 +613,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(pose_tool_test
     test/rviz_default_plugins/tools/pose/pose_tool_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_tool_test)
     target_include_directories(pose_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -619,7 +623,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(range_display_test
     test/rviz_default_plugins/displays/range/range_display_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET range_display_test)
     target_include_directories(range_display_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -629,7 +633,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(robot_test
     test/rviz_default_plugins/robot/robot_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET robot_test)
     target_include_directories(robot_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -641,7 +645,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(ros_image_texture_test
     test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ros_image_texture_test)
     target_include_directories(ros_image_texture_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -651,7 +655,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(selection_tool_test
     test/rviz_default_plugins/tools/select/selection_tool_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET selection_tool_test)
     target_include_directories(selection_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -662,7 +666,7 @@ if(BUILD_TESTING)
   ament_add_gmock(xy_orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
     test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET xy_orbit_view_controller_test)
     target_include_directories(xy_orbit_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -672,7 +676,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(frame_transformer_tf_test
     test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_transformer_tf_test)
     target_include_directories(frame_transformer_tf_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -682,7 +686,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(transformer_guard_test
     test/rviz_default_plugins/transformation/transformer_guard_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET transformer_guard_test)
     target_include_directories(transformer_guard_test PUBLIC ${TEST_INCLUDE_DIRS})
@@ -693,7 +697,7 @@ if(BUILD_TESTING)
   ament_add_gtest(axes_display_visual_test
     test/rviz_default_plugins/displays/axes/axes_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/axes_display_page_object.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET axes_display_visual_test)
@@ -701,7 +705,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(axes_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -712,7 +715,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
     test/rviz_default_plugins/publishers/image_publisher.hpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET camera_display_visual_test)
@@ -721,7 +724,6 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(camera_display_visual_test
       point_cloud_common_page_object
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -729,7 +731,7 @@ if(BUILD_TESTING)
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
     test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET fluid_pressure_display_visual_test)
@@ -739,7 +741,6 @@ if(BUILD_TESTING)
     target_link_libraries(fluid_pressure_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -747,7 +748,7 @@ if(BUILD_TESTING)
   ament_add_gtest(grid_display_visual_test
     test/rviz_default_plugins/displays/grid/grid_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/grid_display_page_object.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_display_visual_test)
@@ -755,7 +756,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(grid_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -763,7 +763,7 @@ if(BUILD_TESTING)
   ament_add_gtest(grid_cells_display_visual_test
     test/rviz_default_plugins/displays/grid_cells/grid_cells_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/grid_cells_display_page_object.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_cells_display_visual_test)
@@ -771,7 +771,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(grid_cells_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -779,7 +778,7 @@ if(BUILD_TESTING)
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
     test/rviz_default_plugins/publishers/illuminance_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET illuminance_display_visual_test)
@@ -789,7 +788,6 @@ if(BUILD_TESTING)
     target_link_libraries(illuminance_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -798,7 +796,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/image/image_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/image_display_page_object.cpp
     test/rviz_default_plugins/publishers/image_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET image_display_visual_test)
@@ -806,19 +804,17 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(image_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
   ament_add_gtest(interactive_marker_namespace_property_test
     test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp
-    ${display_test_fixture_sources})
+  ${TEST_FIXTURE_SOURCES})
   if(TARGET interactive_marker_namespace_property_test)
     target_include_directories(interactive_marker_namespace_property_test PUBLIC
       ${TEST_INCLUDE_DIRS})
     target_link_libraries(interactive_marker_namespace_property_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES})
     ament_target_dependencies(interactive_marker_namespace_property_test
       ${TEST_TARGET_DEPENDENCIES})
@@ -826,7 +822,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(laser_scan_display_visual_test
     test/rviz_default_plugins/displays/laser_scan/laser_scan_display_visual_test.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET laser_scan_display_visual_test)
@@ -835,7 +831,6 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(laser_scan_display_visual_test
       point_cloud_common_page_object
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -846,7 +841,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     test/rviz_default_plugins/publishers/map_publisher.hpp
     test/rviz_default_plugins/publishers/single_marker_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET map_display_visual_test)
@@ -854,7 +849,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(map_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -864,7 +858,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/marker_array_display_page_object.cpp
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     test/rviz_default_plugins/publishers/marker_array_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_array_display_visual_test)
@@ -872,7 +866,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(marker_array_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -881,7 +874,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker/marker_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     test/rviz_default_plugins/publishers/marker_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_display_visual_test)
@@ -889,7 +882,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(marker_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -898,7 +890,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/odometry/odometry_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/odometry_display_page_object.cpp
     test/rviz_default_plugins/publishers/odometry_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET odometry_display_visual_test)
@@ -906,7 +898,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(odometry_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -915,7 +906,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/path/path_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/path_display_page_object.cpp
     test/rviz_default_plugins/publishers/path_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET path_display_visual_test)
@@ -923,7 +914,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(path_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -932,7 +922,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/point/point_stamped_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_display_page_object.cpp
     test/rviz_default_plugins/publishers/point_stamped_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_display_visual_test)
@@ -940,7 +930,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -948,7 +937,7 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_display_visual_test.cpp
     test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud_display_visual_test)
@@ -957,7 +946,6 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud_display_visual_test
       point_cloud_common_page_object
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -965,7 +953,7 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
     test/rviz_default_plugins/publishers/point_cloud2_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud2_display_visual_test)
@@ -975,7 +963,6 @@ if(BUILD_TESTING)
     target_link_libraries(point_cloud2_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -985,7 +972,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/page_objects/pose_array_display_page_object.cpp
     test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
     test/rviz_default_plugins/publishers/pose_array_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_array_display_visual_test)
@@ -993,7 +980,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(pose_array_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1002,7 +988,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/pose/pose_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
     test/rviz_default_plugins/publishers/pose_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_display_visual_test)
@@ -1010,7 +996,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(pose_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1019,7 +1004,7 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.cpp
     test/rviz_default_plugins/publishers/pose_with_covariance_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_with_covariance_display_visual_test)
@@ -1027,7 +1012,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(pose_with_covariance_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1035,7 +1019,7 @@ if(BUILD_TESTING)
   ament_add_gtest(range_display_visual_test
     test/rviz_default_plugins/displays/range/range_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/range_display_page_object.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET range_display_visual_test)
@@ -1043,7 +1027,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(range_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1051,7 +1034,7 @@ if(BUILD_TESTING)
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
     test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET relative_humidity_display_visual_test)
@@ -1061,7 +1044,6 @@ if(BUILD_TESTING)
     target_link_libraries(relative_humidity_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1069,7 +1051,7 @@ if(BUILD_TESTING)
   ament_add_gtest(robot_model_display_visual_test
     test/rviz_default_plugins/displays/robot_model/robot_model_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/robot_model_display_page_object.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET robot_model_display_visual_test)
@@ -1077,7 +1059,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(robot_model_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       ament_index_cpp::ament_index_cpp
       rviz_visual_testing_framework::rviz_visual_testing_framework)
@@ -1086,7 +1067,7 @@ if(BUILD_TESTING)
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
     test/rviz_default_plugins/publishers/temperature_publisher.hpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET temperature_display_visual_test)
@@ -1096,7 +1077,6 @@ if(BUILD_TESTING)
     target_link_libraries(temperature_display_visual_test
       point_cloud_common_page_object
       pointcloud_messages
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1104,7 +1084,7 @@ if(BUILD_TESTING)
   ament_add_gtest(tf_display_visual_test
     test/rviz_default_plugins/displays/tf/tf_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/tf_display_page_object.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET tf_display_visual_test)
@@ -1112,7 +1092,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(tf_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
@@ -1120,7 +1099,7 @@ if(BUILD_TESTING)
   ament_add_gtest(wrench_display_visual_test
     test/rviz_default_plugins/displays/wrench/wrench_stamped_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/wrench_display_page_object.cpp
-    ${display_test_fixture_sources}
+    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET wrench_display_visual_test)
@@ -1128,7 +1107,6 @@ if(BUILD_TESTING)
       ${TEST_INCLUDE_DIRS}
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(wrench_display_visual_test
-      ${GMOCK_LIBRARIES}
       ${TEST_LINK_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -24,7 +24,7 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
   <author email="william@openrobotics.org">William Woodall</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>rviz_ogre_vendor</build_depend>


### PR DESCRIPTION
The test fixture is explicitly linking against gmock, but tests get linked again as a result of the ament_add_gmock call.

This causes an ODR violation, but it didn't seem to cause any issues with tests.
Running the QOS tests with asan causes ODR violations though.