### PR TITLE
Change an rviz_ogre_vendor dependency to libfreetype-dev.

### DIFF
--- a/rviz_ogre_vendor/package.xml
+++ b/rviz_ogre_vendor/package.xml
@@ -23,8 +23,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
-  <build_depend>libfreetype6-dev</build_depend>
-  <build_export_depend>libfreetype6-dev</build_export_depend>
+  <build_depend>libfreetype-dev</build_depend>
+  <build_export_depend>libfreetype-dev</build_export_depend>
   <exec_depend>libfreetype6</exec_depend>
 
   <depend>libx11-dev</depend>


### PR DESCRIPTION
The situation is complicated, but in versions of Ubuntu prior to Focal and versions of Debian prior to Bookworm, the name of the library was 'libfreetype6-dev'.  Since Focal and Bookworm, the name of the library is 'libfreetype-dev'. While 'libfreetype-dev' provides a "virtual package" for 'libfreetype6-dev', we should really use the new canonical name.

Further, there is currently a bug on ros_buildfarm where it doesn't properly deal with "virtual packages" like this. This is currently preventing this package from building on Ubuntu Noble.  That bug is being worked on separately.

Finally, I'll note that we already have a libfreetype-dev key in rosdep, so we just switch to using that here which should work around the bug on the buildfarm, and also use the correct canonical name going forward.