### PR TITLE
allow Pan, Rotate and Zoom using touch

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
@@ -193,6 +193,14 @@ bool OrbitViewController::setMouseMovementFromEvent(
   } else if (dragging_ && event.type == QEvent::MouseMove) {
     diff_x = event.x - event.last_x;
     diff_y = event.y - event.last_y;
+  } else if (dragging_ && event.type == QEvent::Wheel) {
+    diff_x = (event.x - event.last_x) / 1.01;
+    diff_y = (event.y - event.last_y) / 1.01;
+    if (std::abs(diff_x) > 50 || std::abs(diff_y) > 50) {
+      diff_x = 0;
+      diff_y = 0;
+      return false;
+    }
     return true;
   }
   return false;

--- a/rviz_rendering/include/rviz_rendering/render_window.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_window.hpp
@@ -36,6 +36,7 @@
 
 #include <QObject>  // NOLINT
 #include <QWindow>  // NOLINT
+#include <QMap>  // NOLINT
 
 #include "OgreSceneNode.h"
 #include "OgreRenderTargetListener.h"
@@ -101,6 +102,12 @@ public:
 
   void
   windowMovedOrResized();
+
+  bool translateTouchToMouseEvent(QTouchEvent* touchEvent);
+
+  QMap<int, QPointF> previousTouchPoints;
+  bool singleTouch = false;
+  bool doubleTouch = false;
 
 public slots:
   virtual


### PR DESCRIPTION
https://github.com/ros2/rviz/commit/718948c3dadf449814e098b966f5b023f24129b0 is the proof of concept, which works fine.

The scope of this PR needs to be defined first, as the proof of concept is a hacky solution with which sending goal pose and all also works, without affecting mouse controls. If a proper code structure is added for this, then the PR might get big.
ToDo:
- [ ] create ViewportMouseEvent for Touch Events
- [ ] add touch gestures for several view controllers
- [ ] add a toggle to enable this in view controller tab

Suggestions are welcome and needed. Thank you