### PR TITLE
make box-mode point cloud voxels render lighter on top than bottom

### DIFF
--- a/rviz_rendering/ogre_media/materials/glsl120/nogp/box.frag
+++ b/rviz_rendering/ogre_media/materials/glsl120/nogp/box.frag
@@ -16,13 +16,13 @@ void main()
   float ay;
   float l;
   
-  if ( gl_TexCoord[0].z < -0.4999 )
+  if ( gl_TexCoord[0].z > 0.4999 )
   {
     ax = gl_TexCoord[0].x;
     ay = gl_TexCoord[0].y;
     l = lightness[0];
   }
-  else if ( gl_TexCoord[0].z > 0.4999 )
+  else if ( gl_TexCoord[0].z < -0.4999 )
   {
     ax = gl_TexCoord[0].x;
     ay = gl_TexCoord[0].y;


### PR DESCRIPTION
Previously, the GLSL 1.2 shader for box-mode rendering of point clouds resulted in the top of the voxels rendering darker than the bottoms of the voxels. I think it looks nicer the other way around (top lighter than bottom), since most scenes are lit from the top.

(The GLSL 1.2 program is being used because of #851 ; the GLSL 1.5 shaders calculate lightness differently.)

Strangely, this GLSL 1.2 shader program structure has been in rviz for at least 11 years (according to git-blame). Am I just using it incorrectly, or have the tops of voxels always been darker than the bottoms of voxels, when rendering point clouds as boxes?

It may be important to note that I'm using a machine with an integrated (Intel) GPU. I don't have access to a machine with a discrete GPU to test the behavior in that case, since I assume a different shader program is selected when a GPU is present. It would be interesting to know if the same behavior happens with a GPU.

To see the effect:
1. start a point cloud streaming from anything
2. add a point cloud visualizer to rviz
3. select "Boxes" style
4. rotate camera around to view the scene from above and below