### PR TITLE
call propertyHiddenChanged synchronously

### DIFF
--- a/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
@@ -101,7 +101,7 @@ void PropertyTreeWidget::setModel(PropertyTreeModel * model)
   if (model_) {
     connect(
       model_, SIGNAL(propertyHiddenChanged(const Property*)),
-      this, SLOT(propertyHiddenChanged(const Property*)), Qt::QueuedConnection);
+      this, SLOT(propertyHiddenChanged(const Property*)));
     connect(
       model_, SIGNAL(expand(const QModelIndex&)),
       this, SLOT(expand(const QModelIndex&)));


### PR DESCRIPTION
Related with this PR https://github.com/ros-visualization/rviz/pull/1795

Property might no longer exist when event is triggered

