### PR TITLE
Use consistent conditionals in render_system.hpp

### DIFF
--- a/rviz_rendering/include/rviz_rendering/render_system.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_system.hpp
@@ -42,7 +42,7 @@
 
 #include <QDir>  // NOLINT cpplint cannot handle include order here
 
-#ifdef __linux__
+#if !defined(__APPLE__) && !defined(_WIN32)
 
 #include <X11/Xutil.h>
 #include <GL/glx.h>


### PR DESCRIPTION
These header files define the `XVisualInfo` type, which is used later in this header based on different conditionals. In particular, the evaluation of these conditionals differ on BSD, which appears to have the headers needed so I don't believe that `__linux__` is the correct conditional to use.

This was the only change I needed to make to rviz to build on FreeBSD.

Here's the spot where the type is used: https://github.com/ros2/rviz/blob/f7112b1ae4337363c4d8177bffe7cce6bbcabf29/rviz_rendering/include/rviz_rendering/render_system.hpp#L164-L168