### PR TITLE
Detect wayland and make sure X rendering is used.

### DIFF
--- a/rviz2/src/main.cpp
+++ b/rviz2/src/main.cpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
+#include <QProcessEnvironment> // NOLINT: cpplint is unable to hande the include order here
 
 #include "rclcpp/rclcpp.hpp"
 #include "rviz_common/logging.hpp"
@@ -44,6 +45,20 @@ int main(int argc, char ** argv)
 {
   // remove ROS arguments before passing to QApplication
   std::vector<std::string> non_ros_args = rclcpp::remove_ros_arguments(argc, argv);
+
+  // check for wayland and if so force the use of X to render everything
+  // but only if the user hasn't already tried to specify -platform
+  // or override QT_QPA_PLATFORM
+  auto env = QProcessEnvironment::systemEnvironment();
+  if(env.value("XDG_SESSION_TYPE") == "wayland" &&
+    non_ros_args.end() == std::find(non_ros_args.begin(), non_ros_args.end(),
+      "-platform") &&
+    !env.contains("QT_QPA_PLATFORM"))
+  {
+    non_ros_args.push_back("-platform");
+    non_ros_args.push_back("xcb");
+  }
+
   std::vector<char *> non_ros_args_c_strings;
   for (auto & arg : non_ros_args) {
     non_ros_args_c_strings.push_back(&arg.front());


### PR DESCRIPTION
This patch causes rviz to detect Wayland and sets it to X compatibility mode, enabling it to run under Wayland.

Currently rviz2 does not support wayland (Issue #847), meaning that rviz2 crashes (e.g., issue #1227, #1245) for Wayland users unless they do a [manual workaround](https://docs.ros.org/en/rolling/How-To-Guides/Installation-Troubleshooting.html#cannot-start-rviz2).  

The current workaround of setting QT_QPA_PLUGIN has a few issues that make it less than ideal:
1. If it is set globally it forces all other QT applications to use X even if they support Wayland.
2. However, when using launchfiles that start rviz2, it needs to be set globally (or you need to modify the launch file) or rviz will crash on startup.
