### PR TITLE
Fix cve into assimp

### DIFF
--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 # TODO: Switch to version range in find_package in CMake 3.19
 find_package(assimp QUIET)
-if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 5.2.0)
+if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 5.4.2)
   set(assimp_FOUND FALSE)
 endif()
 
@@ -33,7 +33,7 @@ endif()
 ament_vendor(assimp_vendor
   SATISFIED ${assimp_FOUND}
   VCS_URL https://github.com/assimp/assimp.git
-  VCS_VERSION v5.3.1
+  VCS_VERSION v5.4.2
   CMAKE_ARGS
     -DASSIMP_BUILD_ASSIMP_TOOLS:BOOL=OFF
     -DASSIMP_BUILD_TESTS:BOOL=OFF

--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -7,12 +7,12 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 # TODO: Switch to version range in find_package in CMake 3.19
 find_package(assimp QUIET)
-if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 5.4.3)
+if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 6.0.2)
   set(assimp_FOUND FALSE)
 endif()
 
 if(MSVC)
-  # TODO(clalancette): When building assimp 5.2.2 on Windows Debug,
+  # TODO(clalancette): When building assimp 6.0.2 on Windows Debug,
   # it fails to install the PDB file with a "File exists" error.
   # Since we don't really need the PDB file, just unconditionally
   # disable it.
@@ -23,7 +23,7 @@ if(MSVC)
 else()
   set(ASSIMP_CMAKE_FLAGS "-DCMAKE_INSTALL_LIBDIR=lib")
 
-  set(ASSIMP_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS}")
+  set(ASSIMP_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
   # assimp version 5.3.1 still uses K&R style function prototypes,
   # which are deprecated as of gcc 13.2 (in Ubuntu 24.04).
   # Suppress the warning here for now.
@@ -33,7 +33,7 @@ endif()
 ament_vendor(assimp_vendor
   SATISFIED ${assimp_FOUND}
   VCS_URL https://github.com/assimp/assimp.git
-  VCS_VERSION v5.4.3
+  VCS_VERSION v6.0.2
   CMAKE_ARGS
     -DASSIMP_BUILD_ASSIMP_TOOLS:BOOL=OFF
     -DASSIMP_BUILD_TESTS:BOOL=OFF

--- a/rviz_assimp_vendor/CMakeLists.txt
+++ b/rviz_assimp_vendor/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 # TODO: Switch to version range in find_package in CMake 3.19
 find_package(assimp QUIET)
-if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 5.4.2)
+if(NOT assimp_FOUND OR "${assimp_VERSION}" VERSION_LESS 5.4.3)
   set(assimp_FOUND FALSE)
 endif()
 
@@ -33,7 +33,7 @@ endif()
 ament_vendor(assimp_vendor
   SATISFIED ${assimp_FOUND}
   VCS_URL https://github.com/assimp/assimp.git
-  VCS_VERSION v5.4.2
+  VCS_VERSION v5.4.3
   CMAKE_ARGS
     -DASSIMP_BUILD_ASSIMP_TOOLS:BOOL=OFF
     -DASSIMP_BUILD_TESTS:BOOL=OFF


### PR DESCRIPTION
Updated assimp .. is need to fix cve https://ubuntu.com/security/CVE-2024-40724
also fix Fixes https://github.com/advisories/GHSA-345v-qrhv-w227: Out-of-bounds Read in Assimp::CSMImporter::InternReadFile 
Fixes https://github.com/advisories/GHSA-4p6w-747g-444c: Heap-based Buffer Overflow in AI_MD5_PARSE_STRING_IN_QUOTATION 
Fixes https://github.com/advisories/GHSA-6x45-4j6r-r8x8: out of bounds write by assigning to wrong array element count tracking 
fix-https://github.com/advisories/GHSA-6r79-vpvw-rfjj: 
Fixes https://github.com/advisories/GHSA-6r79-vpvw-rfjj: Heap-based Buffer Overflow in Assimp::LWO::AnimResolver::UpdateAnimRangeSetup