### PR TITLE
Fix the XYOrbitViewController drag-move

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
@@ -145,7 +145,7 @@ void OrbitViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & eve
   if (event.left() && !event.shift()) {
     rotateCamera(diff_x, diff_y);
   } else if (event.middle() || (event.shift() && event.left())) {
-    moveFocalPoint(distance, diff_x, diff_y, 0, 0);
+    moveFocalPoint(distance, diff_x, diff_y, event.last_x, event.last_y);
   } else if (event.right()) {
     handleRightClick(event, distance, diff_y);
   } else {


### PR DESCRIPTION
Fixed the XY Orbit drag-move which would be hard to control at lower camera elevations. 

The mouse click point from OrbitViewController is always getting passed as (0, 0), which makes XY Orbit Controller pick a control point near/above the horizon. 

The change is to ensure that the position of the last mouse event also gets passed to `moveFocalPoint()` 

Behavior of OrbitViewController is unchanged since it does not depend on the last_x, last_y of the mouse position.

|  Rolling | This PR | 
| -- | -- |
| ![bad_orbit](https://github.com/user-attachments/assets/6c53a073-e3ac-4685-b907-737f661e6a24)  | ![good_orbit](https://github.com/user-attachments/assets/d75e94cb-bf37-4532-a83a-291be9570521) | 

moveFocalPoint is overridden in XYOrbitViewController, though handleMouseEvent is not.

[Here's](https://github.com/ros2/rviz/blob/9be9fab373e21792f3fe1df084fdddac8c76f500/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp#L142) what's being called with these parameters.