### PR TITLE
Don't pass screw_display.hpp to the moc generator.

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -113,7 +113,6 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/displays/range/range_display.hpp
   include/rviz_default_plugins/displays/relative_humidity/relative_humidity_display.hpp
   include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
-  include/rviz_default_plugins/displays/screw/screw_display.hpp
   include/rviz_default_plugins/displays/temperature/temperature_display.hpp
   include/rviz_default_plugins/displays/tf/frame_info.hpp
   include/rviz_default_plugins/displays/tf/tf_display.hpp


### PR DESCRIPTION
Since it isn't a Qt class, you get a warning from moc:

Note: No relevant classes found. No output generated.

Just skip adding it to the moc list here, which gets rid of the warning.