### PR TITLE
Add "R" key as shortcut for resetTime

### DIFF
--- a/rviz2/doc/index.rst
+++ b/rviz2/doc/index.rst
@@ -309,7 +309,8 @@ Clock" (aka real) time has passed.
 
 The time panel also lets you reset the visualizer's internal time
 state -- this causes a reset of all the displays, as well as a reset
-of tf's internal cache of data.
+of tf's internal cache of data. The keyboard shortcut for this "reset" 
+functionality is "r".
 
 .. image:: time-panel.png
 

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -47,6 +47,7 @@
 #include "rviz_common/properties/float_property.hpp"
 #include "rviz_common/interaction/view_picker_iface.hpp"
 #include "rviz_common/render_panel.hpp"
+#include "rviz_common/visualization_manager.hpp"
 
 namespace rviz_common
 {
@@ -231,6 +232,15 @@ void ViewController::handleKeyEvent(QKeyEvent * event, RenderPanel * panel)
 
   if (event->key() == Qt::Key_Z) {
     reset();
+  }
+
+  if (event->key() == Qt::Key_R) {
+    rviz_common::VisualizationManager * vis_manager =
+      dynamic_cast<rviz_common::VisualizationManager *>(context_);
+
+    if (vis_manager != nullptr) {
+      vis_manager->resetTime();
+    }
   }
 }
 


### PR DESCRIPTION
I find myself often wishing there was an easier way to easily "reset" rviz. I prefer to work with rviz in full-screen mode which exasperates the issue (as one must first minimize rviz, then click reset, then go back to full-screen).

For that reason, I've added key handling for the "R"-key to call `resetTime`. 

Two questions from me:
1. Is anyone else interested in this or am I weird?
2. Is this an o.k. implementation?