### PR TITLE
Shape Constructor Does Not Check for Null scene_manager Pointer, Leading to Crashes

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/wrench_visual.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/wrench_visual.cpp
@@ -51,6 +51,10 @@ WrenchVisual::WrenchVisual(Ogre::SceneManager * scene_manager, Ogre::SceneNode *
   torque_scale_(1),
   width_(1)
 {
+  if (!scene_manager) {
+    throw std::invalid_argument("WrenchVisual constructor requires a non-null scene_manager.");
+  }
+
   scene_manager_ = scene_manager;
 
   frame_node_ = parent_node->createChildSceneNode();

--- a/rviz_rendering/test/rviz_rendering/objects/wrench_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/wrench_visual_test.cpp
@@ -114,3 +114,10 @@ TEST_F(WrenchVisualTestFixture, setWrench_hides_force_arrow_for_larger_width_tha
     EXPECT_THAT(object->isVisible(), IsFalse());
   }
 }
+
+TEST_F(WrenchVisualTestFixture, constructor_handles_null_scene_manager) {
+  auto root_node = Ogre::Root::getSingletonPtr()->createSceneManager()->getRootSceneNode();
+  ASSERT_NE(root_node, nullptr);
+  ASSERT_THROW(std::make_shared<rviz_rendering::WrenchVisual>(nullptr, root_node),
+    std::invalid_argument);
+}


### PR DESCRIPTION
Related with https://github.com/ros2/rviz/issues/1403