### PR TITLE
Fix to render window flash problem after resizing (in python environment only)

### DIFF
--- a/rviz_rendering/include/rviz_rendering/render_window.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_window.hpp
@@ -139,9 +139,6 @@ protected:
   // void
   // mouseReleaseEvent(QMouseEvent * mouse_event) override;
 
-  void
-  exposeEvent(QExposeEvent * expose_event) override;
-
   bool
   event(QEvent * event) override;
 

--- a/rviz_rendering/src/rviz_rendering/render_window.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window.cpp
@@ -157,9 +157,7 @@ RenderWindow::event(QEvent * event)
 {
   switch (event->type()) {
     case QEvent::Resize:
-      if (this->isExposed()) {
-        impl_->resize(this->width(), this->height());
-      }
+      impl_->resize(this->width(), this->height());
       return QWindow::event(event);
     case QEvent::UpdateRequest:
       this->renderNow();
@@ -181,18 +179,6 @@ RenderWindow::event(QEvent * event)
       return false;
   }
 }
-
-void
-RenderWindow::exposeEvent(QExposeEvent * expose_event)
-{
-  Q_UNUSED(expose_event);
-
-  if (this->isExposed()) {
-    impl_->resize(this->width(), this->height());
-    this->renderNow();
-  }
-}
-
 
 void
 RenderWindowOgreAdapter::setOgreCamera(RenderWindow * render_window, Ogre::Camera * ogre_camera)


### PR DESCRIPTION
This fix is a prelude of VisualizationFrame python API (https://github.com/ros2/rviz/issues/640)

The code related to `render_window` expose event was dated back near the beginning of rviz2:
1. Introduction of `exposeEvent()` (https://github.com/ros2/rviz/commit/2ca8c2caf53288e0aae4c034b124dda2aaf299ee)
2. Introduce resize event but with isExposed() condition (https://github.com/ros2/rviz/commit/07054d19ec585cd6982b65973944ef6516af45fc)
3. Further add `impl_->resize()` inside `exposeEvent()`, thus causing this issue although python API was not yet introduced (https://github.com/ros2/rviz/commit/f0bee03547f6b4347f98f7f6de398ef8d82b0bd2)
4. Another call to `impl_->resize(0, 0)` that seems could be removed (https://github.com/ros2/rviz/commit/847a5529e2effc96f77843bbe4a33dc7ceea8168) (because of the isExposed() condition, `impl_->resize()` is not called at the start (as observed in https://github.com/ros2/rviz/issues/640#issuecomment-1686029564). Therefore OGRE window does not have size information to start the rendering, and therefore crashes on macOS due to assertion failure in `OgreOSXCocoaWindow.mm, line 410` stated in the comment (https://github.com/ros2/rviz/blob/847a5529e2effc96f77843bbe4a33dc7ceea8168/rviz_common/include/rviz_common/render_panel.hpp#L102C54-L102C54). But maybe better leave it here for a while first until there is a chance to test it in macOS)