### PR TITLE
Expose the possibility to create ROS node with custom `NodeOptions`

### DIFF
--- a/rviz2/src/main.cpp
+++ b/rviz2/src/main.cpp
@@ -86,7 +86,11 @@ int main(int argc, char ** argv)
   );
 
   rviz_common::VisualizerApp vapp(
-    std::make_unique<rviz_common::ros_integration::RosClientAbstraction>());
+    std::make_unique<rviz_common::ros_integration::RosClientAbstraction>(
+      // In custom setups, this is the injection point for ROS node options
+      rclcpp::NodeOptions()
+    )
+  );
   vapp.setApp(&qapp);
   if (vapp.init(argc, argv)) {
     return qapp.exec();

--- a/rviz_common/include/rviz_common/ros_integration/ros_client_abstraction.hpp
+++ b/rviz_common/include/rviz_common/ros_integration/ros_client_abstraction.hpp
@@ -48,7 +48,7 @@ class RosClientAbstraction : public RosClientAbstractionIface
 {
 public:
   RVIZ_COMMON_PUBLIC
-  RosClientAbstraction(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+  explicit RosClientAbstraction(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   // TODO(wjwwood): Figure out which exceptions can be raised and document them
   //                consider consolidating all possible exceptions to a few

--- a/rviz_common/include/rviz_common/ros_integration/ros_client_abstraction.hpp
+++ b/rviz_common/include/rviz_common/ros_integration/ros_client_abstraction.hpp
@@ -48,7 +48,7 @@ class RosClientAbstraction : public RosClientAbstractionIface
 {
 public:
   RVIZ_COMMON_PUBLIC
-  RosClientAbstraction();
+  RosClientAbstraction(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   // TODO(wjwwood): Figure out which exceptions can be raised and document them
   //                consider consolidating all possible exceptions to a few
@@ -93,6 +93,7 @@ public:
 
 private:
   std::shared_ptr<RosNodeAbstractionIface> rviz_ros_node_;
+  rclcpp::NodeOptions options_;
 };
 
 }  // namespace ros_integration

--- a/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction.hpp
+++ b/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction.hpp
@@ -62,7 +62,9 @@ public:
    * \param node_name name of the node to create
    */
   RVIZ_COMMON_PUBLIC
-  explicit RosNodeAbstraction(const std::string & node_name);
+  explicit RosNodeAbstraction(
+    const std::string & node_name,
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /// Returns the name of the ros node
   /**

--- a/rviz_common/src/rviz_common/ros_integration/ros_client_abstraction.cpp
+++ b/rviz_common/src/rviz_common/ros_integration/ros_client_abstraction.cpp
@@ -44,7 +44,8 @@ namespace rviz_common
 namespace ros_integration
 {
 
-RosClientAbstraction::RosClientAbstraction()
+RosClientAbstraction::RosClientAbstraction(const rclcpp::NodeOptions & options)
+: options_(options)
 {}
 
 RosNodeAbstractionIface::WeakPtr
@@ -63,7 +64,7 @@ RosClientAbstraction::init(int argc, char ** argv, const std::string & name, boo
     // TODO(wjwwood): make a better exception type rather than using std::runtime_error.
     throw std::runtime_error("Node with name " + final_name + " already exists.");
   }
-  rviz_ros_node_ = std::make_shared<RosNodeAbstraction>(final_name);
+  rviz_ros_node_ = std::make_shared<RosNodeAbstraction>(final_name, options_);
   return rviz_ros_node_;
 }
 

--- a/rviz_common/src/rviz_common/ros_integration/ros_node_abstraction.cpp
+++ b/rviz_common/src/rviz_common/ros_integration/ros_node_abstraction.cpp
@@ -44,8 +44,10 @@ namespace rviz_common
 namespace ros_integration
 {
 
-RosNodeAbstraction::RosNodeAbstraction(const std::string & node_name)
-: raw_node_(rclcpp::Node::make_shared(node_name))
+RosNodeAbstraction::RosNodeAbstraction(
+  const std::string & node_name,
+  const rclcpp::NodeOptions & options)
+: raw_node_(rclcpp::Node::make_shared(node_name, options))
 {}
 
 std::string


### PR DESCRIPTION
This PR upstreams some small changes useful for launching Rviz with custom `NodeOptions`.
For example, this allows to enable IPC communication and obtain the maximum yield from #1331 and #1346.

In commit 0e4cfda1d03232b98ddf82f42d4e7b3d2eea468e the class `RosNodeAbstraction` is enabled.
In commit d916ac001c8199d10f61b0e7f4a75d6a30777894 the class `RosClientAbstraction` is enabled.
In commit 072a01ac3f9d83f42a540da556eee065e612fbae the `main` function gets an explicit hint of the new entrypoint for node option injection.