### PR TITLE
PointCloudDisplay: Fix decay time 0 keeping more than the last message.

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -425,7 +425,7 @@ void PointCloudCommon::removeObsoleteCloudInfos()
 bool PointCloudCommon::cloudInfoIsDecayed(
   CloudInfoPtr cloud_info, float point_decay_time, const rclcpp::Time & now)
 {
-  return (now.nanoseconds() - cloud_info->receive_time_.nanoseconds()) / 1000000000.0 >
+  return (now.nanoseconds() - cloud_info->receive_time_.nanoseconds()) / 1E9 >=
          point_decay_time;
 }
 


### PR DESCRIPTION
Fixes issue #1399.

Here's an example with the fix:
![image](https://github.com/user-attachments/assets/99254f50-3e7b-4bbd-83d3-5b1ebe6b55e8)

and without:
![image](https://github.com/user-attachments/assets/de789627-50bb-4d6a-af08-6e62816b711c)

as you can see by the normals and my other point cloud display, where this is currently fixed with a workaround, there is at least a second, if not a third, point cloud that should have been decayed.

Should I also backport it to jazzy, or do you also use the fancy bot here?