### PR TITLE
fix: add `rclcpp::shutdown`

### DIFF
--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
@@ -109,5 +109,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   QApplication app(argc, argv);
   InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/transformation/transformer_guard_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/transformation/transformer_guard_test.cpp
@@ -156,5 +156,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   QApplication app(argc, argv);
   InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
+  auto ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
 }


### PR DESCRIPTION
This PR adds the missing `rclcpp::shutdown`.