### PR TITLE
Remove onHelpWiki.

### DIFF
--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -262,10 +262,6 @@ protected Q_SLOTS:
   void
   onRecentConfigSelected();
 
-  /// Handle event to display the help on the ROS wiki.
-  void
-  onHelpWiki();
-
   /// Handle event to show the about dialog.
   void
   onHelpAbout();

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -502,7 +502,6 @@ void VisualizationFrame::initMenus()
 
   QMenu * help_menu = menuBar()->addMenu("&Help");
   help_menu->addAction("Show &Help panel", this, SLOT(showHelpPanel()));
-  help_menu->addAction("Open rviz wiki in browser", this, SLOT(onHelpWiki()));
   help_menu->addSeparator();
   help_menu->addAction("&About", this, SLOT(onHelpAbout()));
 }
@@ -1134,11 +1133,6 @@ void VisualizationFrame::showHelpPanel()
 void VisualizationFrame::onHelpDestroyed()
 {
   show_help_action_ = nullptr;
-}
-
-void VisualizationFrame::onHelpWiki()
-{
-  QDesktopServices::openUrl(QUrl("http://www.ros.org/wiki/rviz"));
 }
 
 void VisualizationFrame::onHelpAbout()


### PR DESCRIPTION
We don't use the wiki in ROS 2, so remove the help page for it.