### PR TITLE
Remove unused LineEditWithButton::simulateReturnPressed()

### DIFF
--- a/rviz_common/include/rviz_common/properties/line_edit_with_button.hpp
+++ b/rviz_common/include/rviz_common/properties/line_edit_with_button.hpp
@@ -57,11 +57,6 @@ public:
 protected:
   virtual void resizeEvent(QResizeEvent * event);
 
-  /** @brief Send key events to mimic the "return" key being pressed and
-   * released.  Useful ending an edit session and sending the data on
-   * out. */
-  void simulateReturnPressed();
-
 protected Q_SLOTS:
   /** @brief Override this to do something when the button is clicked. */
   virtual void onButtonClick() {}

--- a/rviz_common/src/rviz_common/properties/line_edit_with_button.cpp
+++ b/rviz_common/src/rviz_common/properties/line_edit_with_button.cpp
@@ -76,21 +76,5 @@ void LineEditWithButton::resizeEvent(QResizeEvent * event)
     width() - button_width - padding, padding,
     button_width, button_height);
 }
-
-void LineEditWithButton::simulateReturnPressed()
-{
-  // I couldn't find a way to directly tell the editor that I was
-  // done with it here.  "Q_EMIT returnPressed()", "Q_EMIT
-  // editingFinished()" etc did nothing.  So instead, here I
-  // simulate the user pressing and releasing the "Return" key,
-  // which does indeed make it act like I want: when you select a
-  // topic from the dialog and the dialog closes, the property's
-  // Setter is called and this editor closes.
-  QKeyEvent * event = new QKeyEvent(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
-  QApplication::postEvent(this, event);
-  event = new QKeyEvent(QEvent::KeyRelease, Qt::Key_Return, Qt::NoModifier);
-  QApplication::postEvent(this, event);
-}
-
 }  // namespace properties
 }  // namespace rviz_common


### PR DESCRIPTION
Related with this PR https://github.com/ros-visualization/rviz/pull/1608 in RViz for ROS 1