### PR TITLE
Fix: issue #1220.

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -250,7 +250,7 @@ std::vector<Ogre::MaterialPtr> AssimpLoader::loadMaterials(
 {
   std::vector<Ogre::MaterialPtr> material_table_out;
 
-  std::string ext = std::filesystem::path(resource_path).extension();
+  std::string ext = std::filesystem::path(resource_path).extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(),
     [](unsigned char c) {return std::tolower(c);});
   // STL meshes don't support proper

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -31,6 +31,9 @@
 
 #include "assimp_loader.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -246,6 +249,18 @@ std::vector<Ogre::MaterialPtr> AssimpLoader::loadMaterials(
   const std::string & resource_path, const aiScene * scene)
 {
   std::vector<Ogre::MaterialPtr> material_table_out;
+
+  std::string ext = std::filesystem::path(resource_path).extension();
+  std::transform(ext.begin(), ext.end(), ext.begin(),
+    [](unsigned char c) { return std::tolower(c); });
+  // STL meshes don't support proper
+  // materials: use Ogre's default material
+  if (ext == ".stl" || ext == ".stlb") {
+    material_table_out.push_back(
+      Ogre::MaterialManager::getSingleton().getByName("BaseWhiteNoLighting"));
+    return material_table_out;
+  }
+
   for (uint32_t i = 0; i < scene->mNumMaterials; i++) {
     std::string material_name;
     material_name = resource_path + "Material" + std::to_string(i);

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -252,7 +252,7 @@ std::vector<Ogre::MaterialPtr> AssimpLoader::loadMaterials(
 
   std::string ext = std::filesystem::path(resource_path).extension();
   std::transform(ext.begin(), ext.end(), ext.begin(),
-    [](unsigned char c) { return std::tolower(c); });
+    [](unsigned char c) {return std::tolower(c);});
   // STL meshes don't support proper
   // materials: use Ogre's default material
   if (ext == ".stl" || ext == ".stlb") {

--- a/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_logging.cpp
@@ -67,6 +67,9 @@ public:
           case Ogre::LogMessageLevel::LML_NORMAL:
             RVIZ_RENDERING_LOG_INFO(message.c_str());
             break;
+          case Ogre::LogMessageLevel::LML_WARNING:
+            RVIZ_RENDERING_LOG_WARNING(message.c_str());
+            break;
           case Ogre::LogMessageLevel::LML_CRITICAL:
             RVIZ_RENDERING_LOG_ERROR(message.c_str());
             break;


### PR DESCRIPTION
Fix: issue #1220. 

The stl loader has been changed in [PR](https://github.com/ros2/rviz/pull/1063
) to refer to that of ROS1. 
However, the material setting part of stl is missing, which is causing issue #1220  where colors are not displayed correctly.

Therefore, I created a modified PR by referring to the ROS1 code
https://github.com/ros-visualization/rviz/blob/fdcf656aa5d9816bf7c06a533f8224ec28bd6e0f/src/rviz/mesh_loader.cpp#L445-L456