### PR TITLE
Invalid Parameter Handling in CovarianceVisual::CovarianceVisual Constructor

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/covariance_visual.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/covariance_visual.cpp
@@ -258,6 +258,11 @@ CovarianceVisual::CovarianceVisual(
   pose_2d_(false),
   orientation_visible_(is_visible)
 {
+  // Check if the passed pointers are valid
+  if (!scene_manager_ || !parent_node) {
+    throw std::runtime_error("Invalid scene_manager or parent_node passed to "
+      "CovarianceVisual constructor.");
+  }
   // Main node of the visual
   root_node_ = parent_node->createChildSceneNode();
   // Node that will have the same orientation as the fixed frame.

--- a/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
@@ -186,3 +186,9 @@ TEST_F(CovarianceVisualTestFixture, covariance_visual_2D)
   EXPECT_FALSE(all_orientation_uncertainties[1]->isVisible());
   EXPECT_FALSE(all_orientation_uncertainties[2]->isVisible());
 }
+
+TEST_F(CovarianceVisualTestFixture, CovarianceVisualNullScene)
+{
+  EXPECT_THROW(std::make_unique<rviz_rendering::CovarianceVisual>(
+    nullptr, nullptr, false, true, .1f, .1f, 2.0f), std::runtime_error);
+}


### PR DESCRIPTION
Related with https://github.com/ros2/rviz/issues/1388