### PR TITLE
Added more time to copyright on Windwos

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -452,3 +452,7 @@ endif()
 ament_package(
   CONFIG_EXTRAS "rviz_common-extras.cmake"
 )
+
+if(TEST copyright)
+  set_tests_properties(copyright PROPERTIES TIMEOUT 600)
+endif()

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -1211,3 +1211,7 @@ ament_package(
 if(TEST cpplint)
   set_tests_properties(cpplint PROPERTIES TIMEOUT 180)
 endif()
+
+if(TEST copyright)
+  set_tests_properties(copyright PROPERTIES TIMEOUT 600)
+endif()

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -339,3 +339,7 @@ list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS
 ament_package(
   CONFIG_EXTRAS "rviz_rendering-extras.cmake"
 )
+
+if(TEST copyright)
+  set_tests_properties(copyright PROPERTIES TIMEOUT 600)
+endif()


### PR DESCRIPTION
I just saw that copyright sometimes is getting a timeout on Windows https://ci.ros2.org/view/nightly/job/nightly_win_deb/3165/#showFailuresLink This should fix the problem.