### PR TITLE
Remove regex_filter_property.hpp from the moc lines.

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -102,7 +102,6 @@ set(rviz_common_headers_to_moc
   include/rviz_common/properties/property_tree_model.hpp
   include/rviz_common/properties/property_tree_with_help.hpp
   include/rviz_common/properties/qos_profile_property.hpp
-  include/rviz_common/properties/regex_filter_property.hpp
   include/rviz_common/properties/ros_topic_property.hpp
   include/rviz_common/properties/status_list.hpp
   include/rviz_common/properties/status_property.hpp


### PR DESCRIPTION
Since it has no SLOTS or SIGNALS, we don't need to run MOC on it.  That will both speed up the compilation and remove a warning when building.

@ahcorde FYI