### PR TITLE
Missing Null Pointer Check in TrianglePolygon Constructor Leads to Crash

### DIFF
--- a/rviz_rendering/include/rviz_rendering/objects/triangle_polygon.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/triangle_polygon.hpp
@@ -57,6 +57,8 @@ public:
     const Ogre::ColourValue & color,
     bool use_color,
     bool upper_triangle);
+
+  RVIZ_RENDERING_PUBLIC
   virtual ~TrianglePolygon();
 
   RVIZ_RENDERING_PUBLIC

--- a/rviz_rendering/src/rviz_rendering/objects/triangle_polygon.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/triangle_polygon.cpp
@@ -52,6 +52,10 @@ TrianglePolygon::TrianglePolygon(
   bool use_color,
   bool upper_triangle)
 {
+  if (!manager || !node) {
+    throw std::invalid_argument("SceneManager and SceneNode must not be null.");
+  }
+
   // uniq string is requred for name
   manual_ = manager->createManualObject();
   manual_->clear();

--- a/rviz_rendering/test/rviz_rendering/objects/triangle_polygon_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/triangle_polygon_test.cpp
@@ -75,3 +75,11 @@ TEST_F(TrianglePolygonTestFixture, setPoints_sets_the_line_position_and_size) {
   ASSERT_THAT(aabb.getMaximum(), Vector3Eq(Ogre::Vector3(1, 1, 0)));
   delete triangle_polygon;
 }
+
+TEST_F(TrianglePolygonTestFixture, trianglePolygon_constructor_nullptr_parameters_throws)
+{
+  EXPECT_THROW(
+    auto triangle = rviz_rendering::TrianglePolygon(nullptr, nullptr, Ogre::Vector3(),
+    Ogre::Vector3(), Ogre::Vector3(), "", Ogre::ColourValue(), false, false),
+    std::invalid_argument);
+}


### PR DESCRIPTION
Related to https://github.com/ros2/rviz/issues/1401