### PR TITLE
Modify access specifier to protected or public for the scope of processMessage() member function

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose/pose_display.hpp
@@ -89,6 +89,7 @@ protected:
   /** @brief Overridden from MessageFilterDisplay to get arrow/axes visibility correct. */
   void onEnable() override;
   void onDisable() override;
+  void processMessage(geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;
 
 private Q_SLOTS:
   void updateShapeVisibility();
@@ -98,7 +99,6 @@ private Q_SLOTS:
   void updateArrowGeometry();
 
 private:
-  void processMessage(geometry_msgs::msg::PoseStamped::ConstSharedPtr message) override;
   void setupSelectionHandler();
 
   std::unique_ptr<rviz_rendering::Arrow> arrow_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display.hpp
@@ -89,6 +89,8 @@ public:
 protected:
   /** @brief Overridden from MessageFilterDisplay to get Arrow/Axes visibility correct. */
   void onEnable() override;
+  void
+  processMessage(geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr message) override;
 
 private Q_SLOTS:
   void updateShapeVisibility();
@@ -99,8 +101,6 @@ private Q_SLOTS:
   void updateCovariance();
 
 private:
-  void
-  processMessage(geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr message) override;
   void setupSelectionHandler();
 
   std::shared_ptr<rviz_rendering::Arrow> arrow_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/relative_humidity/relative_humidity_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/relative_humidity/relative_humidity_display.hpp
@@ -56,7 +56,7 @@ public:
   RelativeHumidityDisplay();
   ~RelativeHumidityDisplay() override;
 
-private:
+protected:
   void processMessage(const sensor_msgs::msg::RelativeHumidity::ConstSharedPtr message) override;
 
   void setInitialValues() override;


### PR DESCRIPTION
- pose_display, pose_with_covariance_display and relative_humidity_display