### PR TITLE
Stop inheriting from std::iterator.

### DIFF
--- a/rviz_common/include/rviz_common/interaction/handler_manager_iface.hpp
+++ b/rviz_common/include/rviz_common/interaction/handler_manager_iface.hpp
@@ -59,9 +59,15 @@ using M_ObjectHandleToSelectionHandler =
 class RVIZ_COMMON_PUBLIC HandlerRange
 {
 public:
-  class iterator : public std::iterator<std::forward_iterator_tag, SelectionHandlerWeakPtr>
+  class iterator
   {
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = SelectionHandlerWeakPtr;
+    using difference_type = std::ptrdiff_t;
+    using pointer = SelectionHandlerWeakPtr *;
+    using reference = SelectionHandlerWeakPtr &;
+
     // TODO(anhosi) uncrustify does not handle this identation correctly
     reference operator*() const
     {


### PR DESCRIPTION
In C++17, inheriting from std::iterator has been
deprecated: https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/

Here, switch away from inheriting and just define the interface ourselves (which is the current recommended best practice).

This removes some warnings when building with gcc 13.1.1