### PR TITLE
Lack of Validity Check for Invalid Parameters in EffortVisual::Effort Visual Constructor

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/effort_visual.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/effort_visual.cpp
@@ -40,6 +40,9 @@ EffortVisual::EffortVisual(
   Ogre::SceneManager * scene_manager, Ogre::SceneNode * parent_node, float width, float scale)
 : scene_manager_(scene_manager), parent_node_(parent_node), width_(width), scale_(scale)
 {
+  if (scene_manager_ == nullptr) {
+    throw std::runtime_error("EffortVisual: Scene Manager is null.");
+  }
 }
 
 void EffortVisual::getRainbowColor(float value, Ogre::ColourValue & color)

--- a/rviz_rendering/test/rviz_rendering/objects/effort_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/effort_visual_test.cpp
@@ -33,6 +33,7 @@
 #include <OgreRoot.h>
 #include <OgreSceneNode.h>
 
+#include <exception>
 #include <memory>
 
 #include "../ogre_testing_environment.hpp"
@@ -139,4 +140,12 @@ TEST_F(EffortVisualTestFixture, setEffort_hides_force_arrow_for_larger_width_tha
   EXPECT_THAT(arrows, SizeIs(1u));
   auto force_arrow = findForceArrow(root_node);
   EXPECT_THAT(force_arrow->getScale(), Vector3Eq(Ogre::Vector3(1, 1, 1)));
+}
+
+TEST_F(EffortVisualTestFixture, verify_no_memory_leak_on_exception) {
+  auto scene_manager = Ogre::Root::getSingletonPtr()->createSceneManager();
+  auto root_node = scene_manager->getRootSceneNode();
+  // Intentionally passing nullptr
+  EXPECT_THROW(std::make_shared<rviz_rendering::EffortVisual>(
+    nullptr, root_node, 0.0f, 0.0f), std::runtime_error);
 }


### PR DESCRIPTION
Related with https://github.com/ros2/rviz/issues/1389