### PR TITLE
BillboardLine::addPoint() does not throw an exception when exceeding max_points_per_line limit

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/billboard_line.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/billboard_line.cpp
@@ -40,6 +40,7 @@
 #include <OgreTechnique.h>
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 #include "rviz_rendering/material_manager.hpp"
@@ -184,6 +185,12 @@ void BillboardLine::addPoint(const Ogre::Vector3 & point, const Ogre::ColourValu
   incrementChainContainerIfNecessary();
 
   rviz_rendering::MaterialManager::enableAlphaBlending(material_, color.a);
+
+  if (chain_containers_[current_chain_container_]->getNumChainElements(current_line_ %
+    chains_per_container_) >= max_points_per_line_)
+  {
+    throw std::out_of_range("Exceeded max_points_per_line limit.");
+  }
 
   Ogre::BillboardChain::Element e;
   e.position = point;

--- a/rviz_rendering/test/rviz_rendering/objects/billboard_line_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/billboard_line_test.cpp
@@ -210,3 +210,11 @@ TEST_F(BillboardLineTestFixture, create_chain_with_extremely_many_elements) {
   ASSERT_THAT(chains, SizeIs(200000 / 16384 + 1));
   ASSERT_THAT(chains[0]->getNumberOfChains(), Eq(1u));
 }
+
+TEST_F(BillboardLineTestFixture, addPoint_checks_for_max_points_per_line_boundary) {
+  rviz_rendering::BillboardLine grid_cell(Ogre::Root::getSingletonPtr()->createSceneManager());
+  grid_cell.setMaxPointsPerLine(2);
+  grid_cell.addPoint(Ogre::Vector3(0, 0, 0));
+  grid_cell.addPoint(Ogre::Vector3(1, 1, 0));
+  EXPECT_THROW(grid_cell.addPoint(Ogre::Vector3(2, 2, 0)), std::out_of_range);
+}


### PR DESCRIPTION
Related to https://github.com/ros2/rviz/issues/1386