### PR TITLE
Re-implemented setName for tools

### DIFF
--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -189,6 +189,8 @@ public:
 Q_SIGNALS:
   /// Emitted when closed.
   void close();
+  /// Emitted when name property has been changed.
+  void nameChanged(const QString& name);
 
 protected:
   /// Override onInitialize to do any setup needed after the DisplayContext has been set.

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -190,7 +190,7 @@ Q_SIGNALS:
   /// Emitted when closed.
   void close();
   /// Emitted when name property has been changed.
-  void nameChanged(const QString& name);
+  void nameChanged(const QString & name);
 
 protected:
   /// Override onInitialize to do any setup needed after the DisplayContext has been set.

--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -296,6 +296,9 @@ protected Q_SLOTS:
   void
   addTool(Tool * tool);
 
+  /// React to name changes of a tool, updating the name of the associated QAction
+  void onToolNameChanged(const QString& name);
+
   /// Remove the given tool from the frame's toolbar.
   void
   removeTool(Tool * tool);

--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -297,7 +297,7 @@ protected Q_SLOTS:
   addTool(Tool * tool);
 
   /// React to name changes of a tool, updating the name of the associated QAction
-  void onToolNameChanged(const QString& name);
+  void onToolNameChanged(const QString & name);
 
   /// Remove the given tool from the frame's toolbar.
   void

--- a/rviz_common/src/rviz_common/tool.cpp
+++ b/rviz_common/src/rviz_common/tool.cpp
@@ -141,6 +141,8 @@ void Tool::setName(const QString & name)
 {
   name_ = name;
   property_container_->setName(name_);
+
+  Q_EMIT nameChanged(name_);
 }
 
 void Tool::setDescription(const QString & description)

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -1062,16 +1062,18 @@ void VisualizationFrame::addTool(Tool * tool)
 
   remove_tool_menu_->addAction(tool->getName());
 
-  QObject::connect(tool, &Tool::nameChanged, this,
-                   &VisualizationFrame::VisualizationFrame::onToolNameChanged);
+  QObject::connect(
+    tool, &Tool::nameChanged, this,
+    &VisualizationFrame::VisualizationFrame::onToolNameChanged);
 }
 
-void VisualizationFrame::onToolNameChanged(const QString& name)
+void VisualizationFrame::onToolNameChanged(const QString & name)
 {
   // Early return if the tool is not present
-  auto it = tool_to_action_map_.find(qobject_cast<Tool*>(sender()));
-  if (it == tool_to_action_map_.end())
+  auto it = tool_to_action_map_.find(qobject_cast<Tool *>(sender()));
+  if (it == tool_to_action_map_.end()) {
     return;
+  }
 
   // Change the name of the action
   it->second->setIconText(name);

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -1061,6 +1061,20 @@ void VisualizationFrame::addTool(Tool * tool)
   tool_to_action_map_[tool] = action;
 
   remove_tool_menu_->addAction(tool->getName());
+
+  QObject::connect(tool, &Tool::nameChanged, this,
+                   &VisualizationFrame::VisualizationFrame::onToolNameChanged);
+}
+
+void VisualizationFrame::onToolNameChanged(const QString& name)
+{
+  // Early return if the tool is not present
+  auto it = tool_to_action_map_.find(qobject_cast<Tool*>(sender()));
+  if (it == tool_to_action_map_.end())
+    return;
+
+  // Change the name of the action
+  it->second->setIconText(name);
 }
 
 void VisualizationFrame::onToolbarActionTriggered(QAction * action)


### PR DESCRIPTION
In the migration towards RViz2 dynamically setting a tool name seems to got dropped. This PR adds this feature again.

We use one central RViz instance in a multi-mobile-robot application where we have a NavGoal tool for each robot. Not being able to rename the tools is a bit hard to use as you'll have to memorize the actual order.

I don't know whether there is a specific reason why this got dropped, but I think this is valid and useful to keep.

As we currently use ROS 2 Humble, I think this should also be backported to Humble. I can open a second PR if desired.