### PR TITLE
Constructor ScrewVisual::ScrewVisual does not handle null pointers, leading to crashes

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/screw_visual.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/screw_visual.cpp
@@ -33,6 +33,7 @@
 #include <OgreSceneManager.h>
 
 #include <cmath>
+#include <stdexcept>
 #include <memory>
 
 #include "rviz_rendering/objects/arrow.hpp"
@@ -46,6 +47,10 @@ ScrewVisual::ScrewVisual(Ogre::SceneManager * scene_manager, Ogre::SceneNode * p
 : linear_scale_(0.0f), angular_scale_(0.0f), width_(0.0f), hide_small_values_(true),
   scene_manager_(scene_manager)
 {
+  if (!scene_manager || !parent_node) {
+    throw std::invalid_argument("Invalid input: scene_manager or parent_node is nullptr.");
+  }
+
   // Ogre::SceneNode s form a tree, with each node storing the transform (position and orientation)
   // of itself relative to its parent. Ogre does the math of combining those transforms
   // for rendering. Here we create a node to store the pose of the screw's header

--- a/rviz_rendering/test/rviz_rendering/objects/screw_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/screw_visual_test.cpp
@@ -138,3 +138,10 @@ TEST_F(ScrewVisualTestFixture, setScrew_sets_linear_arrow_correctly) {
   angular_arrow = findAngularArrow(root_node);
   EXPECT_THAT(angular_arrow->getScale(), Vector3Eq(Ogre::Vector3(0.0f, 3.4641f, 0.0f)));
 }
+
+TEST_F(ScrewVisualTestFixture, HandleNullSceneManagerAndParentNode)
+{
+  EXPECT_THROW(
+    auto screw_visual = std::make_shared<rviz_rendering::ScrewVisual>(nullptr, nullptr),
+    std::invalid_argument);
+}


### PR DESCRIPTION
Related to https://github.com/ros2/rviz/issues/1383