### PR TITLE
Include QString

### DIFF
--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -36,6 +36,7 @@
 
 #include <QIcon>  // NOLINT: cpplint is unable to handle the include order here
 #include <QSet>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rclcpp/time.hpp"
 

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__DISPLAY_GROUP_HPP_
 #define RVIZ_COMMON__DISPLAY_GROUP_HPP_
 
+#include <QString>
+
 #include "rviz_common/display.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/factory/class_id_recording_factory.hpp
+++ b/rviz_common/include/rviz_common/factory/class_id_recording_factory.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__FACTORY__CLASS_ID_RECORDING_FACTORY_HPP_
 #define RVIZ_COMMON__FACTORY__CLASS_ID_RECORDING_FACTORY_HPP_
 
+#include <QString>
+
 #include "./factory.hpp"
 
 namespace rviz_common

--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -35,6 +35,8 @@
 #include <memory>
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include <message_filters/subscriber.hpp>
 
 #include "rviz_common/ros_topic_display.hpp"

--- a/rviz_common/include/rviz_common/panel.hpp
+++ b/rviz_common/include/rviz_common/panel.hpp
@@ -33,6 +33,7 @@
 #ifndef RVIZ_COMMON__PANEL_HPP_
 #define RVIZ_COMMON__PANEL_HPP_
 
+#include <QString>
 #include <QWidget>
 
 #include "rviz_common/config.hpp"

--- a/rviz_common/include/rviz_common/panel_dock_widget.hpp
+++ b/rviz_common/include/rviz_common/panel_dock_widget.hpp
@@ -34,6 +34,7 @@
 
 #include <QDockWidget>
 #include <QLabel>
+#include <QString>
 
 #include "rviz_common/config.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/properties/bool_property.hpp
+++ b/rviz_common/include/rviz_common/properties/bool_property.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__PROPERTIES__BOOL_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__BOOL_PROPERTY_HPP_
 
+#include <QString>
+
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/combo_box.hpp
+++ b/rviz_common/include/rviz_common/properties/combo_box.hpp
@@ -31,6 +31,7 @@
 #define RVIZ_COMMON__PROPERTIES__COMBO_BOX_HPP_
 
 #include <QComboBox>
+#include <QString>
 
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/covariance_property.hpp
+++ b/rviz_common/include/rviz_common/properties/covariance_property.hpp
@@ -38,6 +38,7 @@
 #include <OgreColourValue.h>
 
 #include <QColor>  // NOLINT cpplint cannot handle include order here
+#include <QString>  // NOLINT cpplint cannot handle include order here
 
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/properties/enum_property.hpp
+++ b/rviz_common/include/rviz_common/properties/enum_property.hpp
@@ -32,9 +32,10 @@
 #ifndef RVIZ_COMMON__PROPERTIES__ENUM_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__ENUM_PROPERTY_HPP_
 
-#include <QStringList>
-
 #include <string>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+#include <QStringList>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/properties/file_picker_property.hpp
+++ b/rviz_common/include/rviz_common/properties/file_picker_property.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_COMMON__PROPERTIES__FILE_PICKER_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__FILE_PICKER_PROPERTY_HPP_
 
+#include <QString>
+
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/float_property.hpp
+++ b/rviz_common/include/rviz_common/properties/float_property.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__PROPERTIES__FLOAT_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__FLOAT_PROPERTY_HPP_
 
+#include <QString>
+
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/grouped_checkbox_property.hpp
+++ b/rviz_common/include/rviz_common/properties/grouped_checkbox_property.hpp
@@ -33,6 +33,8 @@
 
 #include <memory>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/bool_property.hpp"
 
 namespace rviz_common

--- a/rviz_common/include/rviz_common/properties/int_property.hpp
+++ b/rviz_common/include/rviz_common/properties/int_property.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__PROPERTIES__INT_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__INT_PROPERTY_HPP_
 
+#include <QString>
+
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/property_tree_model.hpp
+++ b/rviz_common/include/rviz_common/properties/property_tree_model.hpp
@@ -33,6 +33,7 @@
 #define RVIZ_COMMON__PROPERTIES__PROPERTY_TREE_MODEL_HPP_
 
 #include <QAbstractItemModel>
+#include <QString>
 
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/property_tree_widget.hpp
+++ b/rviz_common/include/rviz_common/properties/property_tree_widget.hpp
@@ -33,6 +33,7 @@
 #define RVIZ_COMMON__PROPERTIES__PROPERTY_TREE_WIDGET_HPP_
 
 #include <QTreeView>
+#include <QString>
 
 #include "./property_tree_model.hpp"
 #include "rviz_common/config.hpp"

--- a/rviz_common/include/rviz_common/properties/quaternion_property.hpp
+++ b/rviz_common/include/rviz_common/properties/quaternion_property.hpp
@@ -33,6 +33,8 @@
 
 #include <OgreQuaternion.h>
 
+#include <QString>
+
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/regex_filter_property.hpp
+++ b/rviz_common/include/rviz_common/properties/regex_filter_property.hpp
@@ -30,13 +30,14 @@
 #ifndef RVIZ_COMMON__PROPERTIES__REGEX_FILTER_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__REGEX_FILTER_PROPERTY_HPP_
 
-#include <QValidator>
-#include <QLineEdit>
-#include <QToolTip>
-#include <QWidget>
-
 #include <regex>
 #include <string>
+
+#include <QValidator>  // NOLINT: cpplint is unable to handle the include order here
+#include <QLineEdit>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+#include <QToolTip>  // NOLINT: cpplint is unable to handle the include order here
+#include <QWidget>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_topic_property.hpp
@@ -32,6 +32,8 @@
 
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/editable_enum_property.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/properties/status_property.hpp
+++ b/rviz_common/include/rviz_common/properties/status_property.hpp
@@ -33,6 +33,7 @@
 #define RVIZ_COMMON__PROPERTIES__STATUS_PROPERTY_HPP_
 
 #include <QIcon>
+#include <QString>
 
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/properties/string_property.hpp
+++ b/rviz_common/include/rviz_common/properties/string_property.hpp
@@ -34,6 +34,8 @@
 
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/properties/tf_frame_property.hpp
+++ b/rviz_common/include/rviz_common/properties/tf_frame_property.hpp
@@ -33,6 +33,9 @@
 #define RVIZ_COMMON__PROPERTIES__TF_FRAME_PROPERTY_HPP_
 
 #include <string>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/frame_manager_iface.hpp"
 
 #include "./editable_enum_property.hpp"

--- a/rviz_common/include/rviz_common/properties/vector_property.hpp
+++ b/rviz_common/include/rviz_common/properties/vector_property.hpp
@@ -34,6 +34,8 @@
 
 #include <OgreVector.h>
 
+#include <QString>
+
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -40,6 +40,8 @@
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #endif
 
 #include "rclcpp/qos.hpp"

--- a/rviz_common/include/rviz_common/tool_manager.hpp
+++ b/rviz_common/include/rviz_common/tool_manager.hpp
@@ -37,6 +37,7 @@
 
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here
 #include <QObject>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QStringList>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/factory/pluginlib_factory.hpp"

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -37,6 +37,7 @@
 
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here
 #include <QObject>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QStringList>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/property.hpp"

--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -36,6 +36,8 @@
 #include <deque>
 #include <memory>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rclcpp/clock.hpp"
 #include "rclcpp/time.hpp"
 #include "tf2_ros/transform_listener.h"

--- a/rviz_common/include/rviz_common/visualizer_app.hpp
+++ b/rviz_common/include/rviz_common/visualizer_app.hpp
@@ -36,6 +36,7 @@
 
 #include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
 #include <QObject>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/ros_integration/ros_client_abstraction_iface.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/window_manager_interface.hpp
+++ b/rviz_common/include/rviz_common/window_manager_interface.hpp
@@ -33,6 +33,7 @@
 #define RVIZ_COMMON__WINDOW_MANAGER_INTERFACE_HPP_
 
 #include <Qt>
+#include <QString>
 
 class QWidget;
 class QString;

--- a/rviz_common/include/rviz_common/yaml_config_reader.hpp
+++ b/rviz_common/include/rviz_common/yaml_config_reader.hpp
@@ -34,6 +34,8 @@
 
 #include <istream>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/config.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/include/rviz_common/yaml_config_writer.hpp
+++ b/rviz_common/include/rviz_common/yaml_config_writer.hpp
@@ -34,6 +34,8 @@
 
 #include <ostream>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/config.hpp"
 #include "rviz_common/visibility_control.hpp"
 

--- a/rviz_common/src/rviz_common/add_display_dialog.cpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.cpp
@@ -47,6 +47,7 @@
 #include <QLabel>  // NOLINT: cpplint is unable to handle the include order here
 #include <QLineEdit>  // NOLINT: cpplint is unable to handle the include order here
 #include <QPushButton>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTabWidget>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTextBrowser>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/src/rviz_common/add_display_dialog.hpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.hpp
@@ -39,6 +39,7 @@
 #include <QComboBox>  // NOLINT: cpplint is unable to handle the include order here
 #include <QDialog>  // NOLINT: cpplint is unable to handle the include order here
 #include <QMultiMap>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTreeWidget>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/factory/factory.hpp"

--- a/rviz_common/src/rviz_common/config.cpp
+++ b/rviz_common/src/rviz_common/config.cpp
@@ -32,6 +32,7 @@
 #include "rviz_common/config.hpp"
 
 #include <QLocale>
+#include <QString>
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -43,6 +43,7 @@
 #include <QFont>  // NOLINT: cpplint is unable to handle the include order here
 #include <QMetaObject>  // NOLINT: cpplint is unable to handle the include order here
 #include <QWidget>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rclcpp/time.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/rviz_common/src/rviz_common/display_factory.cpp
+++ b/rviz_common/src/rviz_common/display_factory.cpp
@@ -35,6 +35,8 @@
 
 #include <tinyxml2.h>  // NOLINT: cpplint is unable to handle the include order here
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/display_group.hpp"
 #include "rviz_common/logging.hpp"
 

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -35,6 +35,7 @@
 #include <map>
 
 #include <QColor>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "./display_factory.hpp"
 #include "./failed_display.hpp"

--- a/rviz_common/src/rviz_common/displays_panel.cpp
+++ b/rviz_common/src/rviz_common/displays_panel.cpp
@@ -39,6 +39,7 @@
 #include <QInputDialog>  // NOLINT: cpplint is unable to handle the include order here
 #include <QProgressDialog> // NOLINT: cpplint is unable to handle the include order here
 #include <QPushButton>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here
 

--- a/rviz_common/src/rviz_common/failed_display.cpp
+++ b/rviz_common/src/rviz_common/failed_display.cpp
@@ -32,6 +32,7 @@
 #include "failed_display.hpp"
 
 #include <QColor>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/load_resource.hpp"
 #include "rviz_common/properties/status_property.hpp"

--- a/rviz_common/src/rviz_common/failed_display.hpp
+++ b/rviz_common/src/rviz_common/failed_display.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__FAILED_DISPLAY_HPP_
 #define RVIZ_COMMON__FAILED_DISPLAY_HPP_
 
+#include <QString>
+
 #include "rviz_common/display.hpp"
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/failed_panel.cpp
+++ b/rviz_common/src/rviz_common/failed_panel.cpp
@@ -34,6 +34,7 @@
 #include <cstdio>
 
 #include <QHBoxLayout>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTextBrowser>  // NOLINT: cpplint is unable to handle the include order here
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/failed_panel.hpp
+++ b/rviz_common/src/rviz_common/failed_panel.hpp
@@ -34,6 +34,8 @@
 
 #include <memory>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/panel.hpp"
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/failed_tool.cpp
+++ b/rviz_common/src/rviz_common/failed_tool.cpp
@@ -32,6 +32,7 @@
 #include "failed_tool.hpp"
 
 #include <QMessageBox>
+#include <QString>
 
 #include "rviz_common/window_manager_interface.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_common/src/rviz_common/failed_view_controller.cpp
+++ b/rviz_common/src/rviz_common/failed_view_controller.cpp
@@ -32,6 +32,7 @@
 #include "failed_view_controller.hpp"
 
 #include <QMessageBox>
+#include <QString>
 
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/window_manager_interface.hpp"

--- a/rviz_common/src/rviz_common/failed_view_controller.hpp
+++ b/rviz_common/src/rviz_common/failed_view_controller.hpp
@@ -34,6 +34,8 @@
 
 #include "rviz_common/view_controller.hpp"
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 namespace rviz_common
 {
 

--- a/rviz_common/src/rviz_common/help_panel.cpp
+++ b/rviz_common/src/rviz_common/help_panel.cpp
@@ -33,6 +33,7 @@
 #include <string>
 
 #include <QDir>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTextBrowser>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here
 

--- a/rviz_common/src/rviz_common/help_panel.hpp
+++ b/rviz_common/src/rviz_common/help_panel.hpp
@@ -32,6 +32,8 @@
 
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/panel.hpp"
 
 class QTextBrowser;

--- a/rviz_common/src/rviz_common/load_resource.cpp
+++ b/rviz_common/src/rviz_common/load_resource.cpp
@@ -36,6 +36,7 @@
 #include <QFile>  // NOLINT: cpplint cannot handle the include order here
 #include <QPainter>  // NOLINT: cpplint cannot handle the include order here
 #include <QPixmapCache>  // NOLINT: cpplint cannot handle the include order here
+#include <QString>  // NOLINT: cpplint cannot handle the include order here
 
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "ament_index_cpp/get_package_prefix.hpp"

--- a/rviz_common/src/rviz_common/loading_dialog.cpp
+++ b/rviz_common/src/rviz_common/loading_dialog.cpp
@@ -33,6 +33,7 @@
 
 #include <QApplication>
 #include <QLabel>
+#include <QString>
 #include <QVBoxLayout>
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/loading_dialog.hpp
+++ b/rviz_common/src/rviz_common/loading_dialog.hpp
@@ -33,6 +33,7 @@
 #define RVIZ_COMMON__LOADING_DIALOG_HPP_
 
 #include <QDialog>
+#include <QString>
 
 class QLabel;
 

--- a/rviz_common/src/rviz_common/new_object_dialog.cpp
+++ b/rviz_common/src/rviz_common/new_object_dialog.cpp
@@ -39,6 +39,7 @@
 #include <QLabel>  // NOLINT: cpplint is unable to handle the include order here
 #include <QLineEdit>  // NOLINT: cpplint is unable to handle the include order here
 #include <QPushButton>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTextBrowser>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTreeWidget>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/src/rviz_common/new_object_dialog.hpp
+++ b/rviz_common/src/rviz_common/new_object_dialog.hpp
@@ -33,6 +33,7 @@
 #define RVIZ_COMMON__NEW_OBJECT_DIALOG_HPP_
 
 #include <QDialog>
+#include <QString>
 
 #include "rviz_common/factory/factory.hpp"
 

--- a/rviz_common/src/rviz_common/panel.cpp
+++ b/rviz_common/src/rviz_common/panel.cpp
@@ -29,6 +29,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <QString>
 
 #include "rviz_common/panel.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_common/src/rviz_common/panel_dock_widget.cpp
+++ b/rviz_common/src/rviz_common/panel_dock_widget.cpp
@@ -36,6 +36,7 @@
 #include <QCloseEvent>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QString>
 #include <QToolButton>
 
 #include "rviz_common/load_resource.hpp"

--- a/rviz_common/src/rviz_common/properties/bool_property.cpp
+++ b/rviz_common/src/rviz_common/properties/bool_property.cpp
@@ -32,6 +32,7 @@
 #include "rviz_common/properties/bool_property.hpp"
 
 #include <QColor>
+#include <QString>
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/properties/color_editor.cpp
+++ b/rviz_common/src/rviz_common/properties/color_editor.cpp
@@ -34,6 +34,7 @@
 
 #include <QPainter>
 #include <QColorDialog>
+#include <QString>
 
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/parse_color.hpp"

--- a/rviz_common/src/rviz_common/properties/color_property.cpp
+++ b/rviz_common/src/rviz_common/properties/color_property.cpp
@@ -30,6 +30,7 @@
 
 
 #include <QPainter>
+#include <QString>
 #include <QStringList>
 #include <QStyleOptionViewItem>
 

--- a/rviz_common/src/rviz_common/properties/covariance_property.cpp
+++ b/rviz_common/src/rviz_common/properties/covariance_property.cpp
@@ -36,6 +36,8 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_rendering/objects/covariance_visual.hpp"
 
 #include "rviz_common/properties/color_property.hpp"

--- a/rviz_common/src/rviz_common/properties/display_group_visibility_property.cpp
+++ b/rviz_common/src/rviz_common/properties/display_group_visibility_property.cpp
@@ -36,6 +36,8 @@
 
 #include <map>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/display_group_visibility_property.hpp"
 
 #include "rviz_common/properties/bool_property.hpp"

--- a/rviz_common/src/rviz_common/properties/display_visibility_property.cpp
+++ b/rviz_common/src/rviz_common/properties/display_visibility_property.cpp
@@ -30,6 +30,8 @@
 
 #include "rviz_common/properties/display_visibility_property.hpp"
 
+#include <QString>
+
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/bit_allocator.hpp"

--- a/rviz_common/src/rviz_common/properties/editable_combo_box.cpp
+++ b/rviz_common/src/rviz_common/properties/editable_combo_box.cpp
@@ -36,6 +36,7 @@
 #include <QCompleter>  // NOLINT: cpplint is unable to handle the include order here
 #include <QKeyEvent>  // NOLINT: cpplint is unable to handle the include order here
 #include <QLineEdit>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/properties/editable_enum_property.cpp
+++ b/rviz_common/src/rviz_common/properties/editable_enum_property.cpp
@@ -31,9 +31,10 @@
 
 #include "rviz_common/properties/editable_enum_property.hpp"
 
-#include <QCompleter>
-
 #include <string>
+
+#include <QCompleter>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/editable_combo_box.hpp"
 

--- a/rviz_common/src/rviz_common/properties/enum_property.cpp
+++ b/rviz_common/src/rviz_common/properties/enum_property.cpp
@@ -33,6 +33,8 @@
 
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/combo_box.hpp"
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/file_picker.cpp
+++ b/rviz_common/src/rviz_common/properties/file_picker.cpp
@@ -31,6 +31,7 @@
 #include "file_picker.hpp"
 
 #include <QFileDialog>
+#include <QString>
 
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/file_picker_property.cpp
+++ b/rviz_common/src/rviz_common/properties/file_picker_property.cpp
@@ -29,6 +29,9 @@
 
 
 #include "rviz_common/properties/file_picker_property.hpp"
+
+#include <QString>
+
 #include "file_picker.hpp"
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/float_edit.cpp
+++ b/rviz_common/src/rviz_common/properties/float_edit.cpp
@@ -33,6 +33,7 @@
 
 #include <QDoubleValidator>
 #include <QLocale>
+#include <QString>
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/properties/float_property.cpp
+++ b/rviz_common/src/rviz_common/properties/float_property.cpp
@@ -34,6 +34,7 @@
 #include <cfloat>  // for FLT_MAX
 
 #include <QtGlobal>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/properties/grouped_checkbox_property.cpp
+++ b/rviz_common/src/rviz_common/properties/grouped_checkbox_property.cpp
@@ -27,10 +27,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "rviz_common/properties/grouped_checkbox_property.hpp"
 
 #include <memory>
 
-#include "rviz_common/properties/grouped_checkbox_property.hpp"
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/grouped_checkbox_property_group.hpp"
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/int_property.cpp
+++ b/rviz_common/src/rviz_common/properties/int_property.cpp
@@ -34,6 +34,7 @@
 
 #include <QtGlobal>  // NOLINT: cpplint is unable to handle the include order here
 #include <QSpinBox>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/properties/parse_color.cpp
+++ b/rviz_common/src/rviz_common/properties/parse_color.cpp
@@ -30,6 +30,8 @@
 
 #include "rviz_common/properties/parse_color.hpp"
 
+#include <QString>
+
 namespace rviz_common
 {
 namespace properties

--- a/rviz_common/src/rviz_common/properties/property.cpp
+++ b/rviz_common/src/rviz_common/properties/property.cpp
@@ -39,6 +39,7 @@
 #include <QPalette>  // NOLINT: cpplint is unable to handle the include order here
 #include <QLineEdit>  // NOLINT: cpplint is unable to handle the include order here
 #include <QSpinBox>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/float_edit.hpp"
 #include "rviz_common/properties/property_tree_model.hpp"

--- a/rviz_common/src/rviz_common/properties/property_tree_model.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_model.cpp
@@ -34,6 +34,7 @@
 #include <cstdio>
 
 #include <QMimeData>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QStringList>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/property.hpp"

--- a/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
@@ -33,6 +33,7 @@
 
 #include <QHash>
 #include <QSet>
+#include <QString>
 #include <QTimer>
 
 #include "rviz_common/properties/property.hpp"

--- a/rviz_common/src/rviz_common/properties/property_tree_with_help.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_with_help.cpp
@@ -30,6 +30,7 @@
 
 #include "rviz_common/properties/property_tree_with_help.hpp"
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTextBrowser>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/property_tree_widget.hpp"

--- a/rviz_common/src/rviz_common/properties/qos_profile_property.cpp
+++ b/rviz_common/src/rviz_common/properties/qos_profile_property.cpp
@@ -34,6 +34,8 @@
 #include <map>
 #include <utility>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rclcpp/qos.hpp"
 
 #include "rviz_common/properties/editable_enum_property.hpp"

--- a/rviz_common/src/rviz_common/properties/quaternion_property.cpp
+++ b/rviz_common/src/rviz_common/properties/quaternion_property.cpp
@@ -30,6 +30,7 @@
 
 #include "rviz_common/properties/quaternion_property.hpp"
 
+#include <QString>
 #include <QStringList>
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/regex_filter_property.cpp
+++ b/rviz_common/src/rviz_common/properties/regex_filter_property.cpp
@@ -31,6 +31,7 @@
 
 #include <QValidator>
 #include <QLineEdit>
+#include <QString>
 #include <QToolTip>
 #include <QWidget>
 

--- a/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include <QApplication>  // NOLINT: cpplint can't handle Qt imports
+#include <QString>  // NOLINT: cpplint can't handle Qt imports
 
 #include "rviz_common/properties/ros_topic_property.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"

--- a/rviz_common/src/rviz_common/properties/status_list.cpp
+++ b/rviz_common/src/rviz_common/properties/status_list.cpp
@@ -32,6 +32,8 @@
 
 #include <cstdio>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/property_tree_model.hpp"
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/status_property.cpp
+++ b/rviz_common/src/rviz_common/properties/status_property.cpp
@@ -32,6 +32,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QPalette>
+#include <QString>
 
 #include "rviz_common/load_resource.hpp"
 #include "rviz_common/properties/property_tree_model.hpp"

--- a/rviz_common/src/rviz_common/properties/string_property.cpp
+++ b/rviz_common/src/rviz_common/properties/string_property.cpp
@@ -31,6 +31,8 @@
 
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/string_property.hpp"
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/tf_frame_property.cpp
+++ b/rviz_common/src/rviz_common/properties/tf_frame_property.cpp
@@ -35,6 +35,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "tf2_ros/transform_listener.h"
 
 #include "../frame_manager.hpp"

--- a/rviz_common/src/rviz_common/properties/vector_property.cpp
+++ b/rviz_common/src/rviz_common/properties/vector_property.cpp
@@ -31,6 +31,7 @@
 
 #include "rviz_common/properties/vector_property.hpp"
 
+#include <QString>
 #include <QStringList>
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/render_panel.cpp
+++ b/rviz_common/src/rviz_common/render_panel.cpp
@@ -41,6 +41,7 @@
 #include <QGridLayout>  // NOLINT: cpplint is unable to handle the include order here
 #include <QMenu>  // NOLINT: cpplint is unable to handle the include order here
 #include <QMouseEvent>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 #include <QWidget>  // NOLINT: cpplint is unable to handle the include order here
 // TODO(wjwwood): remove

--- a/rviz_common/src/rviz_common/screenshot_dialog.cpp
+++ b/rviz_common/src/rviz_common/screenshot_dialog.cpp
@@ -44,6 +44,7 @@
 // Included so we know that QPushButton inherits QAbstractButton
 #include <QPushButton>  // NOLINT: cpplint is unable to handle the include order here
 #include <QScreen>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 #include <QVBoxLayout>  // NOLINT: cpplint is unable to handle the include order here
 #include <QWindow>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/src/rviz_common/screenshot_dialog.hpp
+++ b/rviz_common/src/rviz_common/screenshot_dialog.hpp
@@ -32,6 +32,7 @@
 #ifndef RVIZ_COMMON__SCREENSHOT_DIALOG_HPP_
 #define RVIZ_COMMON__SCREENSHOT_DIALOG_HPP_
 
+#include <QString>
 #include <QWidget>
 
 class QAbstractButton;

--- a/rviz_common/src/rviz_common/splash_screen.cpp
+++ b/rviz_common/src/rviz_common/splash_screen.cpp
@@ -32,9 +32,10 @@
 
 #include <iostream>
 
+#include <QCoreApplication>  // NOLINT: cpplint is unable to handle the include order here
 #include <QPainter>  // NOLINT: cpplint is unable to handle the include order here
 #include <QPoint>  // NOLINT: cpplint is unable to handle the include order here
-#include <QCoreApplication>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "env_config.hpp"
 #include "rviz_common/load_resource.hpp"

--- a/rviz_common/src/rviz_common/splash_screen.hpp
+++ b/rviz_common/src/rviz_common/splash_screen.hpp
@@ -32,6 +32,7 @@
 #define RVIZ_COMMON__SPLASH_SCREEN_HPP_
 
 #include <QSplashScreen>
+#include <QString>
 
 
 class QPainter;

--- a/rviz_common/src/rviz_common/time_panel.cpp
+++ b/rviz_common/src/rviz_common/time_panel.cpp
@@ -37,6 +37,7 @@
 #include <QButtonGroup>
 #include <QCheckBox>
 #include <QSlider>
+#include <QString>
 #include <QComboBox>
 
 #include "rviz_common/visualization_manager.hpp"

--- a/rviz_common/src/rviz_common/time_panel.hpp
+++ b/rviz_common/src/rviz_common/time_panel.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_COMMON__TIME_PANEL_HPP_
 #define RVIZ_COMMON__TIME_PANEL_HPP_
 
+#include <QString>
+
 #include "rviz_common/panel.hpp"
 #include "rclcpp/rclcpp.hpp"
 

--- a/rviz_common/src/rviz_common/tool.cpp
+++ b/rviz_common/src/rviz_common/tool.cpp
@@ -28,6 +28,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <QString>
 
 #include "rviz_common/tool.hpp"
 

--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -37,6 +37,7 @@
 #include <QKeyEvent>  // NOLINT: cpplint is unable to handle the include order here
 #include <QKeySequence>  // NOLINT: cpplint is unable to handle the include order here
 #include <QRegExp>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/logging.hpp"
 

--- a/rviz_common/src/rviz_common/transformation/transformation_manager.cpp
+++ b/rviz_common/src/rviz_common/transformation/transformation_manager.cpp
@@ -34,6 +34,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/factory/pluginlib_factory.hpp"
 #include "./identity_frame_transformer.hpp"
 

--- a/rviz_common/src/rviz_common/transformation_panel.hpp
+++ b/rviz_common/src/rviz_common/transformation_panel.hpp
@@ -36,8 +36,9 @@
 #include <string>
 #include <vector>
 
-#include <QPushButton>  // NOLINT
-#include <QVBoxLayout>  // NOLINT
+#include <QPushButton>  // NOLINT: cpplint cannot handle the include order here
+#include <QVBoxLayout>  // NOLINT: cpplint cannot handle the include order here
+#include <QString>  // NOLINT: cpplint cannot handle the include order here
 
 #include "rviz_common/panel.hpp"
 #include "rviz_common/properties/grouped_checkbox_property_group.hpp"

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -39,6 +39,7 @@
 
 #include <QFont>  // NOLINT: cpplint cannot handle include order here
 #include <QKeyEvent>  // NOLINT: cpplint cannot handle include order here
+#include <QString>  // NOLINT: cpplint cannot handle include order here
 
 #include "rviz_rendering/render_window.hpp"
 

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -36,6 +36,8 @@
 #include <memory>
 #include <sstream>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/factory/pluginlib_factory.hpp"
 #include "rviz_common/logging.hpp"
 #include "rviz_common/properties/property_tree_model.hpp"

--- a/rviz_common/src/rviz_common/views_panel.cpp
+++ b/rviz_common/src/rviz_common/views_panel.cpp
@@ -37,6 +37,7 @@
 #include <QLabel>
 #include <QListWidget>
 #include <QPushButton>
+#include <QString>
 #include <QVBoxLayout>
 
 #include "rviz_common/visualization_manager.hpp"

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -56,6 +56,7 @@
 #include <QShortcut>  // NOLINT cpplint cannot handle include order here
 #include <QSplashScreen>  // NOLINT cpplint cannot handle include order here
 #include <QStatusBar>  // NOLINT cpplint cannot handle include order here
+#include <QString>  // NOLINT cpplint cannot handle include order here
 #include <QTimer>  // NOLINT cpplint cannot handle include order here
 #include <QToolBar>  // NOLINT cpplint cannot handle include order here
 #include <QToolButton>  // NOLINT cpplint cannot handle include order here

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -53,6 +53,7 @@
 #include <QApplication>  // NOLINT: cpplint cannot handle include order here
 #include <QCursor>  // NOLINT: cpplint cannot handle include order here
 #include <QKeyEvent>  // NOLINT: cpplint cannot handle include order here
+#include <QString>  // NOLINT: cpplint cannot handle include order here
 #include <QTimer>  // NOLINT: cpplint cannot handle include order here
 #include <QWindow>  // NOLINT: cpplint cannot handle include order here
 

--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -40,8 +40,9 @@
 // #include <OgreMaterialManager.h>
 
 #include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
-#include <QCommandLineParser>  // NOLINT: cpplint is unable to handle the include order here
 #include <QCommandLineOption>  // NOLINT: cpplint is unable to handle the include order here
+#include <QCommandLineParser>  // NOLINT: cpplint is unable to handle the include order here
+#include <QString>  // NOLINT: cpplint cannot handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/interaction/selection_manager.hpp"

--- a/rviz_common/src/rviz_common/yaml_config_reader.cpp
+++ b/rviz_common/src/rviz_common/yaml_config_reader.cpp
@@ -35,6 +35,8 @@
 #include <sstream>
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 // TODO(wjwwood): consider restoring support for yamlcpp < 0.5, force 0.5 for now
 #define RVIZ_HAVE_YAMLCPP_05 1
 

--- a/rviz_common/src/rviz_common/yaml_config_writer.cpp
+++ b/rviz_common/src/rviz_common/yaml_config_writer.cpp
@@ -33,6 +33,8 @@
 
 #include <fstream>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "yaml-cpp/emitter.h"
 
 namespace rviz_common

--- a/rviz_common/test/config_test.cpp
+++ b/rviz_common/test/config_test.cpp
@@ -29,7 +29,11 @@
 
 
 #include <gtest/gtest.h>
+
+#include <QString>
+
 #include <rviz_common/config.hpp>
+
 
 TEST(Config, set_then_get) {
   rviz_common::Config c;

--- a/rviz_common/test/display_test.cpp
+++ b/rviz_common/test/display_test.cpp
@@ -35,6 +35,8 @@
 #include <sstream>
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/vector_property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/config.hpp"

--- a/rviz_common/test/mock_display_context.hpp
+++ b/rviz_common/test/mock_display_context.hpp
@@ -35,6 +35,8 @@
 
 #include <memory>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"

--- a/rviz_common/test/mock_display_group.cpp
+++ b/rviz_common/test/mock_display_group.cpp
@@ -28,6 +28,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
+#include <QString>
+
 #include "../src/rviz_common/failed_display.hpp"
 
 #include "mock_display_group.hpp"

--- a/rviz_common/test/mock_display_group.hpp
+++ b/rviz_common/test/mock_display_group.hpp
@@ -31,6 +31,8 @@
 #ifndef MOCK_DISPLAY_GROUP_HPP_
 #define MOCK_DISPLAY_GROUP_HPP_
 
+#include <QString>
+
 #include "rviz_common/display_group.hpp"
 
 using namespace rviz_common;  // NOLINT

--- a/rviz_common/test/mock_property_change_receiver.hpp
+++ b/rviz_common/test/mock_property_change_receiver.hpp
@@ -31,6 +31,7 @@
 #define MOCK_PROPERTY_CHANGE_RECEIVER_HPP_
 
 #include <QObject>
+#include <QString>
 
 #include "rviz_common/properties/property.hpp"
 

--- a/rviz_common/test/mock_window_manager_interface.hpp
+++ b/rviz_common/test/mock_window_manager_interface.hpp
@@ -34,6 +34,8 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <QString>
+
 #include "rviz_common/panel_dock_widget.hpp"
 
 #include "rviz_common/window_manager_interface.hpp"

--- a/rviz_common/test/property_test.cpp
+++ b/rviz_common/test/property_test.cpp
@@ -32,6 +32,8 @@
 
 #include <gtest/gtest.h>
 
+#include <QString>
+
 #include "rviz_common/properties/property.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/vector_property.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -39,6 +39,7 @@
 #include <string>
 
 #include <QObject>  // NOLINT: cpplint cannot handle the include order here
+#include <QString>  // NOLINT: cpplint cannot handle the include order here
 
 #ifndef Q_MOC_RUN
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -36,6 +36,8 @@
 #include <memory>
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "get_transport_from_topic.hpp"
 #include "image_transport/image_transport.hpp"
 #include "image_transport/subscriber_filter.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/integer_action.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/integer_action.hpp
@@ -32,6 +32,7 @@
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__INTERACTIVE_MARKERS__INTEGER_ACTION_HPP_
 
 #include <QAction>
+#include <QString>
 
 namespace rviz_default_plugins
 {

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker.hpp
@@ -46,6 +46,7 @@
 #endif
 
 #include <QMenu>
+#include <QString>
 
 #include <visualization_msgs/msg/interactive_marker.hpp>
 #include <visualization_msgs/msg/interactive_marker_pose.hpp>

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.hpp
@@ -45,6 +45,7 @@
 #endif
 
 #include <QCursor>
+#include <QString>
 
 #include <visualization_msgs/msg/interactive_marker_control.hpp>
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
@@ -36,6 +36,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "visualization_msgs/msg/interactive_marker.hpp"
 #include "visualization_msgs/msg/interactive_marker_update.hpp"
 #include "visualization_msgs/msg/interactive_marker_init.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.hpp
@@ -34,6 +34,8 @@
 
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/editable_enum_property.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_common.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_common.hpp
@@ -42,6 +42,8 @@
 
 #include <OgreSceneNode.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_selection_handler.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/marker_selection_handler.hpp
@@ -36,6 +36,8 @@
 #include <string>
 #include <utility>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/interaction/forwards.hpp"
 #include "rviz_common/interaction/selection_manager.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transformer.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transformer.hpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include <QObject>  // NOLINT
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #ifndef Q_MOC_RUN
 #include <OgreVector.h>

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -34,6 +34,8 @@
 #include <memory>
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "get_transport_from_topic.hpp"
 #include "point_cloud_transport/point_cloud_transport.hpp"
 #include "point_cloud_transport/subscriber_filter.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pose_array/pose_array_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pose_array/pose_array_display.hpp
@@ -35,6 +35,8 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "geometry_msgs/msg/pose_array.hpp"
 
 #include "rviz_rendering/objects/shape.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/axes/axes_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/axes/axes_display.cpp
@@ -36,6 +36,8 @@
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_rendering/objects/axes.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -48,6 +48,8 @@
 #include <OgreTechnique.h>
 #include <OgreCamera.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "image_transport/camera_common.hpp"
 
 #include "rviz_rendering/material_manager.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
@@ -41,6 +41,8 @@
 #include <OgreTechnique.h>
 #include <OgreHardwarePixelBuffer.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include <rviz_common/uniform_string_stream.hpp>
 #include <rviz_common/properties/parse_color.hpp>
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
@@ -34,6 +34,7 @@
 #include <tf2_ros/message_filter.h>
 
 #include <QRegExp>
+#include <QString>
 
 #include <iostream>
 #include <functional>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/effort/effort_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/effort/effort_display.cpp
@@ -30,17 +30,17 @@
 
 #include "rviz_default_plugins/displays/effort/effort_display.hpp"
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-
-#include <QString>
-
 #include <chrono>
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <OgreSceneNode.h>
+#include <OgreSceneManager.h>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include <rviz_common/validate_floats.hpp>
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
@@ -38,6 +38,8 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/properties/parse_color.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -45,6 +45,8 @@
 #include <OgreTextureManager.h>
 #include <OgreViewport.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "sensor_msgs/image_encodings.hpp"
 
 #include "rviz_common/display_context.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/integer_action.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/integer_action.cpp
@@ -29,6 +29,8 @@
 
 #include "rviz_default_plugins/displays/interactive_markers/integer_action.hpp"
 
+#include <QString>
+
 namespace rviz_default_plugins
 {
 namespace displays

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
@@ -29,8 +29,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <QMenu>
-
 #include <map>
 #include <memory>
 #include <set>
@@ -45,6 +43,9 @@
 #include <OgreSubEntity.h>
 #include <OgreMath.h>
 #include <OgreRenderWindow.h>
+
+#include <QMenu>  // NOLINT: cpplint cannot handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "interactive_markers/tools.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
@@ -45,6 +45,8 @@
 #include <OgreSharedPtr.h>
 #include <OgreTechnique.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/interaction/handler_manager.hpp"
 #include "rviz_common/interaction/view_picker_iface.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
@@ -34,6 +34,8 @@
 #include <utility>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/validate_floats.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_namespace_property.cpp
@@ -28,11 +28,12 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <QApplication>
-
 #include <map>
 #include <string>
 #include <vector>
+
+#include <QApplication>  // NOLINT: cpplint cannot handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/logging.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -33,6 +33,8 @@
 #include <memory>
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "tf2_ros/buffer.h"
 
 #include "rviz_common/properties/int_property.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -42,6 +42,8 @@
 #include <OgreTechnique.h>
 #include <OgreSharedPtr.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rclcpp/time.hpp"
 
 #include "rviz_rendering/material_manager.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -38,6 +38,8 @@
 #include <utility>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rclcpp/duration.hpp"
 
 #include "rviz_common/display.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
@@ -33,6 +33,8 @@
 
 #include <memory>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 namespace rviz_default_plugins
 {
 namespace displays

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/marker_selection_handler.cpp
@@ -34,6 +34,8 @@
 #include <OgreQuaternion.h>
 #include <OgreVector.h>
 
+#include <QString>
+
 #include "rviz_common/msg_conversions.hpp"
 #include "rviz_default_plugins/displays/marker/marker_display.hpp"
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -39,6 +39,8 @@
 #include <OgreSceneNode.h>
 #include <OgreWireBoundingBox.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rclcpp/clock.hpp"
 
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_to_point_cloud2.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_selection_handler.cpp
@@ -39,6 +39,8 @@
 #include <OgreSceneNode.h>
 #include <OgreWireBoundingBox.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_rendering/objects/point_cloud.hpp"
 #include "rviz_common/display.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
@@ -38,6 +38,8 @@
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/logging.hpp"
 #include "rviz_common/msg_conversions.hpp"
 #include "rviz_common/properties/enum_property.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -37,6 +37,7 @@
 #include <OgreSceneNode.h>
 
 #include <QFile>  // NOLINT cpplint cannot handle include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "tf2_ros/transform_listener.h"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/screw/screw_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/screw/screw_display.cpp
@@ -30,9 +30,10 @@
 
 #include "rviz_default_plugins/displays/screw/screw_display.hpp"
 
-#include <QObject>
-#include <QString>
 #include <memory>
+
+#include <QObject>  // NOLINT: cpplint cannot handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/accel_stamped.hpp>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_info.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_info.cpp
@@ -35,6 +35,8 @@
 
 #include <OgreSceneNode.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/axes.hpp"
 #include "rviz_rendering/objects/movable_text.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_selection_handler.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/frame_selection_handler.cpp
@@ -32,6 +32,8 @@
 
 #include <string>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/float_property.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
@@ -31,10 +31,6 @@
 
 #include "rviz_default_plugins/displays/tf/tf_display.hpp"
 
-#include <QValidator>
-#include <QLineEdit>
-#include <QToolTip>
-
 #include <algorithm>
 #include <cassert>
 #include <memory>
@@ -46,6 +42,11 @@
 
 #include <OgreSceneNode.h>
 #include <OgreSceneManager.h>
+
+#include <QValidator>  // NOLINT: cpplint cannot handle the include order here
+#include <QLineEdit>  // NOLINT: cpplint cannot handle the include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+#include <QToolTip>  // NOLINT: cpplint cannot handle the include order here
 
 #include "tf2_ros/transform_listener.h"
 #include "tf2_ros/buffer.h"

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_joint.cpp
@@ -35,6 +35,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_default_plugins/robot/robot.hpp"
 
 #include "rviz_common/load_resource.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -50,6 +50,7 @@
 #include <OgreTechnique.h>
 
 #include <QFileInfo>  // NOLINT cpplint cannot handle include order here
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include <gz/math/Inertial.hh>
 #include <gz/math/MassMatrix3.hh>

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/measure/measure_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/measure/measure_tool.cpp
@@ -42,6 +42,8 @@
 
 #include <OgreSceneNode.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_rendering/objects/line.hpp"
 
 #include "rviz_common/display_context.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/robot_model/robot_model_display_visual_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/robot_model/robot_model_display_visual_test.cpp
@@ -32,6 +32,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "ament_index_cpp/get_package_prefix.hpp"
 
 #include "rviz_visual_testing_framework/visual_test_fixture.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_display_context.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_display_context.hpp
@@ -35,6 +35,8 @@
 
 #include <memory>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_window_manager_interface.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_window_manager_interface.hpp
@@ -33,6 +33,8 @@
 
 #include <gmock/gmock.h>
 
+#include <QString>
+
 #include "rviz_common/panel_dock_widget.hpp"
 
 #include "rviz_common/window_manager_interface.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/accel_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/accel_display_page_object.cpp
@@ -31,9 +31,10 @@
 
 #include "accel_display_page_object.hpp"
 
-#include <QString>
 #include <memory>
 #include <vector>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 AccelDisplayPageObject::AccelDisplayPageObject()
 : BasePageObject(0, "AccelStamped")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/axes_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/axes_display_page_object.cpp
@@ -32,6 +32,8 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_visual_testing_framework/test_helpers.hpp"
 
 AxesDisplayPageObject::AxesDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/axes_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/axes_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__AXES_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__AXES_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class AxesDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/camera_display_page_object.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 #include "rviz_visual_testing_framework/test_helpers.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/camera_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/camera_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__CAMERA_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__CAMERA_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/page_object_with_window.hpp"
 
 class CameraDisplayPageObject : public PageObjectWithWindow

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/camera_info_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/camera_info_display_page_object.cpp
@@ -31,6 +31,8 @@
 
 #include "camera_info_display_page_object.hpp"
 
+#include <QString>
+
 CameraInfoDisplayPageObject::CameraInfoDisplayPageObject()
 : BasePageObject(0, "CameraInfo")
 {

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/depth_cloud_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/depth_cloud_page_object.cpp
@@ -33,6 +33,8 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 DepthCloudDisplayPageObject::DepthCloudDisplayPageObject()
 : BasePageObject(0, "DepthCloud")
 {}

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/depth_cloud_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/depth_cloud_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__DEPTH_CLOUD_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__DEPTH_CLOUD_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class DepthCloudDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/effort_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/effort_display_page_object.cpp
@@ -33,6 +33,8 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 EffortDisplayPageObject::EffortDisplayPageObject()
 : BasePageObject(0, "Effort")
 {}

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/effort_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/effort_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__EFFORT_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__EFFORT_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class EffortDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_cells_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_cells_display_page_object.cpp
@@ -33,6 +33,8 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_visual_testing_framework/test_helpers.hpp"
 
 GridCellsDisplayPageObject::GridCellsDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_cells_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_cells_display_page_object.hpp
@@ -34,6 +34,8 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class GridCellsDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_display_page_object.cpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 GridDisplayPageObject::GridDisplayPageObject()

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/grid_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__GRID_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__GRID_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class GridDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/image_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/image_display_page_object.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 #include "rviz_visual_testing_framework/test_helpers.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/image_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/image_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__IMAGE_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__IMAGE_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/page_object_with_window.hpp"
 
 class ImageDisplayPageObject : public PageObjectWithWindow

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/map_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/map_display_page_object.cpp
@@ -28,9 +28,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <QString>
-
 #include "map_display_page_object.hpp"
+
+#include <QString>
 
 MapDisplayPageObject::MapDisplayPageObject()
 : BasePageObject(0, "Map")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/map_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/map_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__MAP_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__MAP_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class MapDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/odometry_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/odometry_display_page_object.cpp
@@ -30,6 +30,8 @@
 
 #include "odometry_display_page_object.hpp"
 
+#include <QString>
+
 OdometryDisplayPageObject::OdometryDisplayPageObject()
 : BasePageObject(0, "Odometry")
 {}

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/odometry_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/odometry_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__ODOMETRY_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__ODOMETRY_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class OdometryDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/path_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/path_display_page_object.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 #include "rviz_visual_testing_framework/test_helpers.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/path_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/path_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__PATH_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__PATH_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class PathDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_cloud_common_page_object.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 PointCloudCommonPageObject::PointCloudCommonPageObject(QString display_name)

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_display_page_object.cpp
@@ -30,6 +30,8 @@
 
 #include "point_display_page_object.hpp"
 
+#include <QString>
+
 PointDisplayPageObject::PointDisplayPageObject()
 : BasePageObject(0, "PointStamped")
 {}

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/point_display_page_object.hpp
@@ -31,6 +31,7 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POINT_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POINT_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
 
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_display_page_object.cpp
@@ -30,10 +30,10 @@
 
 #include "pose_display_page_object.hpp"
 
-#include <QString>
-
 #include <memory>
 #include <vector>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 PoseDisplayPageObject::PoseDisplayPageObject()
 : BasePageObject(0, "Pose")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/pose_with_covariance_display_page_object.hpp
@@ -34,6 +34,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POSE_WITH_COVARIANCE_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__POSE_WITH_COVARIANCE_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class PoseWithCovarianceDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/range_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/range_display_page_object.cpp
@@ -28,9 +28,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <QString>
-
 #include "range_display_page_object.hpp"
+
+#include <QString>
 
 RangeDisplayPageObject::RangeDisplayPageObject()
 : BasePageObject(0, "Range")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/range_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/range_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__RANGE_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__RANGE_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class RangeDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/robot_model_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/robot_model_display_page_object.cpp
@@ -28,9 +28,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#include <QString>
-
 #include "robot_model_display_page_object.hpp"
+
+#include <QString>
 
 RobotModelDisplayPageObject::RobotModelDisplayPageObject()
 : BasePageObject(0, "RobotModel")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/robot_model_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/robot_model_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__ROBOT_MODEL_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__ROBOT_MODEL_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class RobotModelDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/tf_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/tf_display_page_object.cpp
@@ -30,10 +30,10 @@
 
 #include "tf_display_page_object.hpp"
 
-#include <QString>
-
 #include <memory>
 #include <vector>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 TFDisplayPageObject::TFDisplayPageObject()
 : BasePageObject(0, "TF")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/tf_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/tf_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__TF_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__TF_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class TFDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/twist_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/twist_display_page_object.cpp
@@ -29,10 +29,10 @@
 
 #include "twist_display_page_object.hpp"
 
-#include <QString>
-
 #include <memory>
 #include <vector>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 TwistDisplayPageObject::TwistDisplayPageObject()
 : BasePageObject(0, "TwistStamped")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/wrench_display_page_object.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/wrench_display_page_object.cpp
@@ -29,10 +29,10 @@
 
 #include "wrench_display_page_object.hpp"
 
-#include <QString>
-
 #include <memory>
 #include <vector>
+
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 WrenchDisplayPageObject::WrenchDisplayPageObject()
 : BasePageObject(0, "Wrench")

--- a/rviz_default_plugins/test/rviz_default_plugins/page_objects/wrench_display_page_object.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/page_objects/wrench_display_page_object.hpp
@@ -31,6 +31,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__WRENCH_DISPLAY_PAGE_OBJECT_HPP_
 #define RVIZ_DEFAULT_PLUGINS__PAGE_OBJECTS__WRENCH_DISPLAY_PAGE_OBJECT_HPP_
 
+#include <QString>
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 class WrenchDisplayPageObject : public BasePageObject

--- a/rviz_default_plugins/test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
@@ -34,6 +34,8 @@
 
 #include <OgreManualObject.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/tool.hpp"
 
 #include "rviz_default_plugins/tools/measure/measure_tool.hpp"

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -51,6 +51,8 @@
 #include <OgreTextureManager.h>
 #include <OgreTextureUnitState.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #define ASSIMP_UNIFIED_HEADER_NAMES 1
 #if defined(ASSIMP_UNIFIED_HEADER_NAMES)
 #include <assimp/postprocess.h>

--- a/rviz_rendering/src/rviz_rendering/render_system.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_system.cpp
@@ -42,6 +42,8 @@
 #include <OgreLogManager.h>
 #include <OgreMeshManager.h>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "ament_index_cpp/get_resource.hpp"
 #include "ament_index_cpp/get_resources.hpp"
 #include "rviz_rendering/material_manager.hpp"

--- a/rviz_rendering/src/rviz_rendering/render_window.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window.cpp
@@ -54,6 +54,7 @@
 #include <QWindow>   // NOLINT
 #include <QMetaEnum>   // NOLINT
 #include <QDebug>   // NOLINT
+#include <QString>  // NOLINT: cpplint cannot handle the include order here
 #include <QTime>   // NOLINT
 
 // Use the Ogre implementation for now.

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/display_handler.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/display_handler.hpp
@@ -34,6 +34,8 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 #include "rviz_visual_testing_framework/internal/executor.hpp"
 

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/page_objects/page_object_with_window.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/page_objects/page_object_with_window.hpp
@@ -34,6 +34,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
 #include "rviz_rendering/render_window.hpp"

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/test_helpers.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/test_helpers.hpp
@@ -32,6 +32,7 @@
 
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTreeView>  // NOLINT
 
 #include "rviz_rendering/render_window.hpp"

--- a/rviz_visual_testing_framework/src/internal/display_handler.cpp
+++ b/rviz_visual_testing_framework/src/internal/display_handler.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 #include "rviz_visual_testing_framework/test_helpers.hpp"

--- a/rviz_visual_testing_framework/src/internal/visual_test.cpp
+++ b/rviz_visual_testing_framework/src/internal/visual_test.cpp
@@ -37,6 +37,7 @@
 #include <string>
 
 #include <QDir>  // NOLINT
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rcutils/env.h"
 

--- a/rviz_visual_testing_framework/src/page_objects/base_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/base_page_object.cpp
@@ -28,11 +28,13 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"
 
+
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 #include "rviz_visual_testing_framework/test_helpers.hpp"

--- a/rviz_visual_testing_framework/src/page_objects/page_object_with_window.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/page_object_with_window.cpp
@@ -33,6 +33,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 PageObjectWithWindow::PageObjectWithWindow(int display_category, QString display_name)
 : BasePageObject(display_category, display_name),
   render_window_(nullptr),

--- a/rviz_visual_testing_framework/src/page_objects/point_cloud_display_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/point_cloud_display_page_object.cpp
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 
 PointCloudDisplayPageObject::PointCloudDisplayPageObject(

--- a/rviz_visual_testing_framework/src/test_helpers.cpp
+++ b/rviz_visual_testing_framework/src/test_helpers.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #include <QApplication>  // NOLINT
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 namespace helpers
 {

--- a/rviz_visual_testing_framework/src/visual_test_fixture.cpp
+++ b/rviz_visual_testing_framework/src/visual_test_fixture.cpp
@@ -33,6 +33,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>  // NOLINT: cpplint is unable to handle the include order here
+
 #include "rviz_common/ros_integration/ros_client_abstraction.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 


### PR DESCRIPTION
Adds `#include <QString>` to all files which use `QString`.

Addresses @clalancette's [comment here](https://github.com/ros2/rviz/pull/1288#discussion_r1834455227). The linter's "include what you use" rule does not work on this header. Probably other QT headers as well, but this is the most common.