### PR TITLE
Fix time-syncing message

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -476,7 +476,8 @@ bool CameraDisplay::updateCamera()
   if (timeDifferenceInExactSyncMode(image, rviz_time)) {
     setStatus(
       StatusLevel::Warn, TIME_STATUS,
-      QString("Time-syncing active and no image at timestamp ") + rviz_time.nanoseconds() + ".");
+      QString("Time-syncing active and no image at timestamp ") +
+      QString::number(rviz_time.nanoseconds()) + ".");
     return false;
   }
 


### PR DESCRIPTION
This message generate some garbage, this is the right way to convert a `uint64_t` to `QString`