### PR TITLE
Correctly load icons of panels with whitespaces in their name

### DIFF
--- a/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp
+++ b/rviz_common/include/rviz_common/factory/pluginlib_factory.hpp
@@ -177,7 +177,9 @@ protected:
       return loadPixmap(default_icon_path);
     }
 
-    auto base_path = "package://" + info.package + "/icons/classes/" + info.name;
+    auto encoded_name = info.name;
+    encoded_name.replace(" ", "%20");
+    auto base_path = "package://" + info.package + "/icons/classes/" + encoded_name;
     QIcon icon = loadPixmap(base_path + ".svg");
     if (icon.isNull()) {
       icon = loadPixmap(base_path + ".png");


### PR DESCRIPTION
In the pictures below, pay attention to `Tool Properties` icon.

Before:
![Screenshot from 2024-07-18 15-27-49](https://github.com/user-attachments/assets/108ad5ca-416a-40d1-a336-1dcb726a476e)

After:
![Screenshot from 2024-07-18 15-25-49](https://github.com/user-attachments/assets/ec079b49-f63d-44a8-a02f-906a50a85d90)

Basically, plugin name was not sanitized for whitespaces before encoding as URL for `resource_retriever` (CURL wrapper).