### PR TITLE
Fixed camera info warning

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera_info/camera_info_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera_info/camera_info_display.hpp
@@ -74,7 +74,7 @@ public:
   void reset() override;
 
 protected:
-  void processMessage(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg);
+  void processMessage(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg) override;
 
   void update(float wall_dt, float ros_dt) override;
   bool isSameCameraInfo(


### PR DESCRIPTION
There is a new warning https://ci.ros2.org/job/ci_linux_clang_libcxx/65/gcc/new/source.2a395b20-72e7-49cc-890d-ae96e094e60a/#77

This PR should fix it