### PR TITLE
Fix Potential Null Pointer Dereference in VisualizerApp::getRenderWindow() to Prevent Crashes

### DIFF
--- a/rviz_common/src/rviz_common/visualizer_app.cpp
+++ b/rviz_common/src/rviz_common/visualizer_app.cpp
@@ -71,6 +71,9 @@ void VisualizerApp::setApp(QApplication * app)
 
 rviz_rendering::RenderWindow * VisualizerApp::getRenderWindow()
 {
+  if (!frame_) {
+    return nullptr;
+  }
   return frame_->getRenderWindow();
 }
 

--- a/rviz_common/test/visualizer_app_test.cpp
+++ b/rviz_common/test/visualizer_app_test.cpp
@@ -57,3 +57,12 @@ TEST(VisualizerApp, shutdownsRosDuringExit) {
     rviz_common::VisualizerApp visualizer_app(std::move(ros_client));
   }
 }
+
+TEST(VisualizerApp, handlesEmptyFrameDuringExit) {
+  std::unique_ptr<rviz_common::ros_integration::RosClientAbstractionIface> ros_client =
+    std::make_unique<MockRosNodeStorage>();
+  EXPECT_CALL(*dynamic_cast<MockRosNodeStorage *>(ros_client.get()), shutdown()).Times(1);
+  rviz_common::VisualizerApp visualizer_app(std::move(ros_client));
+  // Simulate that frame_ is nullptr during exit, ensuring no crash occurs
+  visualizer_app.getRenderWindow();
+}

--- a/rviz_common/test/visualizer_app_test.cpp
+++ b/rviz_common/test/visualizer_app_test.cpp
@@ -64,5 +64,5 @@ TEST(VisualizerApp, handlesEmptyFrameDuringExit) {
   EXPECT_CALL(*dynamic_cast<MockRosNodeStorage *>(ros_client.get()), shutdown()).Times(1);
   rviz_common::VisualizerApp visualizer_app(std::move(ros_client));
   // Simulate that frame_ is nullptr during exit, ensuring no crash occurs
-  visualizer_app.getRenderWindow();
+  EXPECT_EQ(nullptr, visualizer_app.getRenderWindow());
 }


### PR DESCRIPTION
Closes https://github.com/ros2/rviz/issues/1358