### PR TITLE
Switch to gz_math_vendor.

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -61,8 +61,8 @@ find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
 
 find_package(geometry_msgs REQUIRED)
 
-find_package(ignition_math6_vendor REQUIRED)
-find_package(ignition-math6 REQUIRED)
+find_package(gz_math_vendor REQUIRED)
+find_package(gz-math REQUIRED)
 
 find_package(image_transport REQUIRED)
 find_package(interactive_markers REQUIRED)
@@ -265,7 +265,7 @@ target_link_libraries(rviz_default_plugins PUBLIC
 )
 
 target_link_libraries(rviz_default_plugins PRIVATE
-  ignition-math6
+  gz-math::core
   resource_retriever::resource_retriever
 )
 

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -38,7 +38,7 @@
   <exec_depend>rviz_ogre_vendor</exec_depend>
 
   <depend>geometry_msgs</depend>
-  <depend>ignition_math6_vendor</depend>
+  <depend>gz_math_vendor</depend>
   <depend>image_transport</depend>
   <depend>interactive_markers</depend>
   <depend>laser_geometry</depend>

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -50,11 +50,11 @@
 
 #include <QFileInfo>  // NOLINT cpplint cannot handle include order here
 
-#include <ignition/math/Inertial.hh>
-#include <ignition/math/MassMatrix3.hh>
-#include <ignition/math/Pose3.hh>
-#include <ignition/math/Quaternion.hh>
-#include <ignition/math/Vector3.hh>
+#include <gz/math/Inertial.hh>
+#include <gz/math/MassMatrix3.hh>
+#include <gz/math/Pose3.hh>
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
 
 #include "resource_retriever/retriever.hpp"
 
@@ -871,18 +871,18 @@ void RobotLink::createMass(const urdf::LinkConstSharedPtr & link)
 void RobotLink::createInertia(const urdf::LinkConstSharedPtr & link)
 {
   if (link->inertial) {
-    const ignition::math::Vector3d i_xx_yy_zz(
+    const gz::math::Vector3d i_xx_yy_zz(
       link->inertial->ixx,
       link->inertial->iyy,
       link->inertial->izz);
-    const ignition::math::Vector3d Ixyxzyz(
+    const gz::math::Vector3d Ixyxzyz(
       link->inertial->ixy,
       link->inertial->ixz,
       link->inertial->iyz);
-    ignition::math::MassMatrix3d mass_matrix(link->inertial->mass, i_xx_yy_zz, Ixyxzyz);
+    gz::math::MassMatrix3d mass_matrix(link->inertial->mass, i_xx_yy_zz, Ixyxzyz);
 
-    ignition::math::Vector3d box_scale;
-    ignition::math::Quaterniond box_rot;
+    gz::math::Vector3d box_scale;
+    gz::math::Quaterniond box_rot;
     if (!mass_matrix.EquivalentBox(box_scale, box_rot)) {
       // Invalid inertia, load with default scale
       if (link->parent_joint && link->parent_joint->type != urdf::Joint::FIXED) {


### PR DESCRIPTION
Ignition is no more, long live Gazebo.

@ahcorde I could use help from you in particular on testing this to make sure it still works.  I'm not entirely sure what plugins `robot_link.cpp` is used in, nor how to test them.

@azeey FYI.

This needs to be merged simultaneously with https://github.com/ros2/ros2/pull/1537