### PR TITLE
Initialize lookup table only once at compile time

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
@@ -77,12 +77,12 @@ bool RGB8PCTransformer::transform(
 
   // Create a look-up table for colors
   constexpr static std::array<float,256> rgb_lut = [](){
-    std::array<float, 256> result{};
-    for (int i = 0; i < 256; ++i) {
-      result[i] = static_cast<float>(i) / 255.0f;
-    }
-    return result;
-  }();
+      std::array<float, 256> result{};
+      for (int i = 0; i < 256; ++i) {
+        result[i] = static_cast<float>(i) / 255.0f;
+      }
+      return result;
+    }();
 
   if (rgb != -1) {  // rgb
     for (V_PointCloudPoint::iterator iter = points_out.begin(); iter != points_out.end();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
@@ -76,7 +76,7 @@ bool RGB8PCTransformer::transform(
 
   // Create a look-up table for colors
   constexpr static std::array<float,256> rgb_lut = [](){
-    std::array<float,256> result{};
+    std::array<float, 256> result{};
     for (int i = 0; i < 256; ++i) {
       result[i] = static_cast<float>(i) / 255.0f;
     }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
@@ -76,7 +76,7 @@ bool RGB8PCTransformer::transform(
   const uint32_t point_step = cloud->point_step;
 
   // Create a look-up table for colors
-  constexpr static std::array<float,256> rgb_lut = [](){
+  constexpr static std::array<float, 256> rgb_lut = [](){
       std::array<float, 256> result{};
       for (int i = 0; i < 256; ++i) {
         result[i] = static_cast<float>(i) / 255.0f;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
@@ -75,10 +75,14 @@ bool RGB8PCTransformer::transform(
   const uint32_t point_step = cloud->point_step;
 
   // Create a look-up table for colors
-  float rgb_lut[256];
-  for (int i = 0; i < 256; ++i) {
-    rgb_lut[i] = static_cast<float>(i) / 255.0f;
-  }
+  constexpr static std::array<float,256> rgb_lut = [](){
+    std::array<float,256> result{};
+    for (int i = 0; i < 256; ++i) {
+      result[i] = static_cast<float>(i) / 255.0f;
+    }
+    return result;
+  }();
+
   if (rgb != -1) {  // rgb
     for (V_PointCloudPoint::iterator iter = points_out.begin(); iter != points_out.end();
       ++iter, rgb_ptr += point_step)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/transformers/rgb8_pc_transformer.cpp
@@ -29,6 +29,7 @@
 
 
 #include <algorithm>
+#include <array>
 
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp"
 


### PR DESCRIPTION
Perhaps not a big improvement, but this loop here that runs everytime the function is called is some CPU waste that can be avoided.