### PR TITLE
Config::mapGetBool causes segmentation fault when value_out is nullptr

### DIFF
--- a/rviz_common/src/rviz_common/config.cpp
+++ b/rviz_common/src/rviz_common/config.cpp
@@ -264,6 +264,10 @@ bool Config::mapGetFloat(const QString & key, float * value_out) const
 
 bool Config::mapGetBool(const QString & key, bool * value_out) const
 {
+  if (value_out == nullptr) {
+    return false;
+  }
+
   QVariant v;
   if (mapGetValue(key, &v) && (v.type() == QVariant::Bool || v.type() == QVariant::String)) {
     *value_out = v.toBool();

--- a/rviz_common/test/config_test.cpp
+++ b/rviz_common/test/config_test.cpp
@@ -81,6 +81,17 @@ TEST(Config, mapGetValue_key_not_found_null_check) {
   EXPECT_EQ(s_default, "my_default_value");
 }
 
+TEST(Config, handle_mixed_type_values_for_keys) {
+  rviz_common::Config c;
+  c.mapSetValue("mixed_key", "123abc");
+  EXPECT_FALSE(c.mapGetInt("mixed_key", nullptr));
+  EXPECT_FALSE(c.mapGetBool("mixed_key", nullptr));
+  EXPECT_FALSE(c.mapGetFloat("mixed_key", nullptr));
+  QString string_value;
+  EXPECT_TRUE(c.mapGetString("mixed_key", &string_value));
+  EXPECT_EQ(string_value, "123abc");
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Related with this issue https://github.com/ros2/rviz/issues/1469