### PR TITLE
If vendored assimp is present, always prefer that

### DIFF
--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -4,13 +4,9 @@
 #   https://bugs.launchpad.net/ubuntu/+source/assimp/+bug/1869405
 set(ON 1)
 
-find_package(assimp QUIET)
-
-if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 4.1.0)
-  # add the local Modules directory to the modules path
-  set(assimp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_assimp_vendor/lib/cmake/assimp-4.1")
-  message(STATUS "Setting assimp_DIR to: '${assimp_DIR}'")
-endif()
+# add the local Modules directory to the modules path
+set(assimp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_assimp_vendor/lib/cmake/assimp-4.1")
+message(STATUS "Setting assimp_DIR to: '${assimp_DIR}'")
 
 find_package(assimp REQUIRED QUIET)
 

--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -4,7 +4,9 @@
 #   https://bugs.launchpad.net/ubuntu/+source/assimp/+bug/1869405
 set(ON 1)
 
-# add the local Modules directory to the modules path
+# We always add the local Modules directory to the modules path, so if a vendored package was
+# built, it is used.  If it was not built, find_package() will fall back to attempting to find the
+# system package.
 set(assimp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_assimp_vendor/lib/cmake/assimp-4.1")
 message(STATUS "Setting assimp_DIR to: '${assimp_DIR}'")
 


### PR DESCRIPTION
The existing behavior is to always prefer the system's assimp package if it is sufficient, even if the vendored assimp package is present. This is very confusing behavior when combined with `FORCE_BUILD_VENDOR_PKG`.

Additionally, the double find_package calls can result in strange behavior if both calls create or modify targets, as targets created by the first call will be present when the second call tries to create them.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18569)](http://ci.ros2.org/job/ci_linux/18569/)
* Linux (forced vendor) [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18570)](https://ci.ros2.org/job/ci_linux/18570/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=13114)](http://ci.ros2.org/job/ci_linux-aarch64/13114/)
* Linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=402)](https://ci.ros2.org/job/ci_linux-rhel/402/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=19307)](http://ci.ros2.org/job/ci_windows/19307/)