### PR TITLE
fixed enableInteraction reference

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/tools/select/selection_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/select/selection_tool.cpp
@@ -86,7 +86,6 @@ void SelectionTool::activate()
   context_->getSelectionManager()->setTextureSize(512);
   selecting_ = false;
   moving_ = false;
-//  context_->getHandlerManager()->enableInteraction(true);
 }
 
 void SelectionTool::deactivate()

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/select/selection_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/select/selection_tool.cpp
@@ -86,7 +86,7 @@ void SelectionTool::activate()
   context_->getSelectionManager()->setTextureSize(512);
   selecting_ = false;
   moving_ = false;
-//  context_->getSelectionManager()->enableInteraction(true);
+//  context_->getHandlerManager()->enableInteraction(true);
 }
 
 void SelectionTool::deactivate()


### PR DESCRIPTION
I came across this while working with the plugins.

The "enableInteraction()" function is located in [handler_manager](https://github.com/ros2/rviz/blob/rolling/rviz_common/src/rviz_common/interaction/handler_manager.cpp#L138) and not in [selection_manager](https://github.com/ros2/rviz/blob/rolling/rviz_common/src/rviz_common/interaction/selection_manager.cpp)

So getHandlerManager() would need to be called instead of getSelectionManager().
For example its used [here](https://github.com/ros2/rviz/blob/3c1eda1427de026fc89fbf4662912a2e6598a1ee/rviz_default_plugins/src/rviz_default_plugins/tools/interaction/interaction_tool.cpp#L80).
Its just a comment, but I thought it would be worth changing to avoid confusion for people looking at selection_tool.cpp for an example plugin, like me.