### PR TITLE
Update resource group name in MeshShape class

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/mesh_shape.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/mesh_shape.cpp
@@ -73,7 +73,7 @@ void MeshShape::beginTriangles()
 
   if (!started_) {
     started_ = true;
-    manual_object_->begin(material_name_, Ogre::RenderOperation::OT_TRIANGLE_LIST);
+    manual_object_->begin(material_name_, Ogre::RenderOperation::OT_TRIANGLE_LIST, "rviz_rendering");
   }
 }
 
@@ -126,7 +126,7 @@ void MeshShape::endTriangles()
     manual_object_->convertToMesh(name);
     entity_ = scene_manager_->createEntity(name);
     if (entity_) {
-      entity_->setMaterial(material_);
+      entity_->setMaterial(material_, "rviz_rendering");
       offset_node_->attachObject(entity_);
     } else {
       RVIZ_RENDERING_LOG_ERROR("Unable to construct triangle mesh");


### PR DESCRIPTION
In PR #1064, MeshShape was added. When I copied those files to the humble branch and used it (building from source), the following error occurred:

```
[ERROR] [1710237479.381395654] [rviz2]: Can't assign material Shape1791Material to the ManualObject MeshShape_ManualObject10 because this Material does not exist in g
roup General. Have you forgotten to define it in a .material script?
```

Upon investigating this message, I found a similar case at https://github.com/ros-planning/moveit2/issues/1164. After applying this fix and rebuilding this rviz, the above error was resolved.

Since I am unfamiliar with this repository myself, I'm not sure if the fix is appropriate. Could you please confirm if the fix is necessary? Thank you.