### PR TITLE
Restore the maybe-uninitialized flag in covariance_visual.hpp

### DIFF
--- a/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/covariance_visual.hpp
@@ -46,6 +46,7 @@
 // freezes, so disable the warning here.
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 #include <Eigen/Dense>


### PR DESCRIPTION
We still need it, as apparently the upstream bug isn't fixed.

This will fix the warnings that popped up overnight in https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/2503/