### PR TITLE
load GLB meshes

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -350,7 +350,7 @@ void AssimpLoader::setLightColorsFromAssimp(
 }
 
 void AssimpLoader::loadEmbeddedTexture(
-  const aiTexture * texture, const std::string &resource_path)
+  const aiTexture * texture, const std::string & resource_path)
 {
   // use the format hint to try to load the image
   std::string format_hint(

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -352,6 +352,11 @@ void AssimpLoader::setLightColorsFromAssimp(
 void AssimpLoader::loadEmbeddedTexture(
   const aiTexture * texture, const std::string & resource_path)
 {
+  if (texture == nullptr) {
+    RVIZ_RENDERING_LOG_ERROR_STREAM("null texture!");
+    return;
+  }
+
   // use the format hint to try to load the image
   std::string format_hint(
     texture->achFormatHint,

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -291,7 +291,7 @@ void AssimpLoader::setLightColorsFromAssimp(
       uint32_t uv_index;
       ai_material->GetTexture(aiTextureType_DIFFUSE, 0, &texture_name, &mapping, &uv_index);
       std::string texture_path;
-      const aiTexture *texture = ai_scene->GetEmbeddedTexture(texture_name.C_Str());
+      const aiTexture * texture = ai_scene->GetEmbeddedTexture(texture_name.C_Str());
       if (texture == nullptr) {
         // It's not an embedded texture. We have to go find it.
         // Assume textures are in paths relative to the mesh
@@ -350,7 +350,7 @@ void AssimpLoader::setLightColorsFromAssimp(
 }
 
 void AssimpLoader::loadEmbeddedTexture(
-  const aiTexture *texture, const std::string &resource_path)
+  const aiTexture * texture, const std::string &resource_path)
 {
   // use the format hint to try to load the image
   std::string format_hint(
@@ -358,17 +358,17 @@ void AssimpLoader::loadEmbeddedTexture(
     strnlen(texture->achFormatHint, sizeof(texture->achFormatHint)));
 
   Ogre::DataStreamPtr stream(
-      new Ogre::MemoryDataStream(
-          (unsigned char *)texture->pcData, texture->mWidth));
+    new Ogre::MemoryDataStream(
+      (unsigned char *)texture->pcData, texture->mWidth));
 
   try {
     Ogre::Image image;
     image.load(stream, format_hint.c_str());
     Ogre::TextureManager::getSingleton().loadImage(
-        resource_path, ROS_PACKAGE_NAME, image);
+      resource_path, ROS_PACKAGE_NAME, image);
   } catch (Ogre::Exception & e) {
     RVIZ_RENDERING_LOG_ERROR_STREAM(
-        "Could not load texture [" << resource_path.c_str() <<
+      "Could not load texture [" << resource_path.c_str() <<
         "] with format hint [" << format_hint << "]: " << e.what());
   }
 }

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
@@ -107,8 +107,13 @@ private:
     const std::string & resource_path,
     Ogre::MaterialPtr & mat,
     const aiMaterial * ai_material,
-    MaterialInternals & material_internals);
+    MaterialInternals & material_internals,
+    const aiScene *ai_scene);
   void loadTexture(const std::string & resource_path);
+  void loadEmbeddedTexture(
+    const aiScene *ai_scene,
+    const std::string & embedded_name,
+    const std::string & resource_path);
   void setBlending(
     Ogre::MaterialPtr & mat, const aiMaterial * ai_material,
     const MaterialInternals & material_internals);

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
@@ -111,8 +111,7 @@ private:
     const aiScene *ai_scene);
   void loadTexture(const std::string & resource_path);
   void loadEmbeddedTexture(
-    const aiScene *ai_scene,
-    const std::string & embedded_name,
+    const aiTexture *ai_texture,
     const std::string & resource_path);
   void setBlending(
     Ogre::MaterialPtr & mat, const aiMaterial * ai_material,

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.hpp
@@ -108,10 +108,10 @@ private:
     Ogre::MaterialPtr & mat,
     const aiMaterial * ai_material,
     MaterialInternals & material_internals,
-    const aiScene *ai_scene);
+    const aiScene * ai_scene);
   void loadTexture(const std::string & resource_path);
   void loadEmbeddedTexture(
-    const aiTexture *ai_texture,
+    const aiTexture * ai_texture,
     const std::string & resource_path);
   void setBlending(
     Ogre::MaterialPtr & mat, const aiMaterial * ai_material,


### PR DESCRIPTION
This PR allows loading GLB meshes into RViz.

The first change is a 1-liner that allows the Assimp GLB loader to correctly parse the file. The problem was that the custom `ResourceIOStream` class was calculating the return value of `Read` as the number of bytes, not the number of items. Usually the calls only ask for 1-byte items, but the GLB loader asks for a 12-byte item (the GLB header) and expects `1` to be returned, not `12`. (This is the same behavior as `fread()` ).

The second change is to load embedded textures from GLB files, rather than always trying to append the texture filename to the current directory. It's easy to tell if it's an embedded texture because the "filename" will start with `*`. There are lots more things potentially in a GLB file, like all sorts of PBR stuff, but at least loading the diffuse texture will start things going. This loader assumes they are PNG-compressed, which seems to usually be the case (?) at least, I haven't seen otherwise, but I suppose we could at least test for compression and bail out if it's not :shrug: 