### PR TITLE
Removed assimp warnings

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -29,6 +29,7 @@ else()
   set(ASSIMP_CMAKE_FLAGS "-DCMAKE_INSTALL_LIBDIR=lib")
 
   set(ASSIMP_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS}")
+  set(ASSIMP_C_FLAGS "-Wno-deprecated-non-prototype ${CMAKE_C_FLAGS}")
 endif()
 
 ament_vendor(assimp_vendor
@@ -41,6 +42,7 @@ ament_vendor(assimp_vendor
     -DASSIMP_BUILD_SAMPLES:BOOL=OFF
     "${ASSIMP_CMAKE_FLAGS}"
     "-DCMAKE_CXX_FLAGS=${ASSIMP_CXX_FLAGS}"
+    "-DCMAKE_C_FLAGS=${ASSIMP_C_FLAGS}"
 )
 
 if(BUILD_TESTING)

--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -29,6 +29,9 @@ else()
   set(ASSIMP_CMAKE_FLAGS "-DCMAKE_INSTALL_LIBDIR=lib")
 
   set(ASSIMP_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS}")
+  # assimp version 5.3.1 still uses K&R style function prototypes,
+  # which are deprecated as of gcc 13.2 (in Ubuntu 24.04).
+  # Suppress the warning here for now.
   set(ASSIMP_C_FLAGS "-Wno-deprecated-non-prototype ${CMAKE_C_FLAGS}")
 endif()
 


### PR DESCRIPTION
There many warnings on this CI job https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1868/clang-tidy/new/folder.-847954078/

This PR should fix them