### PR TITLE
Grid Class Constructor Does Not Handle Null Pointer, Leading to Program Crash

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/grid.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/grid.cpp
@@ -64,6 +64,10 @@ Grid::Grid(
   height_count_(0),
   color_(color)
 {
+  if (!scene_manager_) {
+    throw std::invalid_argument("SceneManager cannot be null");
+  }
+
   static uint32_t grid_count = 0;
   std::string grid_name = "Grid" + std::to_string(grid_count++);
 

--- a/rviz_rendering/test/rviz_rendering/objects/grid_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/grid_test.cpp
@@ -152,3 +152,13 @@ TEST_F(GridTestFixture, setStyle_creates_a_new_grid_with_new_style) {
   auto manual_object = grid.getManualObject();
   ASSERT_THAT(manual_object->getBoundingBox(), Eq(Ogre::AxisAlignedBox()));
 }
+
+TEST_F(GridTestFixture, createGrid_with_null_scene_manager_throws_exception) {
+  uint32_t cell_count = 2;
+  float cell_length = 2.0f;
+  ASSERT_THROW(
+    rviz_rendering::Grid(
+      nullptr, nullptr, rviz_rendering::Grid::Style::Lines, cell_count, cell_length, 1.0f,
+    Ogre::ColourValue()),
+    std::invalid_argument);
+}


### PR DESCRIPTION
Related with https://github.com/ros2/rviz/issues/1390