### PR TITLE
Handle time source exception

### DIFF
--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -264,18 +264,32 @@ protected:
 
     ++messages_received_;
     QString topic_str = QString::number(messages_received_) + " messages received";
+    rviz_common::properties::StatusProperty::Level topic_status_level =
+      rviz_common::properties::StatusProperty::Ok;
     // Append topic subscription frequency if we can lock rviz_ros_node_.
     std::shared_ptr<ros_integration::RosNodeAbstractionIface> node_interface =
       rviz_ros_node_.lock();
     if (node_interface != nullptr) {
-      const double duration =
-        (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
-      const double subscription_frequency =
-        static_cast<double>(messages_received_) / duration;
-      topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+      try {
+        const double duration =
+          (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
+        const double subscription_frequency =
+          static_cast<double>(messages_received_) / duration;
+        topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+      } catch (const std::runtime_error & e) {
+        if (std::string(e.what()).find("can't subtract times with different time sources") !=
+          std::string::npos)
+        {
+          topic_status_level = rviz_common::properties::StatusProperty::Warn;
+          topic_str += ". ";
+          topic_str += e.what();
+        } else {
+          throw;
+        }
+      }
     }
     setStatus(
-      properties::StatusProperty::Ok,
+      topic_status_level,
       "Topic",
       topic_str);
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -184,7 +184,7 @@ protected:
         const double subscription_frequency =
           static_cast<double>(messages_received_) / duration;
         topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
-      } catch (const std::runtime_error &e) {
+      } catch (const std::runtime_error & e) {
         if (std::string(e.what()).find("can't subtract times with different time sources") !=
           std::string::npos)
         {

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -191,8 +191,9 @@ protected:
           topic_status_level = rviz_common::properties::StatusProperty::Warn;
           topic_str += ". ";
           topic_str += e.what();
-        } else
+        } else {
           throw;
+        }
       }
     }
     setStatus(

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -178,16 +178,16 @@ protected:
     std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> node_interface =
       rviz_ros_node_.lock();
     if (node_interface != nullptr) {
-      try{
+      try {
         const double duration =
           (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
         const double subscription_frequency =
           static_cast<double>(messages_received_) / duration;
         topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
-      }
-      catch (const std::runtime_error &e){
+      } catch (const std::runtime_error &e){
         if (std::string(e.what()).find("can't subtract times with different time sources") !=
-          std::string::npos){
+          std::string::npos)
+        {
           topic_status_level = rviz_common::properties::StatusProperty::Warn;
           topic_str += ". ";
           topic_str += e.what();

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -175,11 +175,19 @@ protected:
     std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> node_interface =
       rviz_ros_node_.lock();
     if (node_interface != nullptr) {
-      const double duration =
-        (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
-      const double subscription_frequency =
-        static_cast<double>(messages_received_) / duration;
-      topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+      try{
+        const double duration =
+          (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
+        const double subscription_frequency =
+          static_cast<double>(messages_received_) / duration;
+        topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+      }
+      catch (const std::runtime_error &e){
+        if (std::string(e.what()).find("can't subtract times with different time sources") != std::string::npos)
+          topic_str += " at ?? hz.";
+        else
+          throw;
+      }
     }
     setStatus(
       rviz_common::properties::StatusProperty::Ok,

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -34,6 +34,7 @@
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__IMAGE__IMAGE_TRANSPORT_DISPLAY_HPP_
 
 #include <memory>
+#include <string>
 
 #include "get_transport_from_topic.hpp"
 #include "image_transport/image_transport.hpp"
@@ -171,7 +172,8 @@ protected:
 
     ++messages_received_;
     QString topic_str = QString::number(messages_received_) + " messages received";
-    rviz_common::properties::StatusProperty::Level topic_status_level = rviz_common::properties::StatusProperty::Ok;
+    rviz_common::properties::StatusProperty::Level topic_status_level =
+      rviz_common::properties::StatusProperty::Ok;
     // Append topic subscription frequency if we can lock rviz_ros_node_.
     std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> node_interface =
       rviz_ros_node_.lock();
@@ -184,12 +186,12 @@ protected:
         topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
       }
       catch (const std::runtime_error &e){
-        if (std::string(e.what()).find("can't subtract times with different time sources") != std::string::npos){
+        if (std::string(e.what()).find("can't subtract times with different time sources") !=
+          std::string::npos){
           topic_status_level = rviz_common::properties::StatusProperty::Warn;
           topic_str += ". ";
           topic_str += e.what();
-        }
-        else
+        } else
           throw;
       }
     }

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -171,6 +171,7 @@ protected:
 
     ++messages_received_;
     QString topic_str = QString::number(messages_received_) + " messages received";
+    rviz_common::properties::StatusProperty::Level topic_status_level = rviz_common::properties::StatusProperty::Ok;
     // Append topic subscription frequency if we can lock rviz_ros_node_.
     std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> node_interface =
       rviz_ros_node_.lock();
@@ -183,14 +184,17 @@ protected:
         topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
       }
       catch (const std::runtime_error &e){
-        if (std::string(e.what()).find("can't subtract times with different time sources") != std::string::npos)
-          topic_str += " at ?? hz.";
+        if (std::string(e.what()).find("can't subtract times with different time sources") != std::string::npos){
+          topic_status_level = rviz_common::properties::StatusProperty::Warn;
+          topic_str += ". ";
+          topic_str += e.what();
+        }
         else
           throw;
       }
     }
     setStatus(
-      rviz_common::properties::StatusProperty::Ok,
+      topic_status_level,
       "Topic",
       topic_str);
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -184,7 +184,7 @@ protected:
         const double subscription_frequency =
           static_cast<double>(messages_received_) / duration;
         topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
-      } catch (const std::runtime_error &e){
+      } catch (const std::runtime_error &e) {
         if (std::string(e.what()).find("can't subtract times with different time sources") !=
           std::string::npos)
         {

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -32,6 +32,7 @@
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__POINTCLOUD__POINT_CLOUD_TRANSPORT_DISPLAY_HPP_
 
 #include <memory>
+#include <string>
 
 #include "get_transport_from_topic.hpp"
 #include "point_cloud_transport/point_cloud_transport.hpp"
@@ -168,18 +169,32 @@ protected:
 
     ++messages_received_;
     QString topic_str = QString::number(messages_received_) + " messages received";
+    rviz_common::properties::StatusProperty::Level topic_status_level =
+      rviz_common::properties::StatusProperty::Ok;
     // Append topic subscription frequency if we can lock rviz_ros_node_.
     std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> node_interface =
       rviz_ros_node_.lock();
     if (node_interface != nullptr) {
-      const double duration =
-        (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
-      const double subscription_frequency =
-        static_cast<double>(messages_received_) / duration;
-      topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+      try {
+        const double duration =
+          (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
+        const double subscription_frequency =
+          static_cast<double>(messages_received_) / duration;
+        topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+      } catch (const std::runtime_error & e) {
+        if (std::string(e.what()).find("can't subtract times with different time sources") !=
+          std::string::npos)
+        {
+          topic_status_level = rviz_common::properties::StatusProperty::Warn;
+          topic_str += ". ";
+          topic_str += e.what();
+        } else {
+          throw;
+        }
+      }
     }
     setStatus(
-      rviz_common::properties::StatusProperty::Ok,
+      topic_status_level,
       "Topic",
       topic_str);
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -360,18 +360,32 @@ void MapDisplay::incomingUpdate(const map_msgs::msg::OccupancyGridUpdate::ConstS
 
   ++update_messages_received_;
   QString topic_str = QString::number(messages_received_) + " update messages received";
+  rviz_common::properties::StatusProperty::Level topic_status_level =
+    rviz_common::properties::StatusProperty::Ok;
   // Append topic subscription frequency if we can lock rviz_ros_node_.
   std::shared_ptr<rviz_common::ros_integration::RosNodeAbstractionIface> node_interface =
     rviz_ros_node_.lock();
   if (node_interface != nullptr) {
-    const double duration =
-      (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
-    const double subscription_frequency =
-      static_cast<double>(messages_received_) / duration;
-    topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+    try {
+      const double duration =
+        (node_interface->get_raw_node()->now() - subscription_start_time_).seconds();
+      const double subscription_frequency =
+        static_cast<double>(messages_received_) / duration;
+      topic_str += " at " + QString::number(subscription_frequency, 'f', 1) + " hz.";
+    } catch (const std::runtime_error & e) {
+      if (std::string(e.what()).find("can't subtract times with different time sources") !=
+        std::string::npos)
+      {
+        topic_status_level = rviz_common::properties::StatusProperty::Warn;
+        topic_str += ". ";
+        topic_str += e.what();
+      } else {
+        throw;
+      }
+    }
   }
   setStatus(
-    rviz_common::properties::StatusProperty::Ok,
+    topic_status_level,
     "Topic",
     topic_str);
 


### PR DESCRIPTION
When playing data from a bag I get this error:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  can't subtract times with different time sources [1 != 2]
Aborted (core dumped)
```
In my case this stems from the section of `image_transport_display.hpp` which computes the topic frequency.

My change catches this exception and makes it a warning on the topic property instead. If approved, I will apply the change to other applicable display interfaces.