### PR TITLE
Fixed the global translation in `MovableText::getWorldTransforms `

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/movable_text.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/movable_text.cpp
@@ -517,8 +517,7 @@ void MovableText::getWorldTransforms(Ogre::Matrix4 * xform) const
 
     mCamera->getDerivedOrientation().ToRotationMatrix(rot3x3);
 
-    Ogre::Vector3 parent_position = mParentNode->_getDerivedPosition() +
-      Ogre::Vector3::UNIT_Y * global_translation_;
+    Ogre::Vector3 parent_position = mParentNode->_getDerivedPosition() + global_translation_;
     parent_position += rot3x3 * local_translation_;
 
     scale3x3[0][0] = mParentNode->_getDerivedScale().x / 2;


### PR DESCRIPTION
closes #974 
Back-ported changes from ROS 1 for  `MovableText::getWorldTransforms ` which was previously applying global translation only in y direction.