### PR TITLE
UniformStringStream::parseFloat Fails to Handle Invalid Float Formats Correctly

### DIFF
--- a/rviz_common/src/rviz_common/uniform_string_stream.cpp
+++ b/rviz_common/src/rviz_common/uniform_string_stream.cpp
@@ -61,6 +61,11 @@ void UniformStringStream::parseFloat(float & f)
   if (float_reader.fail()) {
     this->setstate(std::ios::failbit);
   }
+
+  // Ensure the entire string is correctly parsed
+  if (float_reader.fail() || !float_reader.eof()) {
+    this->setstate(std::ios::failbit);
+  }
 }
 
 }  // namespace rviz_common

--- a/rviz_common/src/rviz_common/uniform_string_stream.cpp
+++ b/rviz_common/src/rviz_common/uniform_string_stream.cpp
@@ -58,10 +58,6 @@ void UniformStringStream::parseFloat(float & f)
   }
   UniformStringStream float_reader(float_string);
   float_reader >> f;
-  if (float_reader.fail()) {
-    this->setstate(std::ios::failbit);
-  }
-
   // Ensure the entire string is correctly parsed
   if (float_reader.fail() || !float_reader.eof()) {
     this->setstate(std::ios::failbit);

--- a/rviz_common/test/uniform_string_stream_test.cpp
+++ b/rviz_common/test/uniform_string_stream_test.cpp
@@ -94,6 +94,14 @@ TEST(UniformStringStream, print_floats) {
   std::locale::global(old_locale);
 }
 
+TEST(UniformStringStream, parse_floats_invalid_float_format) {
+  UniformStringStream uss("1.2.3 4,5");
+  float a, b;
+  uss.parseFloat(a);
+  uss.parseFloat(b);
+  EXPECT_FALSE(!!uss);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Closes https://github.com/ros2/rviz/issues/1357