### PR TITLE
Fix ESC shortcut

### DIFF
--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -309,6 +309,9 @@ Q_SIGNALS:
   /// Emitted during file-loading and initialization to indicate progress.
   void statusUpdate(const QString & message);
 
+  /// Emmited when ESC key is pressed
+  void escapePressed();
+
 protected Q_SLOTS:
   /// Call update() on all managed objects.
   /**

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -331,6 +331,7 @@ void VisualizationFrame::initialize(
   ToolManager * tool_man = manager_->getToolManager();
 
   connect(manager_, SIGNAL(configChanged()), this, SLOT(setDisplayConfigModified()));
+  connect(manager_, SIGNAL(escapePressed()), this, SLOT(exitFullScreen()));
   connect(tool_man, SIGNAL(toolAdded(Tool*)), this, SLOT(addTool(Tool*)));
   connect(tool_man, SIGNAL(toolRemoved(Tool*)), this, SLOT(removeTool(Tool*)));
   connect(tool_man, SIGNAL(toolRefreshed(Tool*)), this, SLOT(refreshTool(Tool*)));
@@ -486,7 +487,6 @@ void VisualizationFrame::initMenus()
   this->addAction(fullscreen_action);  // Also add to window, or the shortcut doest work
                                        // when the menu is hidden.
   connect(this, SIGNAL(fullScreenChange(bool)), fullscreen_action, SLOT(setChecked(bool)));
-  new QShortcut(Qt::Key_Escape, this, SLOT(exitFullScreen()));
   view_menu_->addSeparator();
 
   QMenu * help_menu = menuBar()->addMenu("&Help");

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -51,6 +51,7 @@
 
 #include <QApplication>  // NOLINT: cpplint cannot handle include order here
 #include <QCursor>  // NOLINT: cpplint cannot handle include order here
+#include <QKeyEvent>  // NOLINT: cpplint cannot handle include order here
 #include <QTimer>  // NOLINT: cpplint cannot handle include order here
 #include <QWindow>  // NOLINT: cpplint cannot handle include order here
 
@@ -636,6 +637,9 @@ void VisualizationManager::handleMouseEvent(const ViewportMouseEvent & vme)
 
 void VisualizationManager::handleChar(QKeyEvent * event, RenderPanel * panel)
 {
+  if (event->key() == Qt::Key_Escape) {
+    Q_EMIT escapePressed();
+  }
   tool_manager_->handleChar(event, panel);
 }
 


### PR DESCRIPTION
This PR addresses #1119 by replacing the ESC shortcut for exiting full screen with the solution for the same issue merged in the ROS1 version of Rviz [here](https://github.com/ros-visualization/rviz/pull/1416)