### PR TITLE
Update the vendored package path.

### DIFF
--- a/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
+++ b/rviz_assimp_vendor/rviz_assimp_vendor-extras.cmake.in
@@ -7,7 +7,7 @@ set(ON 1)
 # We always add the local Modules directory to the modules path, so if a vendored package was
 # built, it is used.  If it was not built, find_package() will fall back to attempting to find the
 # system package.
-set(assimp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_assimp_vendor/lib/cmake/assimp-5.2")
+set(assimp_DIR "${@PROJECT_NAME@_DIR}/../../../opt/rviz_assimp_vendor/lib/cmake/assimp-5.3")
 message(STATUS "Setting assimp_DIR to: '${assimp_DIR}'")
 
 find_package(assimp REQUIRED QUIET)


### PR DESCRIPTION
Since we just updated to assimp 5.3, we also need to update the path we look for it.

This should fix the build with clang which is currently failing.