### PR TITLE
addTrackedObject Function Fails to Handle Null Pointer, Causing Crash When nullptr is Passed

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_handler.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_handler.cpp
@@ -127,6 +127,11 @@ void SelectionHandler::addTrackedObjects(Ogre::SceneNode * node)
 
 void SelectionHandler::addTrackedObject(Ogre::MovableObject * object)
 {
+  if (!object) {
+    // If object is nullptr, return immediately without further processing
+    return;
+  }
+
   tracked_objects_.insert(object);
   object->setListener(listener_.get());
 

--- a/rviz_common/test/interaction/selection_handler_test.cpp
+++ b/rviz_common/test/interaction/selection_handler_test.cpp
@@ -152,3 +152,8 @@ TEST_F(SelectionHandlerFixture, onDeselect_removes_wirebox_around_object) {
     Not(
       ContainsWireBoxWithBoundingBox(Ogre::AxisAlignedBox(-2.0f, -2.0f, 0.0f, 2.0f, 2.0f, 0.0f))));
 }
+
+TEST_F(SelectionHandlerFixture, addTrackedObject_invalid_pointer_does_not_crash) {
+  Ogre::MovableObject * invalid_object = nullptr;
+  EXPECT_NO_THROW(handler_->addTrackedObject(invalid_object));
+}


### PR DESCRIPTION
Closes https://github.com/ros2/rviz/issues/1373