### PR TITLE
Support Qt6

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -18,24 +18,24 @@ find_package(rviz_common REQUIRED)
 
 find_package(rviz_ogre_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
-if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
-  get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)
+if(Qt6_FOUND AND WIN32 AND TARGET Qt6::qmake AND NOT TARGET Qt6::windeployqt)
+  get_target_property(_qt6_qmake_location Qt6::qmake IMPORTED_LOCATION)
 
   execute_process(
-    COMMAND "${_qt5_qmake_location}" -query QT_INSTALL_PREFIX
+    COMMAND "${_qt6_qmake_location}" -query QT_INSTALL_PREFIX
     RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE qt5_install_prefix
+    OUTPUT_VARIABLE qt6_install_prefix
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-  set(imported_location "${qt5_install_prefix}/bin/windeployqt.exe")
+  set(imported_location "${qt6_install_prefix}/bin/windeployqt.exe")
 
   if(EXISTS ${imported_location})
-    add_executable(Qt5::windeployqt IMPORTED)
+    add_executable(Qt6::windeployqt IMPORTED)
 
-    set_target_properties(Qt5::windeployqt PROPERTIES
+    set_target_properties(Qt6::windeployqt PROPERTIES
       IMPORTED_LOCATION ${imported_location}
     )
   endif()
@@ -48,21 +48,21 @@ target_link_libraries(${PROJECT_NAME}
   rviz_common::rviz_common
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
-  Qt5::Widgets
+  Qt6::Widgets
 )
 
 # TODO(wjwwood): find a way to make this optional or to run without "deploying" the
 #                necessary dlls and stuff to the bin folder.
 #                see:
 # https://stackoverflow.com/questions/41193584/deploy-all-qt-dependencies-when-building#41199492
-if(TARGET Qt5::windeployqt)
+if(TARGET Qt6::windeployqt)
   # execute windeployqt in a tmp directory after build
   add_custom_command(TARGET ${PROJECT_NAME}
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
-    COMMAND set PATH=%PATH%$<SEMICOLON>${qt5_install_prefix}/bin
+    COMMAND set PATH=%PATH%$<SEMICOLON>${qt6_install_prefix}/bin
     COMMAND
-    Qt5::windeployqt
+    Qt6::windeployqt
     --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/$<TARGET_FILE_NAME:${PROJECT_NAME}>"
   )

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(ament_cmake REQUIRED)
 # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
 find_package(rviz_ogre_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 find_package(geometry_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -131,7 +131,7 @@ set(rviz_common_headers_to_moc
 )
 
 foreach(header "${rviz_common_headers_to_moc}")
-  qt5_wrap_cpp(rviz_common_moc_files "${header}")
+  qt6_wrap_cpp(rviz_common_moc_files "${header}")
 endforeach()
 
 set(rviz_common_source_files
@@ -239,7 +239,7 @@ target_link_libraries(rviz_common PUBLIC
   ${geometry_msgs_TARGETS}
   message_filters::message_filters
   pluginlib::pluginlib
-  Qt5::Widgets
+  Qt6::Widgets
   rclcpp::rclcpp
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
@@ -265,7 +265,7 @@ ament_export_dependencies(
   geometry_msgs
   message_filters
   pluginlib
-  Qt5
+  Qt6
   rclcpp
   rviz_ogre_vendor
   rviz_rendering
@@ -324,10 +324,10 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
 
-  qt5_wrap_cpp(rviz_common_test_moc_files test/mock_display.hpp)
-  qt5_wrap_cpp(rviz_common_test_moc_files test/mock_property_change_receiver.hpp)
+  qt6_wrap_cpp(rviz_common_test_moc_files test/mock_display.hpp)
+  qt6_wrap_cpp(rviz_common_test_moc_files test/mock_property_change_receiver.hpp)
 
-  qt5_wrap_cpp(rviz_common_test_frame_manager_moc src/rviz_common/frame_manager.hpp)
+  qt6_wrap_cpp(rviz_common_test_frame_manager_moc src/rviz_common/frame_manager.hpp)
 
   ament_add_gmock(display_factory_test
     test/display_factory_test.cpp
@@ -336,7 +336,7 @@ if(BUILD_TESTING)
   if(TARGET display_factory_test)
     target_compile_definitions(display_factory_test PUBLIC
       -D_TEST_PLUGIN_DESCRIPTIONS="${CMAKE_CURRENT_SOURCE_DIR}")
-    target_link_libraries(display_factory_test rviz_common Qt5::Widgets)
+    target_link_libraries(display_factory_test rviz_common Qt6::Widgets)
   endif()
 
   ament_add_gmock(frame_manager_test
@@ -445,7 +445,7 @@ if(BUILD_TESTING)
     test/mock_property_change_receiver.cpp
     ${SKIP_DISPLAY_TESTS})
   if(TARGET rviz_common_display_test)
-    target_link_libraries(rviz_common_display_test rviz_common Qt5::Widgets yaml-cpp::yaml-cpp)
+    target_link_libraries(rviz_common_display_test rviz_common Qt6::Widgets yaml-cpp::yaml-cpp)
   endif()
 endif()
 

--- a/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
@@ -31,6 +31,8 @@
 
 #include <string>
 
+#include <QRegularExpression>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/editable_enum_property.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
 #include "rviz_common/visibility_control.hpp"
@@ -89,20 +91,20 @@ public:
     const QString & default_value = QString(),
     const QString & message_type = QString(),
     const QString & description = QString(),
-    const QRegExp & filter = QRegExp(),
+    const QRegularExpression & filter = QRegularExpression(),
     Property * parent = 0,
     const char * changed_slot = 0,
     QObject * receiver = 0);
 
   void enableFilter(bool enabled);
 
-  QRegExp filter() const;
+  QRegularExpression filter() const;
 
 protected Q_SLOTS:
   void fillTopicList() override;
 
 private:
-  QRegExp filter_;
+  QRegularExpression filter_;
   bool filter_enabled_;
 };
 

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -26,16 +26,16 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>libqt5-svg-dev</build_depend>
-  <build_depend>qtbase5-dev</build_depend>
+  <build_depend>libqt6-svg-dev</build_depend>
+  <build_depend>qtbase6-dev</build_depend>
 
-  <build_export_depend>qtbase5-dev</build_export_depend>
+  <build_export_depend>qtbase6-dev</build_export_depend>
 
-  <exec_depend>libqt5-core</exec_depend>
-  <exec_depend>libqt5-gui</exec_depend>
-  <exec_depend>libqt5-opengl</exec_depend>
-  <exec_depend>libqt5-svg</exec_depend>
-  <exec_depend>libqt5-widgets</exec_depend>
+  <exec_depend>libqt6-core</exec_depend>
+  <exec_depend>libqt6-gui</exec_depend>
+  <exec_depend>libqt6-opengl</exec_depend>
+  <exec_depend>libqt6-svg</exec_depend>
+  <exec_depend>libqt6-widgets</exec_depend>
 
   <depend>geometry_msgs</depend>
   <depend>pluginlib</depend>

--- a/rviz_common/rviz_common-extras.cmake
+++ b/rviz_common/rviz_common-extras.cmake
@@ -25,6 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# find package Qt5 because otherwise using the rviz_common::rviz_common
-# exported target will complain that the Qt5::Widgets target does not exist
-find_package(Qt5 REQUIRED QUIET COMPONENTS Widgets)
+# find package Qt6 because otherwise using the rviz_common::rviz_common
+# exported target will complain that the Qt6::Widgets target does not exist
+find_package(Qt6 REQUIRED QUIET COMPONENTS Widgets)

--- a/rviz_common/src/rviz_common/add_display_dialog.cpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.cpp
@@ -49,6 +49,7 @@
 #include <QTabWidget>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTextBrowser>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here
+#include <QRegularExpression>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rcl/validate_topic_name.h"
 
@@ -590,7 +591,7 @@ void TopicDisplayWidget::findPlugins(DisplayFactory * factory)
       // For now, we assume that all types supported by plugins have the form
       // "<pkg_name>/msg/<type_name>", though in the future zero or more namespaces may be
       // permitted.
-      QRegExp delim("/");
+      QRegularExpression delim("/");
       QStringList topic_type_parts = topic_type.split(delim);
       if (topic_type_parts.size() == 2) {
         topic_type = topic_type_parts.at(0) + "/msg/" + topic_type_parts.at(1);

--- a/rviz_common/src/rviz_common/properties/property_tree_model.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_model.cpp
@@ -34,6 +34,7 @@
 
 #include <QMimeData>  // NOLINT: cpplint is unable to handle the include order here
 #include <QStringList>  // NOLINT: cpplint is unable to handle the include order here
+#include <QIODevice>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/property.hpp"
 

--- a/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
@@ -94,7 +94,7 @@ RosFilteredTopicProperty::RosFilteredTopicProperty(
   const QString & default_value,
   const QString & message_type,
   const QString & description,
-  const QRegExp & filter,
+  const QRegularExpression & filter,
   Property * parent,
   const char * changed_slot,
   QObject * receiver)
@@ -110,7 +110,7 @@ void RosFilteredTopicProperty::enableFilter(bool enabled)
   fillTopicList();
 }
 
-QRegExp RosFilteredTopicProperty::filter() const
+QRegularExpression RosFilteredTopicProperty::filter() const
 {
   return filter_;
 }

--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -35,7 +35,7 @@
 
 #include <QKeyEvent>  // NOLINT: cpplint is unable to handle the include order here
 #include <QKeySequence>  // NOLINT: cpplint is unable to handle the include order here
-#include <QRegExp>  // NOLINT: cpplint is unable to handle the include order here
+#include <QRegularExpression>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/logging.hpp"
 
@@ -52,7 +52,7 @@ using rviz_common::properties::PropertyTreeModel;
 
 QString addSpaceToCamelCase(QString input)
 {
-  QRegExp re = QRegExp("([A-Z])([a-z]*)");
+  QRegularExpression re = QRegularExpression("([A-Z])([a-z]*)");
   input.replace(re, " \\1\\2");
   return input.trimmed();
 }

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -42,6 +42,7 @@
 #include <OgreMeshManager.h>
 #include <OgreMaterialManager.h>
 
+#include <QActionGroup>  // NOLINT cpplint cannot handle include order here
 #include <QApplication>  // NOLINT cpplint cannot handle include order here
 #include <QCloseEvent>  // NOLINT cpplint cannot handle include order here
 #include <QDesktopServices>  // NOLINT cpplint cannot handle include order here
@@ -262,7 +263,7 @@ void VisualizationFrame::initialize(
   QWidget * central_widget = new QWidget(this);
   QHBoxLayout * central_layout = new QHBoxLayout;
   central_layout->setSpacing(0);
-  central_layout->setMargin(0);
+  central_layout->setContentsMargins(0, 0, 0, 0);
 
   render_panel_ = new RenderPanel(central_widget);
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -57,7 +57,7 @@ find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Test)
 
 find_package(geometry_msgs REQUIRED)
 
@@ -135,7 +135,7 @@ set(rviz_default_plugins_headers_to_moc
 )
 
 foreach(header "${rviz_default_plugins_headers_to_moc}")
-  qt5_wrap_cpp(rviz_default_plugins_moc_files "${header}")
+  qt6_wrap_cpp(rviz_default_plugins_moc_files "${header}")
 endforeach()
 
 set(rviz_default_plugins_source_files
@@ -240,7 +240,7 @@ add_library(rviz_default_plugins SHARED
 target_include_directories(rviz_default_plugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
-  ${Qt5Widgets_INCLUDE_DIRS}
+  ${Qt6Widgets_INCLUDE_DIRS}
 )
 
 target_link_libraries(rviz_default_plugins PUBLIC
@@ -365,7 +365,7 @@ if(BUILD_TESTING)
     target_link_libraries(fps_view_controller_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
-      Qt5::Widgets
+      Qt6::Widgets
       ogre_testing_environment
     )
   endif()
@@ -402,7 +402,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET image_display_test)
     target_include_directories(image_display_test PRIVATE test)
-    target_link_libraries(image_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt5::Widgets rviz_default_plugins ogre_testing_environment)
+    target_link_libraries(image_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} Qt6::Widgets rviz_default_plugins ogre_testing_environment)
   endif()
 
   add_library(marker_messages STATIC test/rviz_default_plugins/displays/marker/marker_messages.cpp)
@@ -495,7 +495,7 @@ if(BUILD_TESTING)
     target_include_directories(orbit_view_controller_test PRIVATE test)
     target_link_libraries(orbit_view_controller_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      Qt5::Widgets
+      Qt6::Widgets
       rviz_default_plugins
       ogre_testing_environment
     )
@@ -509,7 +509,7 @@ if(BUILD_TESTING)
     target_include_directories(ortho_view_controller_test PRIVATE test)
     target_link_libraries(ortho_view_controller_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      Qt5::Widgets
+      Qt6::Widgets
       rviz_default_plugins
       ogre_testing_environment
     )
@@ -602,7 +602,7 @@ if(BUILD_TESTING)
     target_include_directories(point_cloud_transformers_test PRIVATE test)
     target_link_libraries(point_cloud_transformers_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      Qt5::Widgets
+      Qt6::Widgets
       rviz_default_plugins
       pointcloud_messages
       ogre_testing_environment
@@ -659,7 +659,7 @@ if(BUILD_TESTING)
     target_link_libraries(robot_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       resource_retriever::resource_retriever
-      Qt5::Widgets
+      Qt6::Widgets
       rviz_default_plugins
       ogre_testing_environment
     )
@@ -696,7 +696,7 @@ if(BUILD_TESTING)
     target_include_directories(xy_orbit_view_controller_test PRIVATE test)
     target_link_libraries(xy_orbit_view_controller_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      Qt5::Widgets
+      Qt6::Widgets
       rviz_default_plugins
       ogre_testing_environment
     )
@@ -773,7 +773,7 @@ if(BUILD_TESTING)
   endif()
 
   add_library(point_cloud_common_page_object STATIC test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp)
-  target_link_libraries(point_cloud_common_page_object PRIVATE Qt5::Test rviz_visual_testing_framework::rviz_visual_testing_framework)
+  target_link_libraries(point_cloud_common_page_object PRIVATE Qt6::Test rviz_visual_testing_framework::rviz_visual_testing_framework)
 
   ament_add_gtest(camera_display_visual_test
     test/rviz_default_plugins/displays/camera/camera_display_visual_test.cpp
@@ -787,7 +787,7 @@ if(BUILD_TESTING)
       rclcpp::rclcpp
       ${sensor_msgs_TARGETS}
       ${std_msgs_TARGETS}
-      Qt5::Test
+      Qt6::Test
       ${geometry_msgs_TARGETS}
       tf2::tf2
       point_cloud_common_page_object
@@ -830,7 +830,7 @@ if(BUILD_TESTING)
     target_include_directories(fluid_pressure_display_visual_test PRIVATE test)
     target_link_libraries(fluid_pressure_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Test
+      Qt6::Test
       rclcpp::rclcpp
       pointcloud_messages
       point_cloud_common_page_object
@@ -845,7 +845,7 @@ if(BUILD_TESTING)
   if(TARGET grid_display_visual_test)
     target_include_directories(grid_display_visual_test PRIVATE test)
     target_link_libraries(grid_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
     )
   endif()
@@ -870,7 +870,7 @@ if(BUILD_TESTING)
   if(TARGET illuminance_display_visual_test)
     target_include_directories(illuminance_display_visual_test PRIVATE test)
     target_link_libraries(illuminance_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       pointcloud_messages
       point_cloud_common_page_object
@@ -885,7 +885,7 @@ if(BUILD_TESTING)
   if(TARGET image_display_visual_test)
     target_include_directories(image_display_visual_test PRIVATE test)
     target_link_libraries(image_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       rclcpp::rclcpp
       ${sensor_msgs_TARGETS}
@@ -901,7 +901,7 @@ if(BUILD_TESTING)
     target_include_directories(interactive_marker_namespace_property_test PRIVATE test)
     target_link_libraries(interactive_marker_namespace_property_test
       rviz_default_plugins
-      Qt5::Widgets
+      Qt6::Widgets
       ogre_testing_environment
     )
   endif()
@@ -914,13 +914,13 @@ if(BUILD_TESTING)
     target_include_directories(laser_scan_display_visual_test PRIVATE test)
     target_link_libraries(laser_scan_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Test
+      Qt6::Test
       point_cloud_common_page_object
     )
   endif()
 
   add_library(marker_display_page_object STATIC test/rviz_default_plugins/page_objects/marker_display_page_object.cpp)
-  target_link_libraries(marker_display_page_object PRIVATE Qt5::Widgets rviz_visual_testing_framework::rviz_visual_testing_framework)
+  target_link_libraries(marker_display_page_object PRIVATE Qt6::Widgets rviz_visual_testing_framework::rviz_visual_testing_framework)
 
   ament_add_gtest(map_display_visual_test
     test/rviz_default_plugins/displays/map/map_display_visual_test.cpp
@@ -931,7 +931,7 @@ if(BUILD_TESTING)
     target_include_directories(map_display_visual_test PRIVATE test)
     target_link_libraries(map_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${geometry_msgs_TARGETS}
@@ -950,7 +950,7 @@ if(BUILD_TESTING)
     target_include_directories(marker_array_display_visual_test PRIVATE test)
     target_link_libraries(marker_array_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${visualization_msgs_TARGETS}
@@ -966,7 +966,7 @@ if(BUILD_TESTING)
     target_include_directories(marker_display_visual_test PRIVATE test)
     target_link_libraries(marker_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${visualization_msgs_TARGETS}
@@ -983,7 +983,7 @@ if(BUILD_TESTING)
     target_include_directories(odometry_display_visual_test PRIVATE test)
     target_link_libraries(odometry_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${geometry_msgs_TARGETS}
@@ -1000,7 +1000,7 @@ if(BUILD_TESTING)
   if(TARGET path_display_visual_test)
     target_include_directories(path_display_visual_test PRIVATE test)
     target_link_libraries(path_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
@@ -1018,7 +1018,7 @@ if(BUILD_TESTING)
     target_include_directories(point_display_visual_test PRIVATE test)
     target_link_libraries(point_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       ${geometry_msgs_TARGETS}
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
@@ -1032,7 +1032,7 @@ if(BUILD_TESTING)
   if(TARGET point_cloud_display_visual_test)
     target_include_directories(point_cloud_display_visual_test PRIVATE test)
     target_link_libraries(point_cloud_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       ${geometry_msgs_TARGETS}
       tf2::tf2
@@ -1050,7 +1050,7 @@ if(BUILD_TESTING)
   if(TARGET point_cloud2_display_visual_test)
     target_include_directories(point_cloud2_display_visual_test PRIVATE test)
     target_link_libraries(point_cloud2_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       pointcloud_messages
       point_cloud_common_page_object
@@ -1058,7 +1058,7 @@ if(BUILD_TESTING)
   endif()
 
   add_library(pose_display_page_object STATIC test/rviz_default_plugins/page_objects/pose_display_page_object.cpp)
-  target_link_libraries(pose_display_page_object PRIVATE Qt5::Widgets rviz_visual_testing_framework::rviz_visual_testing_framework)
+  target_link_libraries(pose_display_page_object PRIVATE Qt6::Widgets rviz_visual_testing_framework::rviz_visual_testing_framework)
 
   ament_add_gtest(pose_array_display_visual_test
     test/rviz_default_plugins/displays/pose_array/pose_array_display_visual_test.cpp
@@ -1069,7 +1069,7 @@ if(BUILD_TESTING)
     target_include_directories(pose_array_display_visual_test PRIVATE test)
     target_link_libraries(pose_array_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
       ${geometry_msgs_TARGETS}
@@ -1085,7 +1085,7 @@ if(BUILD_TESTING)
     target_include_directories(pose_display_visual_test PRIVATE test)
     target_link_libraries(pose_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       ${geometry_msgs_TARGETS}
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
@@ -1102,7 +1102,7 @@ if(BUILD_TESTING)
     target_include_directories(pose_with_covariance_display_visual_test PRIVATE test)
     target_link_libraries(pose_with_covariance_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
       ${geometry_msgs_TARGETS}
       rclcpp::rclcpp
       ${std_msgs_TARGETS}
@@ -1119,7 +1119,7 @@ if(BUILD_TESTING)
     target_include_directories(range_display_visual_test PRIVATE test)
     target_link_libraries(range_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
     )
   endif()
 
@@ -1130,7 +1130,7 @@ if(BUILD_TESTING)
   if(TARGET relative_humidity_display_visual_test)
     target_include_directories(relative_humidity_display_visual_test PRIVATE test)
     target_link_libraries(relative_humidity_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       point_cloud_common_page_object
     )
@@ -1156,7 +1156,7 @@ if(BUILD_TESTING)
   if(TARGET temperature_display_visual_test)
     target_include_directories(temperature_display_visual_test PRIVATE test)
     target_link_libraries(temperature_display_visual_test
-      Qt5::Test
+      Qt6::Test
       rviz_visual_testing_framework::rviz_visual_testing_framework
       point_cloud_common_page_object
     )
@@ -1171,7 +1171,7 @@ if(BUILD_TESTING)
     target_include_directories(tf_display_visual_test PRIVATE test)
     target_link_libraries(tf_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
     )
   endif()
 
@@ -1199,7 +1199,7 @@ if(BUILD_TESTING)
     target_include_directories(wrench_display_visual_test PRIVATE test)
     target_link_libraries(wrench_display_visual_test
       rviz_visual_testing_framework::rviz_visual_testing_framework
-      Qt5::Widgets
+      Qt6::Widgets
     )
   endif()
 endif()

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -31,10 +31,10 @@
 
   <build_export_depend>rviz_ogre_vendor</build_export_depend>
 
-  <exec_depend>libqt5-core</exec_depend>
-  <exec_depend>libqt5-gui</exec_depend>
-  <exec_depend>libqt5-opengl</exec_depend>
-  <exec_depend>libqt5-widgets</exec_depend>
+  <exec_depend>libqt6-core</exec_depend>
+  <exec_depend>libqt6-gui</exec_depend>
+  <exec_depend>libqt6-opengl</exec_depend>
+  <exec_depend>libqt6-widgets</exec_depend>
   <exec_depend>rviz_ogre_vendor</exec_depend>
 
   <depend>geometry_msgs</depend>

--- a/rviz_default_plugins/rviz_default_plugins-extras.cmake
+++ b/rviz_default_plugins/rviz_default_plugins-extras.cmake
@@ -25,6 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# find package Qt5 because otherwise using the rviz_default_plugins::rviz_default_plugins
-# exported target will complain that the Qt5::Widgets target does not exist
-find_package(Qt5 REQUIRED QUIET COMPONENTS Widgets)
+# find package Qt6 because otherwise using the rviz_default_plugins::rviz_default_plugins
+# exported target will complain that the Qt6::Widgets target does not exist
+find_package(Qt6 REQUIRED QUIET COMPONENTS Widgets)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
@@ -33,7 +33,7 @@
 #include <Ogre.h>
 #include <tf2_ros/message_filter.h>
 
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include <iostream>
 #include <functional>
@@ -80,9 +80,12 @@ DepthCloudDisplay::DepthCloudDisplay()
   , trans_thres_(0.01f)
 {
   ml_depth_data_ = std::make_unique<rviz_common::MultiLayerDepth>();
+
+  // Set options for case insensitivity
+  auto reOptions =  QRegularExpression::CaseInsensitiveOption;
+
   // Depth map properties
-  QRegExp depth_filter("depth");
-  depth_filter.setCaseSensitivity(Qt::CaseInsensitive);
+  QRegularExpression depth_filter("depth", reOptions);
 
   reliability_policy_property_ = new rviz_common::properties::EditableEnumProperty(
     "Reliability Policy",
@@ -119,8 +122,7 @@ DepthCloudDisplay::DepthCloudDisplay()
   depth_transport_property_->setStdString("raw");
 
   // color image properties
-  QRegExp color_filter("color|rgb|bgr|gray|mono");
-  color_filter.setCaseSensitivity(Qt::CaseInsensitive);
+  QRegularExpression color_filter("color|rgb|bgr|gray|mono", reOptions);
 
   color_topic_property_ = new rviz_common::properties::RosFilteredTopicProperty(
     "Color Image Topic", "",

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_assimp_vendor REQUIRED)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
 
 find_package(ament_index_cpp REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
@@ -41,29 +41,29 @@ find_package(Eigen3 REQUIRED)
 find_package(resource_retriever REQUIRED)
 
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
-if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
-  get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)
+if(Qt6_FOUND AND WIN32 AND TARGET Qt6::qmake AND NOT TARGET Qt6::windeployqt)
+  get_target_property(_qt6_qmake_location Qt6::qmake IMPORTED_LOCATION)
 
   execute_process(
-    COMMAND "${_qt5_qmake_location}" -query QT_INSTALL_PREFIX
+    COMMAND "${_qt6_qmake_location}" -query QT_INSTALL_PREFIX
     RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE qt5_install_prefix
+    OUTPUT_VARIABLE qt6_install_prefix
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-  set(imported_location "${qt5_install_prefix}/bin/windeployqt.exe")
+  set(imported_location "${qt6_install_prefix}/bin/windeployqt.exe")
 
   if(EXISTS ${imported_location})
-    add_executable(Qt5::windeployqt IMPORTED)
+    add_executable(Qt6::windeployqt IMPORTED)
 
-    set_target_properties(Qt5::windeployqt PROPERTIES
+    set_target_properties(Qt6::windeployqt PROPERTIES
       IMPORTED_LOCATION ${imported_location}
     )
   endif()
 endif()
 
 # These need to be added in the add_library() call
-qt5_wrap_cpp(rviz_rendering_moc_files include/rviz_rendering/render_window.hpp)
+qt6_wrap_cpp(rviz_rendering_moc_files include/rviz_rendering/render_window.hpp)
 
 add_library(rviz_rendering SHARED
   ${rviz_rendering_moc_files}
@@ -100,7 +100,7 @@ add_library(rviz_rendering SHARED
 )
 
 target_link_libraries(rviz_rendering PUBLIC
-  Qt5::Widgets
+  Qt6::Widgets
   rviz_ogre_vendor::OgreMain
   rviz_ogre_vendor::OgreOverlay
 )
@@ -128,7 +128,7 @@ target_compile_definitions(rviz_rendering PRIVATE "RVIZ_RENDERING_BUILDING_LIBRA
 
 ament_export_dependencies(
   Eigen3
-  Qt5
+  Qt6
   rviz_ogre_vendor
 )
 
@@ -194,7 +194,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -206,7 +206,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -218,7 +218,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -230,7 +230,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -242,7 +242,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -254,7 +254,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -267,7 +267,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreOverlay
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets
+      Qt6::Widgets
     )
   endif()
 
@@ -279,7 +279,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -291,7 +291,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -303,7 +303,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -315,7 +315,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 
@@ -327,7 +327,7 @@ if(BUILD_TESTING)
       rviz_ogre_vendor::OgreMain
       rviz_rendering
       rviz_rendering_test_utils
-      Qt5::Widgets  # explicitly do this for include directories (not necessary for external use)
+      Qt6::Widgets  # explicitly do this for include directories (not necessary for external use)
     )
   endif()
 endif()

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -41,10 +41,10 @@
   <build_export_depend>rviz_ogre_vendor</build_export_depend>
 
   <exec_depend>ament_index_cpp</exec_depend>
-  <exec_depend>libqt5-core</exec_depend>
-  <exec_depend>libqt5-gui</exec_depend>
-  <exec_depend>libqt5-opengl</exec_depend>
-  <exec_depend>libqt5-widgets</exec_depend>
+  <exec_depend>libqt6-core</exec_depend>
+  <exec_depend>libqt6-gui</exec_depend>
+  <exec_depend>libqt6-opengl</exec_depend>
+  <exec_depend>libqt6-widgets</exec_depend>
   <exec_depend>resource_retriever</exec_depend>
   <exec_depend>rviz_assimp_vendor</exec_depend>
   <exec_depend>rviz_ogre_vendor</exec_depend>

--- a/rviz_rendering/rviz_rendering-extras.cmake
+++ b/rviz_rendering/rviz_rendering-extras.cmake
@@ -25,6 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# find package Qt5 because otherwise using the rviz_rendering::rviz_rendering
-# exported target will complain that the Qt5::Widgets target does not exist
-find_package(Qt5 REQUIRED QUIET COMPONENTS Widgets)
+# find package Qt6 because otherwise using the rviz_rendering::rviz_rendering
+# exported target will complain that the Qt6::Widgets target does not exist
+find_package(Qt6 REQUIRED QUIET COMPONENTS Widgets)

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
@@ -62,7 +62,7 @@ namespace rviz_rendering
 /// Implementation for the rviz_rendering::RenderWindow class that uses Ogre.
 /**
  * Based on the QtOgreRenderWindow from previous versions of rviz and new
- * Ogre/Qt5 integration recommendationd.
+ * Ogre/Qt6 integration recommendationd.
  */
 class RenderWindowImpl
 {

--- a/rviz_rendering/src/rviz_rendering/render_window.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window.cpp
@@ -27,13 +27,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-// This class is based on the Ogre documentation's recommendation on how to use with Qt5:
+// This class is based on the Ogre documentation's recommendation on how to use with Qt6:
 //
 //   http://www.ogre3d.org/tikiwiki/tiki-index.php?page=Integrating+Ogre+into+QT5
 //
 // Which is in the public domain.
 //
-// As well as the Qt5 suggestions on how to integrate with OpenGL:
+// As well as the Qt6 suggestions on how to integrate with OpenGL:
 //
 //   https://doc.qt.io/qt-5/qtgui-openglwindow-example.html
 //

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(ament_cmake REQUIRED)
 if(BUILD_TESTING)
   # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
   find_package(rviz_ogre_vendor REQUIRED)
-  find_package(Qt5 REQUIRED COMPONENTS Widgets)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets)
   find_package(rviz_rendering REQUIRED)
   find_package(resource_retriever REQUIRED)
 

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Test)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rviz_common REQUIRED)
@@ -39,13 +39,13 @@ find_package(ament_cmake_gtest REQUIRED)
 ament_find_gtest()
 
 # TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
-if(Qt5_FOUND AND WIN32 AND TARGET Qt5::qmake AND NOT TARGET Qt5::windeployqt)
-  get_target_property(_qt5_qmake_location Qt5::qmake IMPORTED_LOCATION)
+if(Qt6_FOUND AND WIN32 AND TARGET Qt6::qmake AND NOT TARGET Qt6::windeployqt)
+  get_target_property(_qt6_qmake_location Qt6::qmake IMPORTED_LOCATION)
 
   execute_process(
-    COMMAND "${_qt5_qmake_location}" -query QT_INSTALL_PREFIX
+    COMMAND "${_qt6_qmake_location}" -query QT_INSTALL_PREFIX
     RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE qt5_install_prefix
+    OUTPUT_VARIABLE qt6_install_prefix
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 endif()
@@ -71,8 +71,8 @@ target_include_directories(rviz_visual_testing_framework
 
 target_link_libraries(rviz_visual_testing_framework PUBLIC
   ${geometry_msgs_TARGETS}
-  Qt5::Test
-  Qt5::Widgets
+  Qt6::Test
+  Qt6::Widgets
   rclcpp::rclcpp
   rcutils::rcutils
   rviz_common::rviz_common
@@ -84,7 +84,7 @@ target_link_libraries(rviz_visual_testing_framework PUBLIC
 )
 
 # export information to downstream packages
-ament_export_dependencies(geometry_msgs Qt5 rclcpp rcutils rviz_common rviz_ogre_vendor rviz_rendering std_msgs tf2 tf2_ros)
+ament_export_dependencies(geometry_msgs Qt6 rclcpp rcutils rviz_common rviz_ogre_vendor rviz_rendering std_msgs tf2 tf2_ros)
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")

--- a/rviz_visual_testing_framework/docs/documentation.md
+++ b/rviz_visual_testing_framework/docs/documentation.md
@@ -109,7 +109,7 @@ In particular, for this mechanism to work, we also need to wrap the `ament_add_g
 
 Moreover, should it not already be present, the following should also be included:
 
-    find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
+    find_package(Qt6 REQUIRED COMPONENTS Widgets Test)
 
 ### How to write a test
 


### PR DESCRIPTION
Add support for Qt6. This makes building on macOS (M1 and Intel) simpler as the default version of Qt distributed with `brew` is as of now Qt 6.7.

Marked as draft as the PR needs to be modified to make using Qt6 an option rather than a requirement. Posting as this may be useful to other mac users looking to run ROS 2 Rolling natively.

## Tasks

- [ ] enable Qt6 as an option
- [ ] testing...