### PR TITLE
Add a libqt5-svg dependency to rviz_common.

### DIFF
--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -26,6 +26,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libqt5-svg-dev</build_depend>
   <build_depend>qtbase5-dev</build_depend>
 
   <build_export_depend>qtbase5-dev</build_export_depend>
@@ -33,6 +34,7 @@
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>
+  <exec_depend>libqt5-svg</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
 
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
rviz_common is the package that loads in various icons in svg format.  In order to have them definitely be loaded in, make sure to depend on libqt5-svg.

This should fix #987 