### PR TITLE
MovableText constructor does not validate invalid character height, default fallback missing

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/movable_text.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/movable_text.cpp
@@ -79,7 +79,6 @@ MovableText::MovableText(
   horizontal_alignment_(H_LEFT),
   vertical_alignment_(V_BELOW),
   color_(color),
-  char_height_(charHeight),
   line_spacing_(0.01f),
   space_width_(0),
   needs_color_update_(true),
@@ -88,6 +87,7 @@ MovableText::MovableText(
   local_translation_(0.0f),
   font_(nullptr)
 {
+  char_height_ = (charHeight > 0.0f) ? charHeight : 1.0f;
   static int count = 0;
   std::stringstream ss;
   ss << "MovableText" << count++;

--- a/rviz_rendering/test/rviz_rendering/objects/movable_text_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/movable_text_test.cpp
@@ -241,3 +241,9 @@ TEST_F(MovableTextTestFixture, getBoundingRadius_gets_squared_length_from_origin
   ASSERT_THAT(
     movable_text->getBoundingRadius(), Eq(Ogre::Math::Sqrt(farthest_point.squaredLength())));
 }
+
+TEST_F(MovableTextTestFixture, handle_invalid_char_height) {
+  auto movable_text = std::make_shared<rviz_rendering::MovableText>("A", "Liberation Sans", -1.0f);
+  // Expect that default char height is used when invalid
+  ASSERT_EQ(movable_text->getCharacterHeight(), 1.0f);
+}


### PR DESCRIPTION
Related with https://github.com/ros2/rviz/issues/1397