### PR TITLE
Change EffortDisplay superclass from MessageFilterDisplay to RosTopicDisplay...

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/effort/effort_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/effort/effort_display.hpp
@@ -38,7 +38,7 @@
 #include <string>
 
 #include <rclcpp/rclcpp.hpp>
-#include <rviz_common/message_filter_display.hpp>
+#include <rviz_common/ros_topic_display.hpp>
 #include <rviz_common/properties/bool_property.hpp>
 #include <rviz_common/properties/int_property.hpp>
 #include <rviz_common/properties/float_property.hpp>
@@ -90,7 +90,7 @@ private:
 };
 
 class RVIZ_DEFAULT_PLUGINS_PUBLIC EffortDisplay
-  : public rviz_common::MessageFilterDisplay<sensor_msgs::msg::JointState>
+  : public rviz_common::RosTopicDisplay<sensor_msgs::msg::JointState>
 {
   Q_OBJECT
 
@@ -122,6 +122,7 @@ protected:
   void onEnable() override;
   void onDisable() override;
   void processMessage(sensor_msgs::msg::JointState::ConstSharedPtr msg) override;
+  void processTypeErasedMessage(std::shared_ptr<const void> type_erased_msg) override;
 
   void load();
   void clear();


### PR DESCRIPTION
…to avoid dropping messages with empty frame_id.

**Problem**: EffortDisplay does not react on JointState messages with emty frame_id. Also the following warning is displayed:
 ```
[rviz2]: Message Filter dropping message: frame '' at time ..... for reason
'the frame id of the message is empty'
```
**Reason**: MessageFilterDisplay uses tf2_ros::MessageFilter which checks that frame_id is not empty. This mechanism is designed to perform message frame change "on-fly" but it is not applicable to JointState messages.

**Solution**: Use RosTopicDisplay instead of MessageFilterDisplay. Use type erased signal/slot pair to ensure messages are processed in the main thread.