### PR TITLE
When a URDF link has multiple visual tags, use appropriate material for each

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/robot/robot_link.hpp
@@ -179,13 +179,18 @@ private:
   Ogre::Entity * createEntityForGeometryElement(
     const urdf::LinkConstSharedPtr & link,
     const urdf::Geometry & geom, const urdf::Pose & origin,
-    std::string material_name, Ogre::SceneNode * scene_node);
+    Ogre::SceneNode * scene_node);
   void assignMaterialsToEntities(
     const urdf::LinkConstSharedPtr & link,
     const std::string & material_name,
     const Ogre::Entity * entity);
   Ogre::MaterialPtr getMaterialForLink(
     const urdf::LinkConstSharedPtr & link, std::string material_name = "");
+  Ogre::MaterialPtr getMaterialForVisual(const urdf::VisualSharedPtr & visual);
+  void getMaterialForVisualizable(Ogre::Entity * entity, const urdf::VisualSharedPtr & visual);
+  void getMaterialForVisualizable(
+    Ogre::Entity * /* entity */,
+    const urdf::CollisionSharedPtr & /* collision */ ) {};
   urdf::VisualSharedPtr getVisualWithMaterial(
     const urdf::LinkConstSharedPtr & link, const std::string & material_name) const;
   void loadMaterialFromTexture(
@@ -214,8 +219,10 @@ private:
       T link_visual_element = vector_element;
       if (link_visual_element && link_visual_element->geometry) {
         Ogre::Entity * mesh = createEntityForGeometryElement(
-          link, *link_visual_element->geometry, link_visual_element->origin, "", scene_node);
+          link, *link_visual_element->geometry, link_visual_element->origin, scene_node);
         if (mesh) {
+          getMaterialForVisualizable(mesh, link_visual_element);
+          assignMaterialsToEntities(link, "", mesh);
           meshes_vector.push_back(mesh);
           valid_visualizable_found = true;
         }
@@ -224,8 +231,10 @@ private:
 
     if (!valid_visualizable_found && visualizable_element && visualizable_element->geometry) {
       Ogre::Entity * mesh = createEntityForGeometryElement(
-        link, *visualizable_element->geometry, visualizable_element->origin, "", scene_node);
+        link, *visualizable_element->geometry, visualizable_element->origin, scene_node);
       if (mesh) {
+        getMaterialForVisualizable(mesh, visualizable_element);
+        assignMaterialsToEntities(link, "", mesh);
         meshes_vector.push_back(mesh);
       }
     }

--- a/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/robot/robot_link.cpp
@@ -597,7 +597,6 @@ Ogre::Entity * RobotLink::createEntityForGeometryElement(
   const urdf::LinkConstSharedPtr & link,
   const urdf::Geometry & geom,
   const urdf::Pose & origin,
-  const std::string material_name,
   Ogre::SceneNode * scene_node)
 {
   Ogre::Entity * entity = nullptr;  // default in case nothing works.
@@ -702,7 +701,6 @@ Ogre::Entity * RobotLink::createEntityForGeometryElement(
     offset_node->setPosition(offset_position);
     offset_node->setOrientation(offset_orientation);
 
-    assignMaterialsToEntities(link, material_name, entity);
   }
   return entity;
 }
@@ -759,13 +757,18 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink(
     return Ogre::MaterialManager::getSingleton().getByName("RVIZ/ShadedRed");
   }
 
+  urdf::VisualSharedPtr visual = getVisualWithMaterial(link, material_name);
+
+  return getMaterialForVisual(visual);
+}
+
+Ogre::MaterialPtr RobotLink::getMaterialForVisual(const urdf::VisualSharedPtr & visual)
+{
   static int count = 0;
-  std::string link_material_name = "Robot Link Material" + std::to_string(count++);
+  std::string link_material_name = "Robot Material" + std::to_string(count++);
 
   auto material_for_link =
     rviz_rendering::MaterialManager::createMaterialWithShadowsAndLighting(link_material_name);
-
-  urdf::VisualSharedPtr visual = getVisualWithMaterial(link, material_name);
 
   if (visual->material->texture_filename.empty()) {
     const urdf::Color & color = visual->material->color;
@@ -780,14 +783,27 @@ Ogre::MaterialPtr RobotLink::getMaterialForLink(
   return material_for_link;
 }
 
+void RobotLink::getMaterialForVisualizable(
+  Ogre::Entity * entity,
+  const urdf::VisualSharedPtr & visual)
+{
+    if (!visual->material_name.empty() || 
+      (visual->material && !visual->material->texture_filename.empty()))
+    {
+      Ogre::MaterialPtr material = getMaterialForVisual(visual);
+      // Sets uniformly for all subentities
+      entity -> setMaterial(material);
+      entity -> setMaterialName(material->getName());
+    }
+}
+
 urdf::VisualSharedPtr RobotLink::getVisualWithMaterial(
   const urdf::LinkConstSharedPtr & link, const std::string & material_name) const
 {
   urdf::VisualSharedPtr visual = link->visual;
   for (const auto & visual_array_element : link->visual_array) {
-    if (visual_array_element &&
-      !material_name.empty() &&
-      visual_array_element->material_name == material_name)
+    if (visual_array_element && !visual_array_element->material_name.empty() &&
+      (material_name.empty() || visual_array_element->material_name == material_name))
     {
       visual = visual_array_element;
       break;


### PR DESCRIPTION
Currently, when loading a URDF robot, rviz uses the same material for each link, even when the link has multiple `<visual>` tags with different materials. See https://github.com/ros2/rviz/issues/1293#issuecomment-2570035080 for a detailed analysis.

Fixes #1293.

I tested that this fixes my use case on ROS Iron (display of a robot inside MoveIt plugin), but do not know enough to test more broadly. The code change appears to apply cleanly to rolling, but I have not tested outside of Iron either. Leaving it to maintainer to figure out the right branch(es) to merge this into.