### PR TITLE
Do not use ${Qt5Widgets_INCLUDE_DIRS} to avoid creating non-relocatable config files

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -242,7 +242,6 @@ add_library(rviz_default_plugins SHARED
 target_include_directories(rviz_default_plugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
-  ${Qt5Widgets_INCLUDE_DIRS}
 )
 
 target_link_libraries(rviz_default_plugins PUBLIC
@@ -266,6 +265,7 @@ target_link_libraries(rviz_default_plugins PUBLIC
   ${visualization_msgs_TARGETS}
   resource_retriever::resource_retriever
   ${rviz_resource_interfaces_TARGETS}
+  Qt5::Widgets
 )
 
 target_link_libraries(rviz_default_plugins PRIVATE


### PR DESCRIPTION
An analysis performed by @knmcguire on ROS 2 Windows binaries highlighted a few non-relocatable files, see https://github.com/ros2/ros2/issues/1675#issuecomment-2841735793 . 

One of those files was `rviz_default_pluginsExport.cmake` . It turns out that this was due to the (probably leftover) use of `${Qt5Widgets_INCLUDE_DIRS}` in `target_include_directories(rviz_default_plugins PUBLIC` . 
This PR fixes this by avoiding the use of  `${Qt5Widgets_INCLUDE_DIRS}` , and instead directly linking to `Qt5::Widgets` 

As `rviz_default_plugins` already links `rviz_common::rviz_common` that itself links `Qt5::Widgets` as `PUBLIC` dependency, there should be no difference in the libraries actually linked by `rviz_default_plugins`.