### PR TITLE
Fix ODR violations in interactive_marker displays.

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
@@ -41,7 +41,10 @@
 
 #include <OgreVector.h>
 #include <OgreQuaternion.h>
+#include <OgreSceneNode.h>
 #endif
+
+#include <QMenu>
 
 #include <visualization_msgs/msg/interactive_marker.hpp>
 #include <visualization_msgs/msg/interactive_marker_pose.hpp>
@@ -49,6 +52,7 @@
 
 #include <rclcpp/publisher.hpp>
 
+#include "rviz_common/display_context.hpp"
 #include "rviz_common/properties/status_property.hpp"
 #include "rviz_rendering/objects/axes.hpp"
 
@@ -56,24 +60,10 @@
 
 #include "rviz_default_plugins/visibility_control.hpp"
 
-namespace Ogre
-{
-class SceneNode;
-}
-
-class QMenu;
-
-namespace rviz_common
-{
-class DisplayContext;
-}
-
 namespace rviz_default_plugins
 {
 namespace displays
 {
-class InteractiveMarkerDisplay;
-
 class RVIZ_DEFAULT_PLUGINS_PUBLIC InteractiveMarker : public QObject
 {
   Q_OBJECT

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
@@ -44,23 +44,17 @@
 #endif
 
 #include "rviz_common/display.hpp"
+#include "rviz_common/properties/bool_property.hpp"
 
 #include "rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp"
-
-namespace rviz_common
-{
-class BoolProperty;
-class Object;
-}
+#include "./interactive_marker_namespace_property.hpp"
+#include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 
 namespace rviz_default_plugins
 {
-class InteractiveMarkerNamespaceProperty;
 
 namespace displays
 {
-class MarkerBase;
-
 /// Displays Interactive Markers
 class InteractiveMarkerDisplay : public rviz_common::Display
 {


### PR DESCRIPTION
When building this on RHEL and with -Wodr specified, we get some ODR violations reported.  The main reason for this is that the InteractiveMarkerNamespaceProperty class is forward-declared in the wrong namespace.

However, when looking at it I realized that there is really little reason to forward-declare all of this stuff at all.  We have header files; we should just use them.  So I did a minor refactoring here where I removed forward declarations in favor of the header file.