### PR TITLE
Enabling manual space width for TextViewFacingMarker

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.cpp
@@ -85,6 +85,10 @@ void TextViewFacingMarker::onNewMessage(
   scene_node_->setVisible(true);
 
   setPosition(pos);
+  if (new_message->scale.x != 0.0)
+  {
+    text_->setSpaceWidth(new_message->scale.x);
+  }
   text_->setCharacterHeight(new_message->scale.z);
   text_->setColor(
     Ogre::ColourValue(

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/text_view_facing_marker.cpp
@@ -85,8 +85,7 @@ void TextViewFacingMarker::onNewMessage(
   scene_node_->setVisible(true);
 
   setPosition(pos);
-  if (new_message->scale.x != 0.0)
-  {
+  if (new_message->scale.x != 0.0) {
     text_->setSpaceWidth(new_message->scale.x);
   }
   text_->setCharacterHeight(new_message->scale.z);


### PR DESCRIPTION
I found [this](https://robotics.stackexchange.com/questions/111230/rviz2-text-markers-spacing-issue) question on robotics.stackexchange.com, and have been having the same issue with the `TextViewFacing` marker. Apologies if there's a prescribed method for handling this that I've missed.

In any case, this PR allows users to manually specify the width of a space in the `TextViewFacing` marker using the `scale.x` field of the `visualization_msgs::msg::Marker` message. In the "with change" screenshot below, I used a width of 0.2. Note that if no width is specified, we retain the current behaviour.

I'd be happy to instead change the logic that controls the space width by default, but this seemed like it would be less intrusive.

![Screenshot from 2024-08-20 14-19-00](https://github.com/user-attachments/assets/b2ad43e3-a036-4f4e-8b31-a2551a531176)

![image](https://github.com/user-attachments/assets/b1dc946c-279b-4241-8cdf-41ee7a93eaa6)
