### PR TITLE
Add test to check mapGetString when key is missing

### DIFF
--- a/rviz_common/test/config_test.cpp
+++ b/rviz_common/test/config_test.cpp
@@ -76,6 +76,9 @@ TEST(Config, mapGetValue_key_not_found_null_check) {
   QString s;
   EXPECT_FALSE(c.mapGetString("non_existent_key", &s));
   EXPECT_EQ(s, "");
+  QString s_default("my_default_value");
+  EXPECT_FALSE(c.mapGetString("non_existent_key", &s_default));
+  EXPECT_EQ(s_default, "my_default_value");
 }
 
 int main(int argc, char ** argv)

--- a/rviz_common/test/config_test.cpp
+++ b/rviz_common/test/config_test.cpp
@@ -71,6 +71,13 @@ TEST(Config, set_get_empty_value) {
   EXPECT_EQ("", s);
 }
 
+TEST(Config, mapGetValue_key_not_found_null_check) {
+  rviz_common::Config c;
+  QString s;
+  EXPECT_FALSE(c.mapGetString("non_existent_key", &s));
+  EXPECT_EQ(s, "");
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Related to this issue https://github.com/ros2/rviz/issues/1355

Instead of returning "default_value" as the issue suggested, I think we should check the returned string is empty