### PR TITLE
Fully handle `Tool::processKeyEvent` return value

### DIFF
--- a/rviz_common/include/rviz_common/tool_manager.hpp
+++ b/rviz_common/include/rviz_common/tool_manager.hpp
@@ -138,7 +138,7 @@ public:
   QStringList getToolClasses();
 
   /// Function to handle a key event.
-  void handleChar(QKeyEvent * event, RenderPanel * panel);
+  [[nodiscard]] int handleChar(QKeyEvent * event, RenderPanel * panel);
 
   PluginlibFactory<Tool> * getFactory();
 

--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -144,12 +144,12 @@ bool ToolManager::toKey(QString const & str, uint & key)
   }
 }
 
-void ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
+int ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
 {
   // if the incoming key is ESC fallback to the default tool
   if (event->key() == Qt::Key_Escape) {
     setCurrentTool(getDefaultTool());
-    return;
+    return 0;
   }
 
   // check if the incoming key triggers the activation of another tool
@@ -180,9 +180,7 @@ void ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
     flags = current_tool_->processKeyEvent(event, panel);
   }
 
-  if (flags & Tool::Finished) {
-    setCurrentTool(getDefaultTool());
-  }
+  return flags;
 }
 
 void ToolManager::setCurrentTool(Tool * tool)

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -641,9 +641,9 @@ void VisualizationManager::handleChar(QKeyEvent * event, RenderPanel * panel)
   if (event->key() == Qt::Key_Escape) {
     Q_EMIT escapePressed();
   }
-  
+
   int flags = tool_manager_->handleChar(event, panel);
-  
+
   if (flags & Tool::Render) {
     queueRender();
   }

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -641,7 +641,16 @@ void VisualizationManager::handleChar(QKeyEvent * event, RenderPanel * panel)
   if (event->key() == Qt::Key_Escape) {
     Q_EMIT escapePressed();
   }
-  tool_manager_->handleChar(event, panel);
+  
+  int flags = tool_manager_->handleChar(event, panel);
+  
+  if (flags & Tool::Render) {
+    queueRender();
+  }
+
+  if (flags & Tool::Finished) {
+    tool_manager_->setCurrentTool(tool_manager_->getDefaultTool());
+  }
 }
 
 void VisualizationManager::notifyConfigChanged()


### PR DESCRIPTION
Complete (non-backportable) fix for #1256.