### PR TITLE
Avoid redefinition of default color materials

### DIFF
--- a/rviz_rendering/src/rviz_rendering/material_manager.cpp
+++ b/rviz_rendering/src/rviz_rendering/material_manager.cpp
@@ -41,6 +41,9 @@ namespace rviz_rendering
 void MaterialManager::createColorMaterial(
   const std::string & name, const Ogre::ColourValue & color, bool use_self_illumination)
 {
+  if (Ogre::MaterialManager::getSingleton().resourceExists(name, "rviz_rendering")) {
+    return;
+  }
   Ogre::MaterialPtr mat = Ogre::MaterialManager::getSingleton().create(name, "rviz_rendering");
   mat->setAmbient(color * 0.5f);
   mat->setDiffuse(color);


### PR DESCRIPTION
I want to prevent an `ItemIdentityException` from occurring when trying to create multiple `rviz_common::VisualizationFrame` instances in a single process.