### PR TITLE
Added Cache to camera display for TimeExact

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -46,6 +46,8 @@
 # include <OgreRenderTargetListener.h>
 # include <OgreSharedPtr.h>
 
+#include <message_filters/cache.h>
+
 # include "sensor_msgs/msg/camera_info.hpp"
 # include "tf2_ros/message_filter.h"
 
@@ -190,6 +192,8 @@ private:
 
   std::unique_ptr<ROSImageTextureIface> texture_;
   std::unique_ptr<rviz_common::RenderPanel> render_panel_;
+
+  std::shared_ptr<message_filters::Cache<sensor_msgs::msg::Image>> cache_images_;
 
   rviz_common::properties::FloatProperty * alpha_property_;
   rviz_common::properties::EnumProperty * image_position_property_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -480,7 +480,7 @@ bool CameraDisplay::updateCamera()
     rclcpp::Time rviz_time = context_->getFrameManager()->getTime();
     std::vector<sensor_msgs::msg::Image::ConstSharedPtr> interval_data = cache_images_->getInterval(
       rviz_time, rviz_time);
-    if (interval_data.size() > 1) {
+    if (!interval_data.empty()) {
       image = interval_data[0];
       if (timeDifferenceInExactSyncMode(image, rviz_time)) {
         setStatus(

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -472,13 +472,28 @@ bool CameraDisplay::updateCamera()
     return false;
   }
 
-  rclcpp::Time rviz_time = context_->getFrameManager()->getTime();
-  if (timeDifferenceInExactSyncMode(image, rviz_time)) {
-    setStatus(
-      StatusLevel::Warn, TIME_STATUS,
-      QString("Time-syncing active and no image at timestamp ") +
-      QString::number(rviz_time.nanoseconds()) + ".");
-    return false;
+  if (context_->getFrameManager()->getSyncMode() == rviz_common::FrameManagerIface::SyncExact) {
+    if (cache_images_ == nullptr) {
+      cache_images_ = std::make_shared<message_filters::Cache<sensor_msgs::msg::Image>>(
+        *subscription_, 20);
+    }
+    rclcpp::Time rviz_time = context_->getFrameManager()->getTime();
+    std::vector<sensor_msgs::msg::Image::ConstSharedPtr> interval_data = cache_images_->getInterval(
+      rviz_time, rviz_time);
+    if (interval_data.size() > 1) {
+      image = interval_data[0];
+      if (timeDifferenceInExactSyncMode(image, rviz_time)) {
+        setStatus(
+          StatusLevel::Warn, TIME_STATUS,
+          QString("Time-syncing active and no image at timestamp ") +
+          QString::number(rviz_time.nanoseconds()) + ".");
+        return false;
+      }
+    }
+  } else {
+    if (cache_images_ != nullptr) {
+      cache_images_.reset();
+    }
   }
 
   Ogre::Vector3 position;


### PR DESCRIPTION
When running the TimeExact experimental mode as you can see in the bottom of the picture

![rviz_time_sync](https://github.com/ros2/rviz/assets/1933907/c8c6a4f5-75b0-4d98-96b4-21fbb3460f42)

This requires that the PointCloud, which is the source that set the time in RViz, is synchronized with the image in the camera display plugin. We cannot assure that the subscribers in the DepthCloud plugin and in the Camera Display are synchonized. That's why I included a cache in the image display plugin.