### PR TITLE
Fix compile with qt6

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -394,7 +394,7 @@ if(BUILD_TESTING)
     target_link_libraries(frame_view_controller_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
-      Qt5::Widgets
+      Qt${QT_VERSION_MAJOR}::Widgets
       ogre_testing_environment
     )
   endif()

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -275,7 +275,6 @@ target_link_libraries(rviz_default_plugins PUBLIC
   ${visualization_msgs_TARGETS}
   resource_retriever::resource_retriever
   ${rviz_resource_interfaces_TARGETS}
-  Qt5::Widgets
 )
 
 target_link_libraries(rviz_default_plugins PRIVATE


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixed a rviz_default_plugin compilation error when using qt6.
The error is silent if you have qt5 and qt6 installed

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
