### PR TITLE
Crash due to Unhandled Null Pointer in ParameterEventsFilter Constructor

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/wrench_visual.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/wrench_visual.cpp
@@ -51,6 +51,9 @@ WrenchVisual::WrenchVisual(Ogre::SceneManager * scene_manager, Ogre::SceneNode *
   torque_scale_(1),
   width_(1)
 {
+  if (!scene_manager || !parent_node) {
+    throw std::invalid_argument("Scene manager or root node is null");
+  }
   scene_manager_ = scene_manager;
 
   frame_node_ = parent_node->createChildSceneNode();

--- a/rviz_rendering/test/rviz_rendering/objects/wrench_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/wrench_visual_test.cpp
@@ -114,3 +114,12 @@ TEST_F(WrenchVisualTestFixture, setWrench_hides_force_arrow_for_larger_width_tha
     EXPECT_THAT(object->isVisible(), IsFalse());
   }
 }
+
+TEST_F(WrenchVisualTestFixture, constructor_handles_null_pointers_gracefully) {
+  Ogre::SceneManager * scene_manager = nullptr;
+  Ogre::SceneNode * root_node = nullptr;
+
+  EXPECT_THROW({
+    auto wrench_visual = std::make_shared<rviz_rendering::WrenchVisual>(scene_manager, root_node);
+  }, std::invalid_argument);
+}


### PR DESCRIPTION
Related https://github.com/ros2/rviz/issues/1404