### PR TITLE
Fix preferred tools loading names

### DIFF
--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -79,7 +79,7 @@ void ToolManager::initialize()
   // get a list of available tool plugin class ids
   auto plugins = factory_->getDeclaredPlugins();
   // define a list of preferred tool names (they will be listed first in the toolbar)
-  std::vector<const char *> preferred_tool_names = {
+  std::vector<const char *> preferred_tool_class_ids = {
     "rviz_default_plugins/MoveCamera",
     "rviz_default_plugins/Interact",
     "rviz_default_plugins/Select",
@@ -87,9 +87,9 @@ void ToolManager::initialize()
     "rviz_default_plugins/SetGoal",
   };
   // attempt to load each preferred tool in order
-  for (const auto & preferred_tool_name : preferred_tool_names) {
+  for (const auto & preferred_tool_class_id : preferred_tool_class_ids) {
     for (const auto & plugin : plugins) {
-      if (plugin.name.toStdString() == preferred_tool_name) {
+      if (plugin.id.toStdString() == preferred_tool_class_id) {
         addTool(plugin);
       }
     }


### PR DESCRIPTION
The preferred tools names defined for initialization in the ToolManager class are in fact the plugin class ids, not the class names.

For example, 
`rviz_default_plugins/MoveCamera` is the plugin class id and
`MoveCamera` is the plugin class name. 

This makes this piece of code actually never useful because the string comparison never matches.

This doesn't cause any bugs usually because we always initialize the tools via the config file `default.rviz` that is either present in a location like `/home/.rviz2/default.rviz` or if not we use the `default.rviz` file that is always installed here for example `/opt/ros2/humble/share/rviz_common/default.rviz`. We can see this logic in `void VisualizationFrame::loadDisplayConfig(const QString & qpath)`. 

This patch is more useful for people using the rviz library to create custom application and that don't install a default rviz config file for example.

In that case, the tools are not initialized and the app becomes unresponsive. 
  