### PR TITLE
Use official freetype github mirror instead of savannah mirror

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -14,7 +14,7 @@ if(WIN32)
   endif()
 
   ament_vendor(freetype_vendor
-    VCS_URL https://git.savannah.gnu.org/git/freetype/freetype2.git
+    VCS_URL https://github.com/freetype/freetype.git
     VCS_VERSION VER-2-13-2
     CMAKE_ARGS
       -DFT_DISABLE_ZLIB:BOOL=ON


### PR DESCRIPTION
Today I tested the official ROS 2 from source installation on Windows, and the `rviz_ogre_vendor` installation was failing on the clone of the freetype repo.

Indeed, by trying to clone the repo also on its own, I obtain an error:

~~~
C:\Users\straversaro>git clone https://git.savannah.gnu.org/git/freetype/freetype2.git
Cloning into 'freetype2'...
fatal: unable to access 'https://git.savannah.gnu.org/git/freetype/freetype2.git/': The requested URL returned error: 502
~~~

I am not sure if this is a problem just for me somehow, but apparently also @knmcguire was affected by this in the past. Indeed, by checking the freetype documentation, it seems that savannah is only supported for CVS access, see https://freetype.org/developer.html . 

There, the official repo for the freetype project is reported as the [freedesktop.org's gitlab instance](https://gitlab.freedesktop.org/freetype). 

However, it seems that also that has its own stability problems (https://www.phoronix.com/news/FreeDesktop-GitLab-2022-Crash, https://www.phoronix.com/news/FreeDesktop-Down-1-Week-Soon). So I guess that a better choice (to have at least a single point of failure, not multiple single point of failure) is to just use the official freetype mirror at https://github.com/freetype/freetype (see https://gitlab.freedesktop.org/freetype/freetype/-/issues/1242 where it is confirmed that indeed that is a official mirror).