### PR TITLE
Fixed transport name in DepthCloud plugin

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
@@ -207,7 +207,6 @@ void DepthCloudDisplay::setTopic(const QString & topic, const QString & datatype
     QString transport = topic.mid(index + 1);
     QString base_topic = topic.mid(0, index);
 
-    depth_transport_property_->setString(transport);
     depth_topic_property_->setString(base_topic);
   }
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
@@ -200,14 +200,10 @@ void DepthCloudDisplay::setTopic(const QString & topic, const QString & datatype
     depth_transport_property_->setStdString("raw");
     depth_topic_property_->setString(topic);
   } else {
-    int index = topic.lastIndexOf("/");
-    if (index == -1) {
-      return;
-    }
-    QString transport = topic.mid(index + 1);
-    QString base_topic = topic.mid(0, index);
-
-    depth_topic_property_->setString(base_topic);
+    setStatus(
+      rviz_common::properties::StatusProperty::Warn,
+      "Message",
+      "Data type of the topic is not correct. Expect sensor_msgs::msgs::Image");
   }
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
@@ -203,7 +203,7 @@ void DepthCloudDisplay::setTopic(const QString & topic, const QString & datatype
     setStatus(
       rviz_common::properties::StatusProperty::Warn,
       "Message",
-      "Data type of the topic is not correct. Expect sensor_msgs::msgs::Image");
+      "Expected topic type of 'sensor_msgs/msg/Image', saw topic type '" + datatype + "'");
   }
 }
 


### PR DESCRIPTION
Fixed transport name in DepthCloud plugin

When setting the topic name the image_transport type is automatically detected based on the topic name. But is not correct for example: `/camera/image_raw` will set the  image_transport type to `image_raw`, but the correct type is `raw`.
