### PR TITLE
Handle `Tool::Finished` returned by `processKeyEvent`

### DIFF
--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -158,6 +158,7 @@ void ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
     tool = shortkey_to_tool_map_[event->key()];
   }
 
+  int flags = 0;
   if (tool) {
     // if there is a incoming tool check if it matches the current tool
     if (current_tool_ == tool) {
@@ -167,7 +168,7 @@ void ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
       // if no, check if the current tool accesses all key events
       if (current_tool_->accessAllKeys()) {
         // if yes, pass the key
-        current_tool_->processKeyEvent(event, panel);
+        flags = current_tool_->processKeyEvent(event, panel);
       } else {
         // if no, switch the tool
         setCurrentTool(tool);
@@ -176,7 +177,11 @@ void ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
   } else {
     // if the incoming key triggers no other tool,
     // just hand down the key event
-    current_tool_->processKeyEvent(event, panel);
+    flags = current_tool_->processKeyEvent(event, panel);
+  }
+ 
+  if (flags & Tool::Finished) { 
+    setCurrentTool(getDefaultTool()); 
   }
 }
 

--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -179,9 +179,9 @@ void ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
     // just hand down the key event
     flags = current_tool_->processKeyEvent(event, panel);
   }
- 
-  if (flags & Tool::Finished) { 
-    setCurrentTool(getDefaultTool()); 
+
+  if (flags & Tool::Finished) {
+    setCurrentTool(getDefaultTool());
   }
 }
 


### PR DESCRIPTION
Partially fixes #1256.

This is a (probably backportable) patch that allows a Tool to declare its own use "Finished" and make Rviz re-select the default tool.


Please notice that some Tools defined in this codebase return another flag (`Render`, see attached issue) but this is not being handled too. 

### Note:

To process `Render` flag, an API breaking change shall be introduced (maybe in another PR) so that:
```
void ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
```
becomes:
```
int ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
```
to propagate flags up in the call hierarchy (up to the `VisualizationManager`).