### PR TITLE
Support loading resources from Fuel

### DIFF
--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -39,6 +39,7 @@ find_package(ament_index_cpp REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(resource_retriever REQUIRED)
+find_package(gz-fuel_tools8 REQUIRED)
 
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
 if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
@@ -103,6 +104,7 @@ target_link_libraries(rviz_rendering PUBLIC
   Qt5::Widgets
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
+  gz-fuel_tools8::gz-fuel_tools8
 )
 if(TARGET Eigen3::Eigen)
   # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
@@ -130,6 +132,7 @@ ament_export_dependencies(
   Eigen3
   Qt5
   rviz_ogre_vendor
+  gz-fuel_tools8
 )
 
 # Export old-style CMake variables
@@ -179,6 +182,7 @@ if(BUILD_TESTING)
     PUBLIC
     rviz_ogre_vendor::OgreMain
     rviz_rendering
+    gz-fuel_tools8::gz-fuel_tools8
   )
 
   ament_add_gmock(string_helper_test test/rviz_rendering/string_helper_test.cpp)

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -35,6 +35,7 @@
   <build_depend>resource_retriever</build_depend>
   <build_depend>rviz_assimp_vendor</build_depend>
   <build_depend>rviz_ogre_vendor</build_depend>
+  <build_depend>gz-fuel_tools8</build_depend>
 
   <build_export_depend>eigen</build_export_depend>
   <build_export_depend>qtbase5-dev</build_export_depend>
@@ -48,6 +49,7 @@
   <exec_depend>resource_retriever</exec_depend>
   <exec_depend>rviz_assimp_vendor</exec_depend>
   <exec_depend>rviz_ogre_vendor</exec_depend>
+  <exec_depend>gz-fuel_tools8</exec_depend>
 
   <!-- TODO(jacobperron): Replace with ament_lint_common when ament_copyright is working -->
   <test_depend>ament_cmake_cppcheck</test_depend>
@@ -59,6 +61,7 @@
   <test_depend>ament_cmake_xmllint</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>rviz_assimp_vendor</test_depend>
+  <test_depend>gz-fuel_tool8</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader.cpp
@@ -47,6 +47,8 @@
 #include <QFileInfo>  // NOLINT cpplint cannot handle include order here
 #include <QString>  // NOLINT cpplint cannot handle include order here
 
+#include <gz/fuel_tools/Interface.hh>
+
 #define ASSIMP_UNIFIED_HEADER_NAMES 1
 #if defined(ASSIMP_UNIFIED_HEADER_NAMES)
 #include "assimp/Importer.hpp"
@@ -108,11 +110,20 @@ Ogre::MeshPtr loadMeshFromResource(const std::string & resource_path)
       return mesh;
     } else {
       AssimpLoader assimp_loader;
+      std::string file_resource_path = resource_path;
 
-      const aiScene * scene = assimp_loader.getScene(resource_path);
+      // Check to see if the resource is referencing a Fuel resource.
+      // If so, then use fuel_tools to resolve the path. This will
+      // also download the resource if it doesn't exist on disk.
+      if (resource_path.find("https://fuel") == 0) {
+        file_resource_path = "file://" +
+          gz::fuel_tools::fetchResource(resource_path);
+      }
+
+      const aiScene * scene = assimp_loader.getScene(file_resource_path);
       if (!scene) {
         RVIZ_RENDERING_LOG_ERROR_STREAM(
-          "Could not load resource [" << resource_path.c_str() << "]: " <<
+          "Could not load resource [" << file_resource_path.c_str() << "]: " <<
             assimp_loader.getErrorMessage());
         return Ogre::MeshPtr();
       }


### PR DESCRIPTION
`sdformat_urdf` supports the use of SDF files, and I'd like to utilize [Fuel](https://app.gazebosim.org) for resource hosting. With this PR, an SDF file can remain consistent when used between Gazebo and RViz. This will also give people the option of store meshes and models in a location other than a git repository.

I think it makes sense to support this capability here, rather than modify SDF files to use absolute paths. A user may run rviz on a separate machine from Gazebo, and wouldn't necessarily be able to resolve an absolute path.

It does add an additional dependency on `gz-fuel_tools`. This is required to resolve urls like `https://fuel.gazebosim.org/1.0/openrobotics/models/backpack`. If a resource is not in the local Fuel cache, then it's downloaded. 

**I'm new to adding dependencies like this. Please let me know what I should do to fix or improve things.**

## Test
Here is a simple launch file that you can use for testing

```
import os

from ament_index_python.packages import get_package_share_directory 
from launch import LaunchDescription
from launch.actions import (
  DeclareLaunchArgument,
  IncludeLaunchDescription,
  RegisterEventHandler,
)
from launch.event_handlers import OnProcessExit
from launch.launch_description_sources import PythonLaunchDescriptionSource
from launch.substitutions import LaunchConfiguration
from launch_ros.actions import Node

def generate_launch_description() -> LaunchDescription:
    use_sim_time = LaunchConfiguration('use_sim_time', default=True)

    # Get SDF via xacro
    robot_description_content = """<?xml version="1.0" encoding="UTF-8"?>
      <sdf version='1.9'>
        <model name="backpack">
          <static>true</static>
          <link name="base_link">
            <collision name="collision">
              <pose>0 0 2 0 0 0</pose>
              <geometry>
                <mesh>
                  <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/backpack/tip/files/meshes/Backpack.dae</uri>
                </mesh>
              </geometry>
            </collision>

            <visual name="visual">
              <geometry>
                <mesh>
                  <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/backpack/tip/files/meshes/Backpack.dae</uri>
                </mesh>
              </geometry>
            </visual>
          </link>
        </model>
      </sdf>"""

    robot_description = {'robot_description': robot_description_content}

   # The node to publish robot state information
    robot_state_publisher_node = Node(
        package='robot_state_publisher',
        executable='robot_state_publisher',
        output='both',
        parameters=[robot_description, {'publish_frequency': 1000.0}],
    )

    rviz_node = Node(
        package='rviz2',
        executable='rviz2',
        name='rviz2',
        output='log',
    )

    gz_spawn_entity = Node(
        package='ros_gz_sim',
        executable='create',
        output='screen',
        arguments=['-string', robot_description_content],
    )

    # Return the final launch description
    return LaunchDescription(
        [
          DeclareLaunchArgument(
              'use_sim_time',
              default_value=use_sim_time,
              description="If true, use simulation clock",
          ),
          # Launch gazebo environment
          IncludeLaunchDescription(
            PythonLaunchDescriptionSource(
              [
                os.path.join(
                  get_package_share_directory('ros_gz_sim'),
                  'launch',
                  'gz_sim.launch.py',
                )
              ]
            ),
            launch_arguments=[('gz_args', [' -r -v 4 empty.sdf'])],
          ),
          # Run the joint state publisher after the robot has been spawned
          RegisterEventHandler(
            event_handler=OnProcessExit(
              target_action=gz_spawn_entity,
              on_exit=[rviz_node],
            )
          ),
          robot_state_publisher_node,
          gz_spawn_entity,
      ]
    )
```
