### PR TITLE
make line endings match between patch and upstream on Windows

### DIFF
--- a/rviz_assimp_vendor/patches/.gitattributes
+++ b/rviz_assimp_vendor/patches/.gitattributes
@@ -1,0 +1,4 @@
+# Because the assimp repo declares eol=lf on all its .cpp files, we also
+# need to declare this on the patch file so that the line endings match
+# on Windows checkouts.
+*.patch text eol=lf


### PR DESCRIPTION
Since upstream (assimp) has a top-level `.gitattributes` file that declares `eol=lf` on all its `.cpp` files, we also need this setting on our patch file. Otherwise, on Windows checkouts we have CRLF endings in our patch file but LF endings in the upstream source, and `git-apply` fails.