### PR TITLE
apply origin rotation to inertia box visualization

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -897,8 +897,13 @@ void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
       link->inertial->origin.position.x,
       link->inertial->origin.position.y,
       link->inertial->origin.position.z);
+
+    double x, y, z, w;
+    link->inertial->origin.rotation.getQuaternion(x, y, z, w);
+    Ogre::Quaternion originRotate(w, x, y, z);
+
     Ogre::Quaternion rotate(box_rot.W(), box_rot.X(), box_rot.Y(), box_rot.Z());
-    Ogre::SceneNode * offset_node = inertia_node_->createChildSceneNode(translate, rotate);
+    Ogre::SceneNode * offset_node = inertia_node_->createChildSceneNode(translate, originRotate * rotate);
     inertia_shape_ = new Shape(Shape::Cube, scene_manager_, offset_node);
 
     inertia_shape_->setColor(1, 0, 0, 1);

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -903,7 +903,8 @@ void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
     Ogre::Quaternion originRotate(w, x, y, z);
 
     Ogre::Quaternion rotate(box_rot.W(), box_rot.X(), box_rot.Y(), box_rot.Z());
-    Ogre::SceneNode * offset_node = inertia_node_->createChildSceneNode(translate, originRotate * rotate);
+    Ogre::SceneNode * offset_node = inertia_node_->createChildSceneNode(
+      translate, originRotate * rotate);
     inertia_shape_ = new Shape(Shape::Cube, scene_manager_, offset_node);
 
     inertia_shape_->setColor(1, 0, 0, 1);


### PR DESCRIPTION
fixes #1170 

The equivalent code in gazebo is here: https://github.com/gazebosim/gazebo-classic/blob/bc30cd94bc0dc3d9df0731a052f50cbdc228e977/gazebo/rendering/InertiaVisual.cc#L59-L75

~~I would appreciate if someone could verify with a more recent gazebo version as well~~ Seems to work the same way in gazebo fortress as well