### PR TITLE
Crash in MovableText::update() when caption is an empty string due to uninitialized resource usage

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/movable_text.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/movable_text.cpp
@@ -540,6 +540,10 @@ void MovableText::getRenderOperation(Ogre::RenderOperation & op)
 
 void MovableText::update()
 {
+  if (caption_.empty()) {
+    return;
+  }
+
   if (needs_update_) {
     setupGeometry();
   }

--- a/rviz_rendering/test/rviz_rendering/objects/movable_text_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/movable_text_test.cpp
@@ -241,3 +241,9 @@ TEST_F(MovableTextTestFixture, getBoundingRadius_gets_squared_length_from_origin
   ASSERT_THAT(
     movable_text->getBoundingRadius(), Eq(Ogre::Math::Sqrt(farthest_point.squaredLength())));
 }
+
+TEST_F(MovableTextTestFixture, EmptyCaptionDoesNotCrash) {
+  auto movable_text = std::make_shared<rviz_rendering::MovableText>("");
+  movable_text->update();
+  ASSERT_THAT(movable_text->getBoundingBox(), Eq(Ogre::AxisAlignedBox::BOX_NULL));
+}


### PR DESCRIPTION
Related with https://github.com/ros2/rviz/issues/1391