### PR TITLE
Increase the cpplint timeout to 180 seconds.

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -1205,3 +1205,7 @@ endif()
 ament_package(
   CONFIG_EXTRAS "rviz_default_plugins-extras.cmake"
 )
+
+if(TEST cpplint)
+  set_tests_properties(cpplint PROPERTIES TIMEOUT 180)
+endif()


### PR DESCRIPTION
This should make it less flaky when running on Windows.

This should make flakes like https://ci.ros2.org/view/nightly/job/nightly_win_deb/3051/testReport/junit/(root)/rviz_default_plugins/cpplint_xunit_missing_result/ less likely to happen.