### PR TITLE
Improve the compilation time of rviz_default_plugins

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -365,7 +365,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(fps_view_controller_test
     test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
-    test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET fps_view_controller_test)
@@ -483,7 +482,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
-    test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET orbit_view_controller_test)
@@ -494,7 +492,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(ortho_view_controller_test
     test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
-    test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ortho_view_controller_test)
@@ -648,7 +645,6 @@ if(BUILD_TESTING)
 
   ament_add_gmock(xy_orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
-    test/rviz_default_plugins/view_controllers/view_controller_test_fixture.hpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET xy_orbit_view_controller_test)
@@ -694,11 +690,8 @@ if(BUILD_TESTING)
 
   ament_add_gtest(camera_display_visual_test
     test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
-    test/rviz_default_plugins/publishers/camera_info_publisher.hpp
     test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/publishers/image_publisher.hpp
-    test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -717,7 +710,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/pointcloud_messages.cpp
-    test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -767,7 +759,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/pointcloud_messages.cpp
-    test/rviz_default_plugins/publishers/illuminance_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -785,7 +776,6 @@ if(BUILD_TESTING)
   ament_add_gtest(image_display_visual_test
     test/rviz_default_plugins/displays/image/image_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/image_display_page_object.cpp
-    test/rviz_default_plugins/publishers/image_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -832,8 +822,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/map/map_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/map_display_page_object.cpp
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
-    test/rviz_default_plugins/publishers/map_publisher.hpp
-    test/rviz_default_plugins/publishers/single_marker_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -850,7 +838,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker_array/marker_array_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/marker_array_display_page_object.cpp
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
-    test/rviz_default_plugins/publishers/marker_array_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -866,7 +853,6 @@ if(BUILD_TESTING)
   ament_add_gtest(marker_display_visual_test
     test/rviz_default_plugins/displays/marker/marker_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
-    test/rviz_default_plugins/publishers/marker_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -882,7 +868,6 @@ if(BUILD_TESTING)
   ament_add_gtest(odometry_display_visual_test
     test/rviz_default_plugins/displays/odometry/odometry_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/odometry_display_page_object.cpp
-    test/rviz_default_plugins/publishers/odometry_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -898,7 +883,6 @@ if(BUILD_TESTING)
   ament_add_gtest(path_display_visual_test
     test/rviz_default_plugins/displays/path/path_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/path_display_page_object.cpp
-    test/rviz_default_plugins/publishers/path_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -915,7 +899,6 @@ if(BUILD_TESTING)
   ament_add_gtest(point_display_visual_test
     test/rviz_default_plugins/displays/point/point_stamped_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_display_page_object.cpp
-    test/rviz_default_plugins/publishers/point_stamped_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -931,7 +914,6 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -950,7 +932,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/pointcloud_messages.cpp
-    test/rviz_default_plugins/publishers/point_cloud2_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -969,7 +950,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/pose_array/pose_array_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_array_display_page_object.cpp
     test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
-    test/rviz_default_plugins/publishers/pose_array_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -985,7 +965,6 @@ if(BUILD_TESTING)
   ament_add_gtest(pose_display_visual_test
     test/rviz_default_plugins/displays/pose/pose_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
-    test/rviz_default_plugins/publishers/pose_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -1001,7 +980,6 @@ if(BUILD_TESTING)
   ament_add_gtest(pose_with_covariance_display_visual_test
     test/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.cpp
-    test/rviz_default_plugins/publishers/pose_with_covariance_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -1033,7 +1011,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/pointcloud_messages.cpp
-    test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -1068,7 +1045,6 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     test/rviz_default_plugins/pointcloud_messages.cpp
-    test/rviz_default_plugins/publishers/temperature_publisher.hpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -390,6 +390,15 @@ if(BUILD_TESTING)
     target_link_libraries(image_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
   endif()
 
+  add_library(marker_messages STATIC test/rviz_default_plugins/displays/marker/marker_messages.cpp)
+  target_link_libraries(marker_messages PRIVATE
+    ${geometry_msgs_TARGETS}
+    rclcpp::rclcpp
+    ${std_msgs_TARGETS}
+    ${visualization_msgs_TARGETS}
+    rviz_ogre_vendor::OgreMain
+  )
+
   ament_add_gmock(marker_test
     test/rviz_default_plugins/displays/marker/markers/arrow_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/line_marker_test.cpp
@@ -399,22 +408,30 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker/markers/text_view_facing_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/triangle_list_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
-    test/rviz_default_plugins/displays/marker/marker_messages.cpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_test)
     target_include_directories(marker_test PRIVATE test)
-    target_link_libraries(marker_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ${visualization_msgs_TARGETS})
+    target_link_libraries(marker_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      rviz_default_plugins
+      marker_messages
+      ${visualization_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gmock(marker_common_test
     test/rviz_default_plugins/displays/marker/marker_common_test.cpp
-    test/rviz_default_plugins/displays/marker/marker_messages.cpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_common_test)
     target_include_directories(marker_common_test PRIVATE test)
-    target_link_libraries(marker_common_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${visualization_msgs_TARGETS} rviz_default_plugins)
+    target_link_libraries(marker_common_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      ${visualization_msgs_TARGETS}
+      rviz_default_plugins
+      marker_messages
+    )
   endif()
 
   ament_add_gmock(map_display_test

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -231,12 +231,28 @@ target_include_directories(rviz_default_plugins PUBLIC
 )
 
 target_link_libraries(rviz_default_plugins PUBLIC
+  ${geometry_msgs_TARGETS}
+  image_transport::image_transport
+  interactive_markers::interactive_markers
+  laser_geometry::laser_geometry
+  ${map_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  rviz_common::rviz_common
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
+  rviz_rendering::rviz_rendering
+  ${sensor_msgs_TARGETS}
+  tf2::tf2
+  ${tf2_geometry_msgs_TARGETS}
+  tf2_ros::tf2_ros
+  urdf::urdf
+  ${visualization_msgs_TARGETS}
 )
 
 target_link_libraries(rviz_default_plugins PRIVATE
   ignition-math6
+  resource_retriever::resource_retriever
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -244,26 +260,6 @@ target_link_libraries(rviz_default_plugins PRIVATE
 target_compile_definitions(rviz_default_plugins PRIVATE "RVIZ_DEFAULT_PLUGINS_BUILDING_LIBRARY")
 
 pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
-
-ament_target_dependencies(rviz_default_plugins
-  PUBLIC
-  geometry_msgs
-  image_transport
-  interactive_markers
-  laser_geometry
-  map_msgs
-  nav_msgs
-  rclcpp
-  resource_retriever
-  rviz_common
-  rviz_rendering
-  sensor_msgs
-  tf2
-  tf2_geometry_msgs
-  tf2_ros
-  urdf
-  visualization_msgs
-)
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
@@ -279,7 +275,6 @@ ament_export_dependencies(
   map_msgs
   nav_msgs
   rclcpp
-  resource_retriever
   rviz_common
   rviz_ogre_vendor
   sensor_msgs
@@ -323,24 +318,6 @@ if(BUILD_TESTING)
 
   # This is needed for the fixture sources down below...
   ament_find_gmock()
-  set(TEST_INCLUDE_DIRS
-    test
-    ${GMOCK_INCLUDE_DIRS}
-    ${OGRE_INCLUDE_DIRS}
-    ${Qt5Widgets_INCLUDE_DIRS}
-  )
-  ament_include_directories_order(TEST_INCLUDE_DIRS ${TEST_INCLUDE_DIRS})
-
-  set(TEST_TARGET_DEPENDENCIES
-    map_msgs
-    nav_msgs
-    rclcpp
-    rviz_common
-    rviz_rendering
-    sensor_msgs
-    urdf
-    visualization_msgs
-  )
 
   # We can't compile the fixtures into a library to be used by every test because that would require
   # linking against gtest/gmock libraries, which would cause ODR violations down the line with
@@ -358,9 +335,15 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES}
   )
 
-  set(TEST_LINK_LIBRARIES
-    rviz_default_plugins
-    Qt5::Widgets
+  set(TEST_FIXTURE_LIBRARIES
+    rviz_ogre_vendor::OgreMain
+    rviz_rendering::rviz_rendering
+  )
+
+  set(TEST_FIXTURE_WITH_MOCK_LIBRARIES
+    ${TEST_FIXTURE_LIBRARIES}
+    rclcpp::rclcpp
+    rviz_common::rviz_common
   )
 
   ament_add_gmock(fps_view_controller_test
@@ -368,9 +351,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET fps_view_controller_test)
-    target_include_directories(fps_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(fps_view_controller_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(fps_view_controller_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(fps_view_controller_test PRIVATE test)
+    target_link_libraries(fps_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins Qt5::Widgets)
   endif()
 
   ament_add_gmock(frame_info_test
@@ -378,17 +360,16 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_info_test)
-    target_include_directories(frame_info_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(frame_info_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(frame_info_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(frame_info_test PRIVATE test)
+    target_link_libraries(frame_info_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(get_transport_from_topic_test
     test/rviz_default_plugins/displays/image/get_transport_from_topic_test.cpp
-  ${TEST_FIXTURE_SOURCES_WITH_MOCK})
+    ${TEST_FIXTURE_SOURCES_WITH_MOCK})
   if(TARGET get_transport_from_topic_test)
-    target_include_directories(get_transport_from_topic_test PUBLIC ${TEST_INCLUDE_DIRS} ${rviz_common_INCLUDE_DIRS})
-    target_link_libraries(get_transport_from_topic_test ${TEST_LINK_LIBRARIES} ${rviz_common})
+    target_include_directories(get_transport_from_topic_test PRIVATE test)
+    target_link_libraries(get_transport_from_topic_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(grid_cells_display_test
@@ -396,9 +377,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET grid_cells_display_test)
-    target_include_directories(grid_cells_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(grid_cells_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(grid_cells_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(grid_cells_display_test PRIVATE test)
+    target_link_libraries(grid_cells_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(image_display_test
@@ -406,9 +386,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET image_display_test)
-    target_include_directories(image_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(image_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(image_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(image_display_test PRIVATE test)
+    target_link_libraries(image_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
   endif()
 
   ament_add_gmock(marker_test
@@ -424,9 +403,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_test)
-    target_include_directories(marker_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(marker_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(marker_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(marker_test PRIVATE test)
+    target_link_libraries(marker_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ${visualization_msgs_TARGETS})
   endif()
 
   ament_add_gmock(marker_common_test
@@ -435,9 +413,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET marker_common_test)
-    target_include_directories(marker_common_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(marker_common_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(marker_common_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(marker_common_test PRIVATE test)
+    target_link_libraries(marker_common_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${visualization_msgs_TARGETS} rviz_default_plugins)
   endif()
 
   ament_add_gmock(map_display_test
@@ -445,9 +422,8 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/map/map_display_test.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET map_display_test)
-    target_include_directories(map_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(map_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(map_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(map_display_test PRIVATE test)
+    target_link_libraries(map_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(measure_tool_test
@@ -455,9 +431,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET measure_tool_test)
-    target_include_directories(measure_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(measure_tool_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(measure_tool_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(measure_tool_test PRIVATE test)
+    target_link_libraries(measure_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(odometry_display_test
@@ -465,9 +440,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_display_test)
-    target_include_directories(odometry_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(odometry_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(odometry_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(odometry_display_test PRIVATE test)
+    target_link_libraries(odometry_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(odometry_ogre_helper_test
@@ -475,9 +449,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_ogre_helper_test)
-    target_include_directories(odometry_ogre_helper_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(odometry_ogre_helper_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(odometry_ogre_helper_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(odometry_ogre_helper_test PRIVATE test)
+    target_link_libraries(odometry_ogre_helper_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES})
   endif()
 
   ament_add_gmock(orbit_view_controller_test
@@ -485,9 +458,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET orbit_view_controller_test)
-    target_include_directories(orbit_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(orbit_view_controller_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(orbit_view_controller_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(orbit_view_controller_test PRIVATE test)
+    target_link_libraries(orbit_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
   endif()
 
   ament_add_gmock(ortho_view_controller_test
@@ -495,9 +467,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ortho_view_controller_test)
-    target_include_directories(ortho_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(ortho_view_controller_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(ortho_view_controller_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(ortho_view_controller_test PRIVATE test)
+    target_link_libraries(ortho_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
   endif()
 
   ament_add_gmock(palette_builder_test
@@ -505,9 +476,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET palette_builder_test)
-    target_include_directories(palette_builder_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(palette_builder_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(palette_builder_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(palette_builder_test PRIVATE test)
+    target_link_libraries(palette_builder_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(path_display_test
@@ -515,9 +485,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET path_display_test)
-    target_include_directories(path_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(path_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(path_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(path_display_test PRIVATE test)
+    target_link_libraries(path_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${visualization_msgs_TARGETS} rviz_default_plugins)
   endif()
 
   ament_add_gmock(point_cloud2_display_test
@@ -526,10 +495,14 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud2_display_test)
-    target_include_directories(point_cloud2_display_test PUBLIC ${TEST_INCLUDE_DIRS})
+    target_include_directories(point_cloud2_display_test PRIVATE test)
     target_link_libraries(point_cloud2_display_test
-      ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(point_cloud2_display_test ${TEST_TARGET_DEPENDENCIES})
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      rviz_default_plugins
+      ${geometry_msgs_TARGETS}
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gmock(point_cloud_common_test
@@ -538,10 +511,14 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_common_test)
-    target_include_directories(point_cloud_common_test PUBLIC ${TEST_INCLUDE_DIRS})
+    target_include_directories(point_cloud_common_test PRIVATE test)
     target_link_libraries(point_cloud_common_test
-      ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(point_cloud_common_test ${TEST_TARGET_DEPENDENCIES})
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      rviz_default_plugins
+      ${geometry_msgs_TARGETS}
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gmock(point_cloud_scalar_display_test
@@ -549,9 +526,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_scalar_display_test)
-    target_include_directories(point_cloud_scalar_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(point_cloud_scalar_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(point_cloud_scalar_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(point_cloud_scalar_display_test PRIVATE test)
+    target_link_libraries(point_cloud_scalar_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ${sensor_msgs_TARGETS})
   endif()
 
   ament_add_gmock(point_cloud_transformers_test
@@ -565,10 +541,15 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_transformers_test)
-    target_include_directories(point_cloud_transformers_test PUBLIC ${TEST_INCLUDE_DIRS})
+    target_include_directories(point_cloud_transformers_test PRIVATE test)
     target_link_libraries(point_cloud_transformers_test
-      ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(point_cloud_transformers_test ${TEST_TARGET_DEPENDENCIES})
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      Qt5::Widgets
+      rviz_default_plugins
+      ${geometry_msgs_TARGETS}
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gmock(point_display_test
@@ -576,9 +557,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_display_test)
-    target_include_directories(point_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(point_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(point_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(point_display_test PRIVATE test)
+    target_link_libraries(point_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${geometry_msgs_TARGETS} rviz_default_plugins)
   endif()
 
   ament_add_gmock(pose_array_display_test
@@ -586,9 +566,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_array_display_test)
-    target_include_directories(pose_array_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(pose_array_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(pose_array_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(pose_array_display_test PRIVATE test)
+    target_link_libraries(pose_array_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(pose_tool_test
@@ -596,9 +575,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_tool_test)
-    target_include_directories(pose_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(pose_tool_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(pose_tool_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(pose_tool_test PRIVATE test)
+    target_link_libraries(pose_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(range_display_test
@@ -606,9 +584,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET range_display_test)
-    target_include_directories(range_display_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(range_display_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(range_display_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(range_display_test PRIVATE test)
+    target_link_libraries(range_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(robot_test
@@ -616,11 +593,13 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET robot_test)
-    target_include_directories(robot_test PUBLIC ${TEST_INCLUDE_DIRS})
-    # TODO(clalancette): Figure out why putting resource_retriever in the
-    # TEST_TARGET_DEPENDENCIES doesn't work.
-    target_link_libraries(robot_test resource_retriever::resource_retriever ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(robot_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(robot_test PRIVATE test)
+    target_link_libraries(robot_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      resource_retriever::resource_retriever
+      Qt5::Widgets
+      rviz_default_plugins
+    )
   endif()
 
   ament_add_gmock(ros_image_texture_test
@@ -628,9 +607,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ros_image_texture_test)
-    target_include_directories(ros_image_texture_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(ros_image_texture_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(ros_image_texture_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(ros_image_texture_test PRIVATE test)
+    target_link_libraries(ros_image_texture_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${sensor_msgs_TARGETS} rviz_default_plugins)
   endif()
 
   ament_add_gmock(selection_tool_test
@@ -638,9 +616,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET selection_tool_test)
-    target_include_directories(selection_tool_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(selection_tool_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(selection_tool_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(selection_tool_test PRIVATE test)
+    target_link_libraries(selection_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
   endif()
 
   ament_add_gmock(xy_orbit_view_controller_test
@@ -648,9 +625,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET xy_orbit_view_controller_test)
-    target_include_directories(xy_orbit_view_controller_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(xy_orbit_view_controller_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(xy_orbit_view_controller_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(xy_orbit_view_controller_test PRIVATE test)
+    target_link_libraries(xy_orbit_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
   endif()
 
   ament_add_gmock(frame_transformer_tf_test
@@ -658,9 +634,13 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_transformer_tf_test)
-    target_include_directories(frame_transformer_tf_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(frame_transformer_tf_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(frame_transformer_tf_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(frame_transformer_tf_test PRIVATE test)
+    target_link_libraries(frame_transformer_tf_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      tf2_ros::tf2_ros
+      ${geometry_msgs_TARGETS}
+      rviz_default_plugins
+    )
   endif()
 
   ament_add_gmock(transformer_guard_test
@@ -668,9 +648,8 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET transformer_guard_test)
-    target_include_directories(transformer_guard_test PUBLIC ${TEST_INCLUDE_DIRS})
-    target_link_libraries(transformer_guard_test ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(transformer_guard_test ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(transformer_guard_test PRIVATE test)
+    target_link_libraries(transformer_guard_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} tf2_ros::tf2_ros rviz_default_plugins)
   endif()
 
   ament_add_gtest(axes_display_visual_test
@@ -680,12 +659,8 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET axes_display_visual_test)
-    target_include_directories(axes_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
-    target_link_libraries(axes_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+    target_include_directories(axes_display_visual_test PRIVATE test)
+    target_link_libraries(axes_display_visual_test ${TEST_FIXTURE_LIBRARIES} rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
   ament_add_gtest(camera_display_visual_test
@@ -696,14 +671,17 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET camera_display_visual_test)
-    target_include_directories(camera_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(camera_display_visual_test PRIVATE test)
     target_link_libraries(camera_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      rclcpp::rclcpp
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${geometry_msgs_TARGETS}
+      tf2::tf2
+    )
   endif()
 
   ament_add_gtest(fluid_pressure_display_visual_test
@@ -714,14 +692,16 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET fluid_pressure_display_visual_test)
-    target_include_directories(fluid_pressure_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(fluid_pressure_display_visual_test PRIVATE test)
     target_link_libraries(fluid_pressure_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rclcpp::rclcpp
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+      ${geometry_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(grid_display_visual_test
@@ -731,13 +711,12 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_display_visual_test)
-    target_include_directories(grid_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(grid_display_visual_test PRIVATE test)
     target_link_libraries(grid_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+    )
   endif()
 
   ament_add_gtest(grid_cells_display_visual_test
@@ -747,12 +726,12 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_cells_display_visual_test)
-    target_include_directories(grid_cells_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(grid_cells_display_visual_test PRIVATE test)
     target_link_libraries(grid_cells_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      ${nav_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(illuminance_display_visual_test
@@ -763,14 +742,16 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET illuminance_display_visual_test)
-    target_include_directories(illuminance_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(illuminance_display_visual_test PRIVATE test)
     target_link_libraries(illuminance_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      ${geometry_msgs_TARGETS}
+      rclcpp::rclcpp
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(image_display_visual_test
@@ -780,25 +761,23 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET image_display_visual_test)
-    target_include_directories(image_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(image_display_visual_test PRIVATE test)
     target_link_libraries(image_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      rclcpp::rclcpp
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(interactive_marker_namespace_property_test
     test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp
-  ${TEST_FIXTURE_SOURCES})
+    ${TEST_FIXTURE_SOURCES})
   if(TARGET interactive_marker_namespace_property_test)
-    target_include_directories(interactive_marker_namespace_property_test PUBLIC
-      ${TEST_INCLUDE_DIRS})
-    target_link_libraries(interactive_marker_namespace_property_test
-      ${TEST_LINK_LIBRARIES})
-    ament_target_dependencies(interactive_marker_namespace_property_test
-      ${TEST_TARGET_DEPENDENCIES})
+    target_include_directories(interactive_marker_namespace_property_test PRIVATE test)
+    target_link_libraries(interactive_marker_namespace_property_test ${TEST_FIXTURE_LIBRARIES} rviz_default_plugins Qt5::Widgets)
   endif()
 
   ament_add_gtest(laser_scan_display_visual_test
@@ -808,14 +787,12 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET laser_scan_display_visual_test)
-    target_include_directories(laser_scan_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(laser_scan_display_visual_test PRIVATE test)
     target_link_libraries(laser_scan_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+    )
   endif()
 
   ament_add_gtest(map_display_visual_test
@@ -826,12 +803,17 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET map_display_visual_test)
-    target_include_directories(map_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(map_display_visual_test PRIVATE test)
     target_link_libraries(map_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      ${geometry_msgs_TARGETS}
+      ${nav_msgs_TARGETS}
+      ${visualization_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(marker_array_display_visual_test
@@ -842,12 +824,15 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_array_display_visual_test)
-    target_include_directories(marker_array_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(marker_array_display_visual_test PRIVATE test)
     target_link_libraries(marker_array_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      ${visualization_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(marker_display_visual_test
@@ -857,12 +842,15 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_display_visual_test)
-    target_include_directories(marker_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(marker_display_visual_test PRIVATE test)
     target_link_libraries(marker_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      ${visualization_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(odometry_display_visual_test
@@ -872,12 +860,17 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET odometry_display_visual_test)
-    target_include_directories(odometry_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(odometry_display_visual_test PRIVATE test)
     target_link_libraries(odometry_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      ${geometry_msgs_TARGETS}
+      ${nav_msgs_TARGETS}
+      tf2_ros::tf2_ros
+    )
   endif()
 
   ament_add_gtest(path_display_visual_test
@@ -887,13 +880,16 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET path_display_visual_test)
-    target_include_directories(path_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(path_display_visual_test PRIVATE test)
     target_link_libraries(path_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      ${geometry_msgs_TARGETS}
+      ${nav_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(point_display_visual_test
@@ -903,12 +899,15 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_display_visual_test)
-    target_include_directories(point_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(point_display_visual_test PRIVATE test)
     target_link_libraries(point_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      ${geometry_msgs_TARGETS}
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(point_cloud_display_visual_test
@@ -918,14 +917,17 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud_display_visual_test)
-    target_include_directories(point_cloud_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(point_cloud_display_visual_test PRIVATE test)
     target_link_libraries(point_cloud_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      ${geometry_msgs_TARGETS}
+      tf2::tf2
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      ${sensor_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(point_cloud2_display_visual_test
@@ -936,14 +938,16 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud2_display_visual_test)
-    target_include_directories(point_cloud2_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(point_cloud2_display_visual_test PRIVATE test)
     target_link_libraries(point_cloud2_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      ${geometry_msgs_TARGETS}
+      rclcpp::rclcpp
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(pose_array_display_visual_test
@@ -954,12 +958,15 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_array_display_visual_test)
-    target_include_directories(pose_array_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(pose_array_display_visual_test PRIVATE test)
     target_link_libraries(pose_array_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      ${geometry_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(pose_display_visual_test
@@ -969,12 +976,15 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_display_visual_test)
-    target_include_directories(pose_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(pose_display_visual_test PRIVATE test)
     target_link_libraries(pose_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      ${geometry_msgs_TARGETS}
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(pose_with_covariance_display_visual_test
@@ -984,12 +994,16 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_with_covariance_display_visual_test)
-    target_include_directories(pose_with_covariance_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(pose_with_covariance_display_visual_test PRIVATE test)
     target_link_libraries(pose_with_covariance_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+      ${geometry_msgs_TARGETS}
+      rclcpp::rclcpp
+      ${std_msgs_TARGETS}
+      tf2_ros::tf2_ros
+    )
   endif()
 
   ament_add_gtest(range_display_visual_test
@@ -999,12 +1013,12 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET range_display_visual_test)
-    target_include_directories(range_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(range_display_visual_test PRIVATE test)
     target_link_libraries(range_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+    )
   endif()
 
   ament_add_gtest(relative_humidity_display_visual_test
@@ -1015,14 +1029,16 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET relative_humidity_display_visual_test)
-    target_include_directories(relative_humidity_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(relative_humidity_display_visual_test PRIVATE test)
     target_link_libraries(relative_humidity_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      ${geometry_msgs_TARGETS}
+      rclcpp::rclcpp
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(robot_model_display_visual_test
@@ -1032,13 +1048,12 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET robot_model_display_visual_test)
-    target_include_directories(robot_model_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(robot_model_display_visual_test PRIVATE test)
     target_link_libraries(robot_model_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       ament_index_cpp::ament_index_cpp
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+    )
   endif()
 
   ament_add_gtest(temperature_display_visual_test
@@ -1049,14 +1064,16 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET temperature_display_visual_test)
-    target_include_directories(temperature_display_visual_test PUBLIC
-      test/page_objects
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(temperature_display_visual_test PRIVATE test)
     target_link_libraries(temperature_display_visual_test
-      ${TEST_LINK_LIBRARIES}
+      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      ${geometry_msgs_TARGETS}
+      rclcpp::rclcpp
+      ${sensor_msgs_TARGETS}
+      ${std_msgs_TARGETS}
+    )
   endif()
 
   ament_add_gtest(tf_display_visual_test
@@ -1066,12 +1083,12 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET tf_display_visual_test)
-    target_include_directories(tf_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(tf_display_visual_test PRIVATE test)
     target_link_libraries(tf_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+    )
   endif()
 
   ament_add_gtest(wrench_display_visual_test
@@ -1081,12 +1098,12 @@ if(BUILD_TESTING)
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET wrench_display_visual_test)
-    target_include_directories(wrench_display_visual_test PUBLIC
-      ${TEST_INCLUDE_DIRS}
-      ${rviz_visual_testing_framework_INCLUDE_DIRS})
+    target_include_directories(wrench_display_visual_test PRIVATE test)
     target_link_libraries(wrench_display_visual_test
-      ${TEST_LINK_LIBRARIES}
-      rviz_visual_testing_framework::rviz_visual_testing_framework)
+      ${TEST_FIXTURE_LIBRARIES}
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      Qt5::Widgets
+    )
   endif()
 endif()
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -316,8 +316,6 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_index_cpp REQUIRED)
   find_package(rviz_visual_testing_framework REQUIRED)
-  find_package(sensor_msgs REQUIRED)
-  find_package(visualization_msgs REQUIRED)
 
   install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test/ogre_media_resources/test_meshes"
     DESTINATION "share/rviz_default_plugins"

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -319,31 +319,25 @@ if(BUILD_TESTING)
   # This is needed for the fixture sources down below...
   ament_find_gmock()
 
-  # We can't compile the fixtures into a library to be used by every test because that would require
-  # linking against gtest/gmock libraries, which would cause ODR violations down the line with
-  # ament_add_gmock.
+  add_library(ogre_testing_environment STATIC test/rviz_default_plugins/ogre_testing_environment.cpp)
+  target_link_libraries(ogre_testing_environment PRIVATE rviz_ogre_vendor::OgreMain rviz_rendering::rviz_rendering)
+
+  # We can't compile these fixtures into a library to be used by every test because that would
+  # require linking against gtest/gmock libraries, which would cause ODR violations down the line
+  # with ament_add_gmock.
   #
   # There are also issues even if we manage to defer the linking, because the fixture class inherits
   # from gtest classes, which are not exported.
-  set(TEST_FIXTURE_SOURCES
-    test/rviz_default_plugins/ogre_testing_environment.cpp
-  )
-
   set(TEST_FIXTURE_SOURCES_WITH_MOCK
     test/rviz_default_plugins/displays/display_test_fixture.cpp
     test/rviz_default_plugins/scene_graph_introspection.cpp
-    ${TEST_FIXTURE_SOURCES}
-  )
-
-  set(TEST_FIXTURE_LIBRARIES
-    rviz_ogre_vendor::OgreMain
-    rviz_rendering::rviz_rendering
   )
 
   set(TEST_FIXTURE_WITH_MOCK_LIBRARIES
-    ${TEST_FIXTURE_LIBRARIES}
     rclcpp::rclcpp
     rviz_common::rviz_common
+    rviz_ogre_vendor::OgreMain
+    ogre_testing_environment
   )
 
   ament_add_gmock(fps_view_controller_test
@@ -351,8 +345,13 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET fps_view_controller_test)
-    target_include_directories(fps_view_controller_test PRIVATE test)
-    target_link_libraries(fps_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins Qt5::Widgets)
+    target_include_directories(fps_view_controller_test PRIVATE ${TEST_INCLUDE_DIRS})
+    target_link_libraries(fps_view_controller_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      rviz_default_plugins
+      Qt5::Widgets
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gmock(frame_info_test
@@ -361,7 +360,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET frame_info_test)
     target_include_directories(frame_info_test PRIVATE test)
-    target_link_libraries(frame_info_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(frame_info_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(get_transport_from_topic_test
@@ -369,7 +368,7 @@ if(BUILD_TESTING)
     ${TEST_FIXTURE_SOURCES_WITH_MOCK})
   if(TARGET get_transport_from_topic_test)
     target_include_directories(get_transport_from_topic_test PRIVATE test)
-    target_link_libraries(get_transport_from_topic_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(get_transport_from_topic_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(grid_cells_display_test
@@ -378,7 +377,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET grid_cells_display_test)
     target_include_directories(grid_cells_display_test PRIVATE test)
-    target_link_libraries(grid_cells_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(grid_cells_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(image_display_test
@@ -387,7 +386,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET image_display_test)
     target_include_directories(image_display_test PRIVATE test)
-    target_link_libraries(image_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
+    target_link_libraries(image_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins ogre_testing_environment)
   endif()
 
   add_library(marker_messages STATIC test/rviz_default_plugins/displays/marker/marker_messages.cpp)
@@ -417,6 +416,7 @@ if(BUILD_TESTING)
       rviz_default_plugins
       marker_messages
       ${visualization_msgs_TARGETS}
+      ogre_testing_environment
     )
   endif()
 
@@ -431,6 +431,7 @@ if(BUILD_TESTING)
       ${visualization_msgs_TARGETS}
       rviz_default_plugins
       marker_messages
+      ogre_testing_environment
     )
   endif()
 
@@ -440,7 +441,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET map_display_test)
     target_include_directories(map_display_test PRIVATE test)
-    target_link_libraries(map_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(map_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(measure_tool_test
@@ -449,7 +450,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET measure_tool_test)
     target_include_directories(measure_tool_test PRIVATE test)
-    target_link_libraries(measure_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(measure_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(odometry_display_test
@@ -458,7 +459,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_display_test)
     target_include_directories(odometry_display_test PRIVATE test)
-    target_link_libraries(odometry_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(odometry_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(odometry_ogre_helper_test
@@ -467,7 +468,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET odometry_ogre_helper_test)
     target_include_directories(odometry_ogre_helper_test PRIVATE test)
-    target_link_libraries(odometry_ogre_helper_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES})
+    target_link_libraries(odometry_ogre_helper_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ogre_testing_environment)
   endif()
 
   ament_add_gmock(orbit_view_controller_test
@@ -476,7 +477,12 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET orbit_view_controller_test)
     target_include_directories(orbit_view_controller_test PRIVATE test)
-    target_link_libraries(orbit_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
+    target_link_libraries(orbit_view_controller_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      Qt5::Widgets
+      rviz_default_plugins
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gmock(ortho_view_controller_test
@@ -485,7 +491,12 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ortho_view_controller_test)
     target_include_directories(ortho_view_controller_test PRIVATE test)
-    target_link_libraries(ortho_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
+    target_link_libraries(ortho_view_controller_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      Qt5::Widgets
+      rviz_default_plugins
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gmock(palette_builder_test
@@ -494,7 +505,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET palette_builder_test)
     target_include_directories(palette_builder_test PRIVATE test)
-    target_link_libraries(palette_builder_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(palette_builder_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(path_display_test
@@ -503,7 +514,12 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET path_display_test)
     target_include_directories(path_display_test PRIVATE test)
-    target_link_libraries(path_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${visualization_msgs_TARGETS} rviz_default_plugins)
+    target_link_libraries(path_display_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      ${visualization_msgs_TARGETS}
+      rviz_default_plugins
+      ogre_testing_environment
+    )
   endif()
 
   add_library(pointcloud_messages STATIC test/rviz_default_plugins/pointcloud_messages.cpp)
@@ -525,6 +541,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
       pointcloud_messages
+      ogre_testing_environment
     )
   endif()
 
@@ -538,6 +555,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
       pointcloud_messages
+      ogre_testing_environment
     )
   endif()
 
@@ -547,7 +565,12 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_scalar_display_test)
     target_include_directories(point_cloud_scalar_display_test PRIVATE test)
-    target_link_libraries(point_cloud_scalar_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ${sensor_msgs_TARGETS})
+    target_link_libraries(point_cloud_scalar_display_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      rviz_default_plugins
+      ${sensor_msgs_TARGETS}
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gmock(point_cloud_transformers_test
@@ -566,6 +589,7 @@ if(BUILD_TESTING)
       Qt5::Widgets
       rviz_default_plugins
       pointcloud_messages
+      ogre_testing_environment
     )
   endif()
 
@@ -575,7 +599,12 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_display_test)
     target_include_directories(point_display_test PRIVATE test)
-    target_link_libraries(point_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${geometry_msgs_TARGETS} rviz_default_plugins)
+    target_link_libraries(point_display_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      ${geometry_msgs_TARGETS}
+      rviz_default_plugins
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gmock(pose_array_display_test
@@ -584,7 +613,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_array_display_test)
     target_include_directories(pose_array_display_test PRIVATE test)
-    target_link_libraries(pose_array_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(pose_array_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(pose_tool_test
@@ -593,7 +622,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET pose_tool_test)
     target_include_directories(pose_tool_test PRIVATE test)
-    target_link_libraries(pose_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(pose_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(range_display_test
@@ -602,7 +631,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET range_display_test)
     target_include_directories(range_display_test PRIVATE test)
-    target_link_libraries(range_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(range_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(robot_test
@@ -616,6 +645,7 @@ if(BUILD_TESTING)
       resource_retriever::resource_retriever
       Qt5::Widgets
       rviz_default_plugins
+      ogre_testing_environment
     )
   endif()
 
@@ -625,7 +655,12 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET ros_image_texture_test)
     target_include_directories(ros_image_texture_test PRIVATE test)
-    target_link_libraries(ros_image_texture_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${sensor_msgs_TARGETS} rviz_default_plugins)
+    target_link_libraries(ros_image_texture_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      ${sensor_msgs_TARGETS}
+      rviz_default_plugins
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gmock(selection_tool_test
@@ -634,7 +669,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET selection_tool_test)
     target_include_directories(selection_tool_test PRIVATE test)
-    target_link_libraries(selection_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins)
+    target_link_libraries(selection_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
   endif()
 
   ament_add_gmock(xy_orbit_view_controller_test
@@ -643,7 +678,12 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET xy_orbit_view_controller_test)
     target_include_directories(xy_orbit_view_controller_test PRIVATE test)
-    target_link_libraries(xy_orbit_view_controller_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins)
+    target_link_libraries(xy_orbit_view_controller_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      Qt5::Widgets
+      rviz_default_plugins
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gmock(frame_transformer_tf_test
@@ -657,6 +697,7 @@ if(BUILD_TESTING)
       tf2_ros::tf2_ros
       ${geometry_msgs_TARGETS}
       rviz_default_plugins
+      ogre_testing_environment
     )
   endif()
 
@@ -666,18 +707,25 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET transformer_guard_test)
     target_include_directories(transformer_guard_test PRIVATE test)
-    target_link_libraries(transformer_guard_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} tf2_ros::tf2_ros rviz_default_plugins)
+    target_link_libraries(transformer_guard_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      tf2_ros::tf2_ros
+      rviz_default_plugins
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gtest(axes_display_visual_test
     test/rviz_default_plugins/displays/axes/axes_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/axes_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET axes_display_visual_test)
     target_include_directories(axes_display_visual_test PRIVATE test)
-    target_link_libraries(axes_display_visual_test ${TEST_FIXTURE_LIBRARIES} rviz_visual_testing_framework::rviz_visual_testing_framework)
+    target_link_libraries(axes_display_visual_test
+      rviz_visual_testing_framework::rviz_visual_testing_framework
+      ogre_testing_environment
+    )
   endif()
 
   add_library(point_cloud_common_page_object STATIC test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp)
@@ -686,13 +734,11 @@ if(BUILD_TESTING)
   ament_add_gtest(camera_display_visual_test
     test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET camera_display_visual_test)
     target_include_directories(camera_display_visual_test PRIVATE test)
     target_link_libraries(camera_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       rclcpp::rclcpp
       ${sensor_msgs_TARGETS}
@@ -706,13 +752,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET fluid_pressure_display_visual_test)
     target_include_directories(fluid_pressure_display_visual_test PRIVATE test)
     target_link_libraries(fluid_pressure_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Test
       rclcpp::rclcpp
@@ -724,13 +768,11 @@ if(BUILD_TESTING)
   ament_add_gtest(grid_display_visual_test
     test/rviz_default_plugins/displays/grid/grid_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/grid_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_display_visual_test)
     target_include_directories(grid_display_visual_test PRIVATE test)
     target_link_libraries(grid_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
     )
@@ -739,13 +781,11 @@ if(BUILD_TESTING)
   ament_add_gtest(grid_cells_display_visual_test
     test/rviz_default_plugins/displays/grid_cells/grid_cells_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/grid_cells_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET grid_cells_display_visual_test)
     target_include_directories(grid_cells_display_visual_test PRIVATE test)
     target_link_libraries(grid_cells_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       ${nav_msgs_TARGETS}
     )
@@ -753,13 +793,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET illuminance_display_visual_test)
     target_include_directories(illuminance_display_visual_test PRIVATE test)
     target_link_libraries(illuminance_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       pointcloud_messages
@@ -770,13 +808,11 @@ if(BUILD_TESTING)
   ament_add_gtest(image_display_visual_test
     test/rviz_default_plugins/displays/image/image_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/image_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET image_display_visual_test)
     target_include_directories(image_display_visual_test PRIVATE test)
     target_link_libraries(image_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       rclcpp::rclcpp
@@ -787,21 +823,24 @@ if(BUILD_TESTING)
 
   ament_add_gtest(interactive_marker_namespace_property_test
     test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp
-    ${TEST_FIXTURE_SOURCES})
+    ${SKIP_VISUAL_TESTS}
+    TIMEOUT 180)
   if(TARGET interactive_marker_namespace_property_test)
     target_include_directories(interactive_marker_namespace_property_test PRIVATE test)
-    target_link_libraries(interactive_marker_namespace_property_test ${TEST_FIXTURE_LIBRARIES} rviz_default_plugins Qt5::Widgets)
+    target_link_libraries(interactive_marker_namespace_property_test
+      rviz_default_plugins
+      Qt5::Widgets
+      ogre_testing_environment
+    )
   endif()
 
   ament_add_gtest(laser_scan_display_visual_test
     test/rviz_default_plugins/displays/laser_scan/laser_scan_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET laser_scan_display_visual_test)
     target_include_directories(laser_scan_display_visual_test PRIVATE test)
     target_link_libraries(laser_scan_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Test
       point_cloud_common_page_object
@@ -814,13 +853,11 @@ if(BUILD_TESTING)
   ament_add_gtest(map_display_visual_test
     test/rviz_default_plugins/displays/map/map_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/map_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET map_display_visual_test)
     target_include_directories(map_display_visual_test PRIVATE test)
     target_link_libraries(map_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       rclcpp::rclcpp
@@ -835,13 +872,11 @@ if(BUILD_TESTING)
   ament_add_gtest(marker_array_display_visual_test
     test/rviz_default_plugins/displays/marker_array/marker_array_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/marker_array_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_array_display_visual_test)
     target_include_directories(marker_array_display_visual_test PRIVATE test)
     target_link_libraries(marker_array_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       rclcpp::rclcpp
@@ -853,13 +888,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(marker_display_visual_test
     test/rviz_default_plugins/displays/marker/marker_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET marker_display_visual_test)
     target_include_directories(marker_display_visual_test PRIVATE test)
     target_link_libraries(marker_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       rclcpp::rclcpp
@@ -872,13 +905,11 @@ if(BUILD_TESTING)
   ament_add_gtest(odometry_display_visual_test
     test/rviz_default_plugins/displays/odometry/odometry_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/odometry_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET odometry_display_visual_test)
     target_include_directories(odometry_display_visual_test PRIVATE test)
     target_link_libraries(odometry_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       rclcpp::rclcpp
@@ -892,13 +923,11 @@ if(BUILD_TESTING)
   ament_add_gtest(path_display_visual_test
     test/rviz_default_plugins/displays/path/path_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/path_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET path_display_visual_test)
     target_include_directories(path_display_visual_test PRIVATE test)
     target_link_libraries(path_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       rclcpp::rclcpp
@@ -911,13 +940,11 @@ if(BUILD_TESTING)
   ament_add_gtest(point_display_visual_test
     test/rviz_default_plugins/displays/point/point_stamped_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_display_visual_test)
     target_include_directories(point_display_visual_test PRIVATE test)
     target_link_libraries(point_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       ${geometry_msgs_TARGETS}
@@ -928,13 +955,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(point_cloud_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud_display_visual_test)
     target_include_directories(point_cloud_display_visual_test PRIVATE test)
     target_link_libraries(point_cloud_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       ${geometry_msgs_TARGETS}
@@ -948,13 +973,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET point_cloud2_display_visual_test)
     target_include_directories(point_cloud2_display_visual_test PRIVATE test)
     target_link_libraries(point_cloud2_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       pointcloud_messages
@@ -968,13 +991,11 @@ if(BUILD_TESTING)
   ament_add_gtest(pose_array_display_visual_test
     test/rviz_default_plugins/displays/pose_array/pose_array_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_array_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_array_display_visual_test)
     target_include_directories(pose_array_display_visual_test PRIVATE test)
     target_link_libraries(pose_array_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       rclcpp::rclcpp
@@ -986,13 +1007,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(pose_display_visual_test
     test/rviz_default_plugins/displays/pose/pose_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_display_visual_test)
     target_include_directories(pose_display_visual_test PRIVATE test)
     target_link_libraries(pose_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       ${geometry_msgs_TARGETS}
@@ -1005,13 +1024,11 @@ if(BUILD_TESTING)
   ament_add_gtest(pose_with_covariance_display_visual_test
     test/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET pose_with_covariance_display_visual_test)
     target_include_directories(pose_with_covariance_display_visual_test PRIVATE test)
     target_link_libraries(pose_with_covariance_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
       ${geometry_msgs_TARGETS}
@@ -1024,13 +1041,11 @@ if(BUILD_TESTING)
   ament_add_gtest(range_display_visual_test
     test/rviz_default_plugins/displays/range/range_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/range_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET range_display_visual_test)
     target_include_directories(range_display_visual_test PRIVATE test)
     target_link_libraries(range_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
     )
@@ -1038,13 +1053,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET relative_humidity_display_visual_test)
     target_include_directories(relative_humidity_display_visual_test PRIVATE test)
     target_link_libraries(relative_humidity_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       point_cloud_common_page_object
@@ -1054,13 +1067,11 @@ if(BUILD_TESTING)
   ament_add_gtest(robot_model_display_visual_test
     test/rviz_default_plugins/displays/robot_model/robot_model_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/robot_model_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET robot_model_display_visual_test)
     target_include_directories(robot_model_display_visual_test PRIVATE test)
     target_link_libraries(robot_model_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       ament_index_cpp::ament_index_cpp
       rviz_visual_testing_framework::rviz_visual_testing_framework
     )
@@ -1068,13 +1079,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET temperature_display_visual_test)
     target_include_directories(temperature_display_visual_test PRIVATE test)
     target_link_libraries(temperature_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       point_cloud_common_page_object
@@ -1084,13 +1093,11 @@ if(BUILD_TESTING)
   ament_add_gtest(tf_display_visual_test
     test/rviz_default_plugins/displays/tf/tf_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/tf_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET tf_display_visual_test)
     target_include_directories(tf_display_visual_test PRIVATE test)
     target_link_libraries(tf_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
     )
@@ -1099,13 +1106,11 @@ if(BUILD_TESTING)
   ament_add_gtest(wrench_display_visual_test
     test/rviz_default_plugins/displays/wrench/wrench_stamped_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/wrench_display_page_object.cpp
-    ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
   if(TARGET wrench_display_visual_test)
     target_include_directories(wrench_display_visual_test PRIVATE test)
     target_link_libraries(wrench_display_visual_test
-      ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Widgets
     )

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -711,6 +711,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(camera_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -729,6 +730,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(fluid_pressure_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -744,6 +746,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(grid_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -777,6 +780,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(illuminance_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -793,6 +797,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(image_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -821,6 +826,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(laser_scan_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -904,6 +910,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(path_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -937,6 +944,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -955,6 +963,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(point_cloud2_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -1037,6 +1046,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(relative_humidity_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
@@ -1071,6 +1081,7 @@ if(BUILD_TESTING)
       ${rviz_visual_testing_framework_INCLUDE_DIRS})
     target_link_libraries(temperature_display_visual_test
       ${TEST_LINK_LIBRARIES}
+      Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -962,10 +962,12 @@ if(BUILD_TESTING)
     )
   endif()
 
+  add_library(pose_display_page_object STATIC test/rviz_default_plugins/page_objects/pose_display_page_object.cpp)
+  target_link_libraries(pose_display_page_object PRIVATE Qt5::Widgets rviz_visual_testing_framework::rviz_visual_testing_framework)
+
   ament_add_gtest(pose_array_display_visual_test
     test/rviz_default_plugins/displays/pose_array/pose_array_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/pose_array_display_page_object.cpp
-    test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -978,12 +980,12 @@ if(BUILD_TESTING)
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${geometry_msgs_TARGETS}
+      pose_display_page_object
     )
   endif()
 
   ament_add_gtest(pose_display_visual_test
     test/rviz_default_plugins/displays/pose/pose_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -996,6 +998,7 @@ if(BUILD_TESTING)
       ${geometry_msgs_TARGETS}
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
+      pose_display_page_object
     )
   endif()
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -506,9 +506,17 @@ if(BUILD_TESTING)
     target_link_libraries(path_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ${visualization_msgs_TARGETS} rviz_default_plugins)
   endif()
 
+  add_library(pointcloud_messages STATIC test/rviz_default_plugins/pointcloud_messages.cpp)
+  target_link_libraries(pointcloud_messages PRIVATE
+    ${sensor_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    rclcpp::rclcpp
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+  )
+
   ament_add_gmock(point_cloud2_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud2_display_test)
@@ -516,15 +524,12 @@ if(BUILD_TESTING)
     target_link_libraries(point_cloud2_display_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
-      ${geometry_msgs_TARGETS}
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
+      pointcloud_messages
     )
   endif()
 
   ament_add_gmock(point_cloud_common_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES_WITH_MOCK}
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_common_test)
@@ -532,9 +537,7 @@ if(BUILD_TESTING)
     target_link_libraries(point_cloud_common_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
-      ${geometry_msgs_TARGETS}
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
+      pointcloud_messages
     )
   endif()
 
@@ -548,7 +551,6 @@ if(BUILD_TESTING)
   endif()
 
   ament_add_gmock(point_cloud_transformers_test
-    test/rviz_default_plugins/pointcloud_messages.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
@@ -563,9 +565,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       Qt5::Widgets
       rviz_default_plugins
-      ${geometry_msgs_TARGETS}
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
+      pointcloud_messages
     )
   endif()
 
@@ -704,7 +704,6 @@ if(BUILD_TESTING)
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -715,9 +714,7 @@ if(BUILD_TESTING)
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Test
       rclcpp::rclcpp
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
-      ${geometry_msgs_TARGETS}
+      pointcloud_messages
     )
   endif()
 
@@ -754,7 +751,6 @@ if(BUILD_TESTING)
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -764,10 +760,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      ${geometry_msgs_TARGETS}
-      rclcpp::rclcpp
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
+      pointcloud_messages
     )
   endif()
 
@@ -950,7 +943,6 @@ if(BUILD_TESTING)
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -960,10 +952,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      ${geometry_msgs_TARGETS}
-      rclcpp::rclcpp
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
+      pointcloud_messages
     )
   endif()
 
@@ -1041,7 +1030,6 @@ if(BUILD_TESTING)
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -1051,10 +1039,6 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      ${geometry_msgs_TARGETS}
-      rclcpp::rclcpp
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
     )
   endif()
 
@@ -1076,7 +1060,6 @@ if(BUILD_TESTING)
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
-    test/rviz_default_plugins/pointcloud_messages.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -1086,10 +1069,6 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      ${geometry_msgs_TARGETS}
-      rclcpp::rclcpp
-      ${sensor_msgs_TARGETS}
-      ${std_msgs_TARGETS}
     )
   endif()
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -680,10 +680,12 @@ if(BUILD_TESTING)
     target_link_libraries(axes_display_visual_test ${TEST_FIXTURE_LIBRARIES} rviz_visual_testing_framework::rviz_visual_testing_framework)
   endif()
 
+  add_library(point_cloud_common_page_object STATIC test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp)
+  target_link_libraries(point_cloud_common_page_object PRIVATE Qt5::Test rviz_visual_testing_framework::rviz_visual_testing_framework)
+
   ament_add_gtest(camera_display_visual_test
     test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -698,12 +700,12 @@ if(BUILD_TESTING)
       Qt5::Test
       ${geometry_msgs_TARGETS}
       tf2::tf2
+      point_cloud_common_page_object
     )
   endif()
 
   ament_add_gtest(fluid_pressure_display_visual_test
     test/rviz_default_plugins/displays/fluid_pressure/fluid_pressure_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -715,6 +717,7 @@ if(BUILD_TESTING)
       Qt5::Test
       rclcpp::rclcpp
       pointcloud_messages
+      point_cloud_common_page_object
     )
   endif()
 
@@ -750,7 +753,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(illuminance_display_visual_test
     test/rviz_default_plugins/displays/illuminance/illuminance_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -761,6 +763,7 @@ if(BUILD_TESTING)
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       pointcloud_messages
+      point_cloud_common_page_object
     )
   endif()
 
@@ -792,7 +795,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(laser_scan_display_visual_test
     test/rviz_default_plugins/displays/laser_scan/laser_scan_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -802,6 +804,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_LIBRARIES}
       rviz_visual_testing_framework::rviz_visual_testing_framework
       Qt5::Test
+      point_cloud_common_page_object
     )
   endif()
 
@@ -922,7 +925,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(point_cloud_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -937,12 +939,12 @@ if(BUILD_TESTING)
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${sensor_msgs_TARGETS}
+      point_cloud_common_page_object
     )
   endif()
 
   ament_add_gtest(point_cloud2_display_visual_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -953,6 +955,7 @@ if(BUILD_TESTING)
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       pointcloud_messages
+      point_cloud_common_page_object
     )
   endif()
 
@@ -1029,7 +1032,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(relative_humidity_display_visual_test
     test/rviz_default_plugins/displays/relative_humidity/relative_humidity_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -1039,6 +1041,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
+      point_cloud_common_page_object
     )
   endif()
 
@@ -1059,7 +1062,6 @@ if(BUILD_TESTING)
 
   ament_add_gtest(temperature_display_visual_test
     test/rviz_default_plugins/displays/temperature/temperature_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -1069,6 +1071,7 @@ if(BUILD_TESTING)
       ${TEST_FIXTURE_LIBRARIES}
       Qt5::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
+      point_cloud_common_page_object
     )
   endif()
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -808,10 +808,12 @@ if(BUILD_TESTING)
     )
   endif()
 
+  add_library(marker_display_page_object STATIC test/rviz_default_plugins/page_objects/marker_display_page_object.cpp)
+  target_link_libraries(marker_display_page_object PRIVATE Qt5::Widgets rviz_visual_testing_framework::rviz_visual_testing_framework)
+
   ament_add_gtest(map_display_visual_test
     test/rviz_default_plugins/displays/map/map_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/map_display_page_object.cpp
-    test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -826,13 +828,13 @@ if(BUILD_TESTING)
       ${geometry_msgs_TARGETS}
       ${nav_msgs_TARGETS}
       ${visualization_msgs_TARGETS}
+      marker_display_page_object
     )
   endif()
 
   ament_add_gtest(marker_array_display_visual_test
     test/rviz_default_plugins/displays/marker_array/marker_array_display_visual_test.cpp
     test/rviz_default_plugins/page_objects/marker_array_display_page_object.cpp
-    test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -845,12 +847,12 @@ if(BUILD_TESTING)
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${visualization_msgs_TARGETS}
+      marker_display_page_object
     )
   endif()
 
   ament_add_gtest(marker_display_visual_test
     test/rviz_default_plugins/displays/marker/marker_display_visual_test.cpp
-    test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
     ${TEST_FIXTURE_SOURCES}
     ${SKIP_VISUAL_TESTS}
     TIMEOUT 180)
@@ -863,6 +865,7 @@ if(BUILD_TESTING)
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${visualization_msgs_TARGETS}
+      marker_display_page_object
     )
   endif()
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/display_test_fixture.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/display_test_fixture.cpp
@@ -35,6 +35,8 @@
 
 #include <OgreSceneNode.h>
 
+#include "rclcpp/clock.hpp"
+
 void DisplayTestFixture::SetUpTestCase()
 {
   testing_environment_ = std::make_shared<rviz_default_plugins::OgreTestingEnvironment>();

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property_test.cpp
@@ -31,6 +31,8 @@
 
 #include <gtest/gtest.h>
 
+#include <QString>
+
 #include \
   "rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_messages.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_messages.cpp
@@ -36,7 +36,11 @@
 
 #include <OgreVector.h>
 
+#include "geometry_msgs/msg/point.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/color_rgba.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "visualization_msgs/msg/marker.hpp"
 
 namespace testing
 {

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_messages.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_messages.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKER_MESSAGES_HPP_
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__MARKER__MARKER_MESSAGES_HPP_
 
+#include "geometry_msgs/msg/point.hpp"
+#include "std_msgs/msg/color_rgba.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 
 namespace testing

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/map_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/map_display_page_object.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QString>
+
 #include "map_display_page_object.hpp"
 
 MapDisplayPageObject::MapDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/marker_display_page_object.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QString>
+
 #include "marker_display_page_object.hpp"
 
 MarkerDisplayPageObject::MarkerDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/marker_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/marker_display_page_object.hpp
@@ -30,6 +30,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__MARKER_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__MARKER_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class MarkerDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_cloud_common_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_cloud_common_page_object.hpp
@@ -30,6 +30,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POINT_CLOUD_COMMON_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POINT_CLOUD_COMMON_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class PointCloudCommonPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
@@ -29,6 +29,8 @@
 
 #include "pose_display_page_object.hpp"
 
+#include <QString>
+
 #include <memory>
 #include <vector>
 

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_display_page_object.hpp
@@ -30,6 +30,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POSE_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POSE_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class PoseDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.cpp
@@ -28,6 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QString>
+
 #include "pose_with_covariance_display_page_object.hpp"
 
 PoseWithCovarianceDisplayPageObject::PoseWithCovarianceDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/range_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/range_display_page_object.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QString>
+
 #include "range_display_page_object.hpp"
 
 RangeDisplayPageObject::RangeDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/robot_model_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/robot_model_display_page_object.cpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <QString>
+
 #include "robot_model_display_page_object.hpp"
 
 RobotModelDisplayPageObject::RobotModelDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/tf_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/tf_display_page_object.cpp
@@ -29,6 +29,8 @@
 
 #include "tf_display_page_object.hpp"
 
+#include <QString>
+
 #include <memory>
 #include <vector>
 

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/wrench_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/wrench_display_page_object.cpp
@@ -29,6 +29,8 @@
 
 #include "wrench_display_page_object.hpp"
 
+#include <QString>
+
 #include <memory>
 #include <vector>
 

--- a/rviz_default_plugins/test/rviz_default_plugins/pointcloud_messages.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/pointcloud_messages.cpp
@@ -33,7 +33,11 @@
 #include <memory>
 #include <vector>
 
+#include "geometry_msgs/msg/point32.hpp"
 #include "rclcpp/clock.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "sensor_msgs/msg/point_field.hpp"
+#include "std_msgs/msg/header.hpp"
 
 namespace rviz_default_plugins
 {

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_array_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_array_publisher.hpp
@@ -35,6 +35,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
+#include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_array.hpp"
 
 using namespace std::chrono_literals;  // NOLINT

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rviz_rendering)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rviz_rendering)
 
-# Default to C++17
+# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rviz_rendering_tests)
 
-# Default to C++17
+# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rviz_rendering_tests)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -24,46 +24,19 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-
-find_package(rcutils REQUIRED)
-
-find_package(rviz_common REQUIRED)
-
-find_package(rviz_ogre_vendor REQUIRED)
-
+find_package(geometry_msgs REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
+find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(rviz_common REQUIRED)
+find_package(rviz_ogre_vendor REQUIRED)
+find_package(rviz_rendering REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 find_package(ament_cmake_gtest REQUIRED)
 ament_find_gtest()
-
-set(visual_test_framework_source_files
-  include/rviz_visual_testing_framework/page_objects/base_page_object.hpp
-  src/page_objects/base_page_object.cpp
-  include/rviz_visual_testing_framework/page_objects/page_object_with_window.hpp
-  src/page_objects/page_object_with_window.cpp
-  src/internal/rviz_scene_test.cpp
-  include/rviz_visual_testing_framework/internal/rviz_scene_test.hpp
-  include/rviz_visual_testing_framework/internal/display_handler.hpp
-  src/internal/display_handler.cpp
-  src/internal/image_tester.cpp
-  include/rviz_visual_testing_framework/internal/image_tester.hpp
-  include/rviz_visual_testing_framework/test_helpers.hpp
-  src/test_helpers.cpp
-  include/rviz_visual_testing_framework/internal/executor.hpp
-  src/internal/executor.cpp
-  include/rviz_visual_testing_framework/internal/transform_message_creator.hpp
-  src/internal/transform_message_creator.cpp
-  include/rviz_visual_testing_framework/internal/visual_test.hpp
-  src/internal/visual_test.cpp
-  include/rviz_visual_testing_framework/visual_test_fixture.hpp
-  src/visual_test_fixture.cpp
-  include/rviz_visual_testing_framework/visual_test_publisher.hpp
-)
-
-set(visual_tests_target_libaries
-  rviz_common::rviz_common
-  Qt5::Widgets
-  Qt5::Test)
 
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
 if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
@@ -77,7 +50,18 @@ if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
   )
 endif()
 
-add_library(rviz_visual_testing_framework STATIC ${visual_test_framework_source_files})
+add_library(rviz_visual_testing_framework STATIC
+  src/page_objects/base_page_object.cpp
+  src/page_objects/page_object_with_window.cpp
+  src/internal/rviz_scene_test.cpp
+  src/internal/display_handler.cpp
+  src/internal/image_tester.cpp
+  src/test_helpers.cpp
+  src/internal/executor.cpp
+  src/internal/transform_message_creator.cpp
+  src/internal/visual_test.cpp
+  src/visual_test_fixture.cpp
+)
 
 target_include_directories(rviz_visual_testing_framework
   PUBLIC
@@ -85,12 +69,22 @@ target_include_directories(rviz_visual_testing_framework
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
     ${GTEST_INCLUDE_DIRS})
 
-target_link_libraries(rviz_visual_testing_framework
-  ${visual_tests_target_libaries})
+target_link_libraries(rviz_visual_testing_framework PUBLIC
+  ${geometry_msgs_TARGETS}
+  Qt5::Test
+  Qt5::Widgets
+  rclcpp::rclcpp
+  rcutils::rcutils
+  rviz_common::rviz_common
+  rviz_ogre_vendor::OgreMain
+  rviz_rendering::rviz_rendering
+  ${std_msgs_TARGETS}
+  tf2::tf2
+  tf2_ros::tf2_ros
+)
 
 # export information to downstream packages
-ament_export_dependencies(Qt5)
-ament_export_dependencies(rviz_common)
+ament_export_dependencies(geometry_msgs Qt5 rclcpp rcutils rviz_common rviz_ogre_vendor rviz_rendering std_msgs tf2 tf2_ros)
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")

--- a/rviz_visual_testing_framework/package.xml
+++ b/rviz_visual_testing_framework/package.xml
@@ -26,8 +26,15 @@
 
   <build_depend>qtbase5-dev</build_depend>
 
+  <depend>geometry_msgs</depend>
+  <depend>rclcpp</depend>
   <depend>rcutils</depend>
   <depend>rviz_common</depend>
+  <depend>rviz_ogre_vendor</depend>
+  <depend>rviz_rendering</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>ament_cmake_gtest</depend>
 
   <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->


### PR DESCRIPTION
The main goal of this PR is to improve the compilation time of rviz_default_plugins.  To do that, there are a number of patches in here which do quite a bit of cleanup.  The most important to mention are:

1.  Cleaning up the rviz_visual_testing_framework package to be a more complete package, exporting all dependencies correctly.
2.  Switching rviz_default_plugins to use `target_link_libraries` instead of `ament_target_dependencies`.
3.  Switch the rviz_default_plugins tests to use libraries where possible (while avoiding the ODR problems of the past).

The net result of all of this is that in my local testing, compilation time is now 12% better.  That doesn't seem like a huge percentage gain, but it is 40 seconds faster locally.  If that percentage maintains on the buildfarm, then this will be several minutes faster on Windows.