### PR TITLE
Fixes for uncrustify 0.78.

### DIFF
--- a/rviz_common/include/rviz_common/logging.hpp
+++ b/rviz_common/include/rviz_common/logging.hpp
@@ -59,45 +59,49 @@
 #include "rviz_rendering/logging_handler.hpp"
 #include "rviz_common/visibility_control.hpp"
 
+// *INDENT-OFF*
+
 #define RVIZ_COMMON_LOG_DEBUG(msg) do { \
-    rviz_common::log_debug(msg, __FILE__, __LINE__); \
+  rviz_common::log_debug(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_COMMON_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_common::log_debug(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_common::log_debug(__ss.str(), __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_COMMON_LOG_INFO(msg) do { \
-    rviz_common::log_info(msg, __FILE__, __LINE__); \
+  rviz_common::log_info(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_COMMON_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_common::log_info(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_common::log_info(__ss.str(), __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_COMMON_LOG_WARNING(msg) do { \
-    rviz_common::log_warning(msg, __FILE__, __LINE__); \
+  rviz_common::log_warning(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_COMMON_LOG_WARNING_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_common::log_warning(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_common::log_warning(__ss.str(), __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_COMMON_LOG_ERROR(msg) do { \
-    rviz_common::log_error(msg, __FILE__, __LINE__); \
+  rviz_common::log_error(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_COMMON_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_common::log_error(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_common::log_error(__ss.str(), __FILE__, __LINE__); \
 } while (0)
+
+// *INDENT-ON*
 
 namespace rviz_common
 {

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp
@@ -78,4 +78,6 @@ private:
 }  // namespace displays
 }  // namespace rviz_default_plugins
 
+// *INDENT-OFF*
 #endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__INTERACTIVE_MARKERS__INTERACTIVE_MARKER_NAMESPACE_PROPERTY_HPP_
+// *INDENT-ON*

--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/follower/third_person_follower_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/follower/third_person_follower_view_controller.hpp
@@ -52,4 +52,6 @@ protected:
 }  // namespace view_controllers
 }  // namespace rviz_default_plugins
 
+// *INDENT-OFF*
 #endif  // RVIZ_DEFAULT_PLUGINS__VIEW_CONTROLLERS__FOLLOWER__THIRD_PERSON_FOLLOWER_VIEW_CONTROLLER_HPP_
+// *INDENT-ON*

--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp
@@ -112,4 +112,6 @@ protected:
 }  // namespace view_controllers
 }  // namespace rviz_default_plugins
 
+// *INDENT-OFF*
 #endif  // RVIZ_DEFAULT_PLUGINS__VIEW_CONTROLLERS__ORTHO__FIXED_ORIENTATION_ORTHO_VIEW_CONTROLLER_HPP_  // NOLINT
+// *INDENT-ON*

--- a/rviz_rendering/include/rviz_rendering/logging.hpp
+++ b/rviz_rendering/include/rviz_rendering/logging.hpp
@@ -37,45 +37,49 @@
 #include "rviz_rendering/logging_handler.hpp"
 #include "rviz_rendering/visibility_control.hpp"
 
+// *INDENT-OFF*
+
 #define RVIZ_RENDERING_LOG_DEBUG(msg) do { \
-    rviz_rendering::log_debug(msg, __FILE__, __LINE__); \
+  rviz_rendering::log_debug(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_RENDERING_LOG_DEBUG_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_rendering::log_debug(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_rendering::log_debug(__ss.str(), __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_RENDERING_LOG_INFO(msg) do { \
-    rviz_rendering::log_info(msg, __FILE__, __LINE__); \
+  rviz_rendering::log_info(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_RENDERING_LOG_INFO_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_rendering::log_info(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_rendering::log_info(__ss.str(), __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_RENDERING_LOG_WARNING(msg) do { \
-    rviz_rendering::log_warning(msg, __FILE__, __LINE__); \
+  rviz_rendering::log_warning(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_RENDERING_LOG_WARNING_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_rendering::log_warning(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_rendering::log_warning(__ss.str(), __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_RENDERING_LOG_ERROR(msg) do { \
-    rviz_rendering::log_error(msg, __FILE__, __LINE__); \
+  rviz_rendering::log_error(msg, __FILE__, __LINE__); \
 } while (0)
 
 #define RVIZ_RENDERING_LOG_ERROR_STREAM(args) do { \
-    std::stringstream __ss; \
-    __ss << args; \
-    rviz_rendering::log_error(__ss.str(), __FILE__, __LINE__); \
+  std::stringstream __ss; \
+  __ss << args; \
+  rviz_rendering::log_error(__ss.str(), __FILE__, __LINE__); \
 } while (0)
+
+// *INDENT-ON*
 
 namespace rviz_rendering
 {


### PR DESCRIPTION
Mostly what we do here is to disable the indentation on certain constructs that are different between 0.72 and 0.78.  It isn't my preferred solution, but since it only affects a small amount of code (and most of that in macros), this seems acceptable to me.