### PR TITLE
Add RVIZ_COMMON_PUBLIC macro to ToolManager

### DIFF
--- a/rviz_common/include/rviz_common/tool_manager.hpp
+++ b/rviz_common/include/rviz_common/tool_manager.hpp
@@ -42,6 +42,7 @@
 
 #include "rviz_common/factory/pluginlib_factory.hpp"
 #include "rviz_common/tool.hpp"
+#include "rviz_common/visibility_control.hpp"
 
 class QKeyEvent;
 
@@ -55,7 +56,7 @@ class PropertyTreeModel;
 
 }  // namespace properties
 
-class ToolManager : public QObject
+class RVIZ_COMMON_PUBLIC ToolManager : public QObject
 {
   Q_OBJECT
 


### PR DESCRIPTION
`ToolManager` is a class exposed in the public API, and that is used in downstream packages like moveit (see https://github.com/moveit/moveit2/blob/3268f16e649c3be6be82119ee326257f66a442d0/moveit_setup_assistant/moveit_setup_framework/src/rviz_panel.cpp#L79).

Properly exposing the `ToolManager` class with the `RVIZ_COMMON_PUBLIC` macro permits to solve the LNK2019 linking error that you would obtain by building the `moveit_setup_framework` on Windows.
