### PR TITLE
Update  zlib 

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -33,7 +33,7 @@ if(WIN32)
 
   ament_vendor(zlib_vendor
     VCS_URL https://github.com/madler/zlib.git
-    VCS_VERSION v1.3
+    VCS_VERSION v1.3.1
     CMAKE_ARGS
       # zlib doesn't use CMAKE_INSTALL_PREFIX correctly, so we need to override
       -DINSTALL_BIN_DIR=<INSTALL_DIR>/bin


### PR DESCRIPTION
updated zlib
fix:
Reject overflows of zip header fields in minizip
Fix bug in inflateSync() for data held in bit buffer Add LIT_MEM define to use more memory for a small deflate speedup Fix decision on the emission of Zip64 end records in minizip Add bounds checking to ERR_MSG() macro, used by zError() Neutralize zip file traversal attacks in miniunz
Fix a bug in ZLIB_DEBUG compiles in check_match()