### PR TITLE
Removed point_cloud_transport deprecation

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -111,10 +111,10 @@ protected:
 
     try {
       auto required_interfaces = std::make_shared<rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeBaseInterface,
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface,
-        rclcpp::node_interfaces::NodeLoggingInterface>>(*rviz_ros_node_.lock()->get_raw_node());
+            rclcpp::node_interfaces::NodeBaseInterface,
+            rclcpp::node_interfaces::NodeParametersInterface,
+            rclcpp::node_interfaces::NodeTopicsInterface,
+            rclcpp::node_interfaces::NodeLoggingInterface>>(*rviz_ros_node_.lock()->get_raw_node());
 
       subscription_ = std::make_shared<point_cloud_transport::SubscriberFilter>();
       subscription_->subscribe(

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -110,9 +110,15 @@ protected:
     }
 
     try {
+      auto required_interfaces = std::make_shared<rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeBaseInterface,
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface,
+        rclcpp::node_interfaces::NodeLoggingInterface>>(*rviz_ros_node_.lock()->get_raw_node());
+
       subscription_ = std::make_shared<point_cloud_transport::SubscriberFilter>();
       subscription_->subscribe(
-        rviz_ros_node_.lock()->get_raw_node(),
+        required_interfaces,
         getPointCloud2BaseTopicFromTopic(topic_property_->getTopicStd()),
         getPointCloud2TransportFromTopic(topic_property_->getTopicStd()),
         qos_profile.get_rmw_qos_profile());


### PR DESCRIPTION
Removed point_cloud_transport deprecation

Related with https://github.com/ros-perception/point_cloud_transport/pull/109/files

Related with this warning on CI https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/2277/clang-tidy/fileName.1856435043/
