### PR TITLE
Fix up warnings when building with clang.

### DIFF
--- a/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
@@ -33,7 +33,6 @@
 
 #include <array>
 #include <memory>
-#include <sstream>  // needed for Eigen until https://gitlab.com/libeigen/eigen/-/merge_requests/65
 #include <vector>
 
 // GCC 11 has a false positive warning about uninitialized variables in Eigen.  There is an open
@@ -45,13 +44,12 @@
 // https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
 // However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
 // freezes, so disable the warning here.
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
-#include <Eigen/Dense>  // NOLINT: cpplint cannot handle correct include here
-#ifdef __GNUC__
+#include <Eigen/Dense>
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
It turns out that clang defines __GNUC__, but doesn't understand all of the flags that GCC does.  Thus, make the pushing and popping of flags conditional on GCC only.

While we are in here, remove some bits of workarounds that are no longer necessary.