### PR TITLE
Revert "Update ASSIMP_VENDOR CMakeLists.txt"

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -4,9 +4,15 @@ project(rviz_assimp_vendor)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
+# Override ON so that the following CMake logic in assimp 5.0.1 and older
+# doesn't result in a CMake warning: if(ON)
+#   https://github.com/ros2/rviz/issues/524
+#   https://bugs.launchpad.net/ubuntu/+source/assimp/+bug/1869405
+set(ON 1)
+
 # TODO: Switch to version range in find_package in CMake 3.19
 find_package(assimp QUIET)
-if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 5.3.1)
+if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 5.2.0)
   set(assimp_FOUND FALSE)
 endif()
 
@@ -22,7 +28,7 @@ if(MSVC)
 else()
   set(ASSIMP_CMAKE_FLAGS "-DCMAKE_INSTALL_LIBDIR=lib")
 
-  set(ASSIMP_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
+  set(ASSIMP_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS}")
   # assimp version 5.3.1 still uses K&R style function prototypes,
   # which are deprecated as of gcc 13.2 (in Ubuntu 24.04).
   # Suppress the warning here for now.


### PR DESCRIPTION
Reverts ros2/rviz#1226

This seems to be causing multiple regressions (see https://github.com/ros2/rviz/pull/1226#issuecomment-2231377436 and https://github.com/ros2/rviz/pull/1226#issuecomment-2231431597), so let's revert it for now.