### PR TITLE
Fix access control for Accel, Effort and Twist displays

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/accel/accel_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/accel/accel_display.hpp
@@ -44,6 +44,7 @@ class AccelStampedDisplay : public ScrewDisplay<geometry_msgs::msg::AccelStamped
 {
   Q_OBJECT
 
+protected:
   // Function to handle an incoming ROS message.
   void processMessage(geometry_msgs::msg::AccelStamped::ConstSharedPtr msg) override;
 };

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/effort/effort_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/effort/effort_display.hpp
@@ -121,6 +121,7 @@ protected:
   // overrides from Display
   void onEnable() override;
   void onDisable() override;
+  void processMessage(sensor_msgs::msg::JointState::ConstSharedPtr msg) override;
 
   void load();
   void clear();
@@ -132,7 +133,6 @@ protected:
   std::string robot_description_topic_;
 
 private:
-  void processMessage(sensor_msgs::msg::JointState::ConstSharedPtr msg) override;
   void topic_callback(const std_msgs::msg::String & msg);
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/twist/twist_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/twist/twist_display.hpp
@@ -44,6 +44,7 @@ class TwistStampedDisplay : public ScrewDisplay<geometry_msgs::msg::TwistStamped
 {
   Q_OBJECT
 
+protected:
   // Function to handle an incoming ROS message.
   void processMessage(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg) override;
 };


### PR DESCRIPTION
Makes the ```processMsg``` function ```protected``` for ```Twist```, ```Accel``` and ```Effort``` displays.