### PR TITLE
Switch to using rcpputils::fs helpers.

### DIFF
--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -37,6 +37,7 @@
   <depend>geometry_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>rcpputils</depend>
   <depend>resource_retriever</depend>
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -32,7 +32,6 @@
 #include "rviz_common/visualization_frame.hpp"
 
 #include <exception>
-#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -60,6 +59,7 @@
 #include <QToolButton>  // NOLINT cpplint cannot handle include order here
 
 #include "rclcpp/clock.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
@@ -778,7 +778,7 @@ void VisualizationFrame::setDisplayConfigFile(const std::string & path)
         }
       };
     title = display_title_format_;
-    std::filesystem::path full_filename(path.c_str());
+    rcpputils::fs::path full_filename(path.c_str());
     find_and_replace_token(
       title, "{NAMESPACE}",
       rviz_ros_node_.lock()->get_raw_node()->get_namespace());


### PR DESCRIPTION
In RHEL-8, std::filesystem is not completely implemented, so we can't rely on it.  Switch to rcpputils::fs here instead, which has the functionality we need.