### PR TITLE
Fixed low FPS when sending point markers

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
@@ -108,7 +108,7 @@ void PointsMarker::setRenderModeAndDimensions(
       points_->setDimensions(scale.x, scale.y, 0.0f);
       break;
     case visualization_msgs::msg::Marker::CUBE_LIST:
-      points_->setRenderMode(rviz_rendering::PointCloud::RM_SQUARES);
+      points_->setRenderMode(rviz_rendering::PointCloud::RM_BOXES);
       points_->setDimensions(scale.x, scale.y, scale.z);
       break;
     case visualization_msgs::msg::Marker::SPHERE_LIST:

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
@@ -108,7 +108,7 @@ void PointsMarker::setRenderModeAndDimensions(
       points_->setDimensions(scale.x, scale.y, 0.0f);
       break;
     case visualization_msgs::msg::Marker::CUBE_LIST:
-      points_->setRenderMode(rviz_rendering::PointCloud::RM_BOXES);
+      points_->setRenderMode(rviz_rendering::PointCloud::RM_SQUARES);
       points_->setDimensions(scale.x, scale.y, scale.z);
       break;
     case visualization_msgs::msg::Marker::SPHERE_LIST:

--- a/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
@@ -584,6 +584,10 @@ PointCloud::addPointToHardwareBuffer(
   float y = point->position.y;
   float z = point->position.z;
 
+  auto num_vertices = internals.rend->getBuffer()->getNumVertices();
+  auto vertex_size =
+    internals.rend->getRenderOperation()->vertexData->vertexDeclaration->getVertexSize(0);
+
   for (uint32_t j = 0; j < getVerticesPerPoint(); ++j, ++internals.current_vertex_count) {
     *float_buffer++ = x;
     *float_buffer++ = y;
@@ -601,9 +605,7 @@ PointCloud::addPointToHardwareBuffer(
 
     assert(
       reinterpret_cast<uint8_t *>(float_buffer) <=
-      reinterpret_cast<uint8_t *>(float_buffer) +
-      internals.rend->getBuffer()->getNumVertices() *
-      internals.rend->getRenderOperation()->vertexData->vertexDeclaration->getVertexSize(0));
+      reinterpret_cast<uint8_t *>(float_buffer) + num_vertices * vertex_size);
   }
   internals.float_buffer = float_buffer;
   return internals;


### PR DESCRIPTION
When sending a big amount of point markers the FPS of RVIZ is very low (~4fps), this PR changes the render mode and the fps it's much more higher

before:
https://github.com/ros2/rviz/assets/1933907/d01a7786-cec3-424a-b7d6-8f2c2838c2fb

after:
https://github.com/ros2/rviz/assets/1933907/caee2258-187e-414c-872c-641bd1421872

