### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -31,7 +31,7 @@ if(WIN32)
 
   ament_vendor(zlib_vendor
     VCS_URL https://github.com/madler/zlib.git
-    VCS_VERSION v1.2.13
+    VCS_VERSION v1.13.1
     CMAKE_ARGS
       # zlib doesn't use CMAKE_INSTALL_PREFIX correctly, so we need to override
       -DINSTALL_BIN_DIR=<INSTALL_DIR>/bin


### PR DESCRIPTION
Reject overflows of zip header fields in minizip
Fix bug in inflateSync() for data held in bit buffer Add LIT_MEM define to use more memory for a small deflate speedup Fix decision on the emission of Zip64 end records in minizip Add bounds checking to ERR_MSG() macro, used by zError() Neutralize zip file traversal attacks in miniunz
Fix a bug in ZLIB_DEBUG compiles in check_match()
Building using K&R (pre-ANSI) function definitions is no longer supported. Fixed a bug in deflateBound() for level 0 and memLevel 9. Fixed a bug when gzungetc() is used immediately after gzopen(). Fixed a bug when using gzflush() with a very small buffer. Fixed a crash when gzsetparams() is attempted for a transparent write. Fixed test/example.c to work with FORCE_STORED.
Fixed minizip to allow it to open an empty zip file. Fixed reading disk number start on zip64 files in minizip. Fixed a logic error in minizip argument processing.