### PR TITLE
Add fullscreen startup option

### DIFF
--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -238,6 +238,14 @@ public Q_SLOTS:
   void
   setStatus(const QString & message) override;
 
+  /// Set full screen mode.
+  void
+  setFullScreen(bool full_screen);
+
+  /// Exit full screen mode.
+  void
+  exitFullScreen();
+
 Q_SIGNALS:
   /// Emitted during file-loading and initialization to indicate progress.
   void
@@ -331,14 +339,6 @@ protected Q_SLOTS:
    */
   void
   onDeletePanel();
-
-  /// Set full screen mode.
-  void
-  setFullScreen(bool full_screen);
-
-  /// Exit full screen mode.
-  void
-  exitFullScreen();
 
   /// Indicate that loading is done.
   void

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -112,12 +112,18 @@ bool VisualizerApp::init(int argc, char ** argv)
       "A custom splash-screen image to display", "splash_path");
   parser.addOption(splash_screen_option);
 
+  QCommandLineOption fullscreen_option(
+    "fullscreen",
+    "Start rviz in fullscreen mode.");
+  parser.addOption(fullscreen_option);
+
   QString display_config, fixed_frame, splash_path, help_path, display_title_format;
-  bool enable_ogre_log;
+  bool enable_ogre_log, fullscreen;
 
   if (app_) {parser.process(*app_);}
 
   enable_ogre_log = parser.isSet(ogre_log_option);
+  fullscreen = parser.isSet(fullscreen_option);
 
   if (parser.isSet(display_config_option)) {
     display_config = parser.value(display_config_option);
@@ -160,6 +166,10 @@ bool VisualizerApp::init(int argc, char ** argv)
 
   if (!fixed_frame.isEmpty()) {
     frame_->getManager()->setFixedFrame(fixed_frame);
+  }
+
+  if (fullscreen) {
+    frame_->setFullScreen(true);
   }
 
   frame_->show();

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -114,7 +114,7 @@ bool VisualizerApp::init(int argc, char ** argv)
 
   QCommandLineOption fullscreen_option(
     "fullscreen",
-    "Start rviz in fullscreen mode.");
+    "Start RViz in fullscreen mode.");
   parser.addOption(fullscreen_option);
 
   QString display_config, fixed_frame, splash_path, help_path, display_title_format;


### PR DESCRIPTION
This PR adds the "--fullscreen" command-line option, which allows rviz to start up in fullscreen mode. This flag is already in rviz1 - originally added by @rhaschke ([Original PR](https://github.com/ros-visualization/rviz/pull/1413)).