### PR TITLE
Add missing glew dependency for ogre vendor package.

### DIFF
--- a/rviz_ogre_vendor/package.xml
+++ b/rviz_ogre_vendor/package.xml
@@ -25,6 +25,7 @@
 
   <build_depend>libfreetype-dev</build_depend>
   <build_export_depend>libfreetype-dev</build_export_depend>
+  <build_export_depend>libglew-dev</build_export_depend>
   <exec_depend>libfreetype6</exec_depend>
 
   <depend>libx11-dev</depend>


### PR DESCRIPTION
The `GL/glew.h` header is used in some headers of OGRE.
This PR adds the missing `build_export_depend` for glew.
See this build log for a failure due to this missing dependency: https://build.ros2.org/job/Jdev__hector_rviz_overlay__ubuntu_noble_amd64/7/console#console-section-4