### PR TITLE
Memory Access Error When Handling Empty Strings in splitStringIntoTrimmedItems Function

### DIFF
--- a/rviz_rendering/src/rviz_rendering/string_helper.cpp
+++ b/rviz_rendering/src/rviz_rendering/string_helper.cpp
@@ -44,18 +44,29 @@ std::vector<std::string> rviz_rendering::string_helper::splitStringIntoTrimmedIt
   std::string item;
   std::vector<std::string> filenames;
   while (std::getline(stringstream, item, delimiter)) {
-    auto whitespace_front = std::find_if_not(
-      item.begin(), item.end(), [](char character) {
+    if (std::all_of(item.begin(), item.end(), [](char character) {
         return std::isspace<char>(character, std::locale(""));
-      });
-    auto whitespace_back = std::find_if_not(
-      item.rbegin(), item.rend(), [](char character) {
-        return std::isspace<char>(character, std::locale(""));
-      });
-    item.erase(whitespace_back.base(), item.end());
-    item.erase(item.begin(), whitespace_front);
-    if (!item.empty()) {
-      filenames.push_back(item);
+    }))
+    {
+      item.clear();
+    } else {
+      auto whitespace_front = std::find_if_not(
+        item.begin(), item.end(), [](char character) {
+          return std::isspace<char>(character, std::locale(""));
+        });
+      auto whitespace_back = std::find_if_not(
+        item.rbegin(), item.rend(), [](char character) {
+          return std::isspace<char>(character, std::locale(""));
+        });
+
+      // Only perform erase operation if the string is not empty
+      if (whitespace_front != item.end() && whitespace_back != item.rend()) {
+        item.erase(whitespace_back.base(), item.end());
+        item.erase(item.begin(), whitespace_front);
+      }
+      if (!item.empty()) {
+        filenames.push_back(item);
+      }
     }
   }
   return filenames;

--- a/rviz_rendering/test/rviz_rendering/string_helper_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/string_helper_test.cpp
@@ -77,3 +77,19 @@ TEST(String_Helper__Test, correctly_split_string_with_other_whitespace) {
 
   ASSERT_THAT(expected, Eq(actual));
 }
+
+TEST(String_Helper__Test, split_string_with_empty_and_space_items) {
+  std::vector<std::string> expected {"Test", "Test2"};
+  std::string test_string(" \n Test \n \n Test2 \n ");
+  std::vector<std::string> actual = rviz_rendering::string_helper::splitStringIntoTrimmedItems(
+    test_string, '\n');
+  ASSERT_THAT(expected, Eq(actual));
+}
+
+TEST(String_Helper__Test, HandlesNothingBesidesDelimiters) {
+    std::vector<std::string> expected{};
+    std::string test_string(",,\n,\n,,");
+    std::vector<std::string> actual = rviz_rendering::string_helper::splitStringIntoTrimmedItems(
+        test_string, ',');
+    ASSERT_THAT(expected, Eq(actual));
+}


### PR DESCRIPTION
Related with https://github.com/ros2/rviz/issues/1407