### PR TITLE
Handle glTF Y-Up frame convention on mesh load

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -215,7 +215,7 @@ Ogre::MeshPtr AssimpLoader::meshFromAssimpScene(const std::string & name, const 
     // by applying a 90 degree rotation about the X-axis,
     // effectively going from (x, y, z) to (x, -z, y)
     aiMatrix4x4 transform;
-    aiMatrix4x4::RotationX(M_PI / 2.0, transform);
+    aiMatrix4x4::RotationX(AI_MATH_HALF_PI, transform);
     scene->mRootNode->mTransformation = scene->mRootNode->mTransformation * transform;
   }
 

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -209,6 +209,16 @@ Ogre::MeshPtr AssimpLoader::meshFromAssimpScene(const std::string & name, const 
 
   Ogre::MeshPtr mesh = Ogre::MeshManager::getSingleton().createManual(name, ROS_PACKAGE_NAME);
 
+  const std::string ext = std::filesystem::path(name).extension().string();
+  if (ext == ".gltf" || ext == ".glb" || ext == ".vrm") {
+    // Transform mesh from glTF Y-Up space to ROS Z-Up space
+    // by applying a 90 degree rotation about the X-axis,
+    // effectively going from (x, y, z) to (x, -z, y)
+    aiMatrix4x4 transform;
+    aiMatrix4x4::RotationX(M_PI / 2.0, transform);
+    scene->mRootNode->mTransformation = scene->mRootNode->mTransformation * transform;
+  }
+
   Ogre::AxisAlignedBox axis_aligned_box(Ogre::AxisAlignedBox::EXTENT_NULL);
   float radius = 0.0f;
   buildMesh(scene, scene->mRootNode, mesh, axis_aligned_box, radius, material_table);


### PR DESCRIPTION
## Description

This patch transforms glTF and glTF2 meshes upon load to reconcile its Y-Up convention with ROS Z-Up convention. It does so by applying a right rotation about the X-axis to the root node transform, as other tools like [Blender](https://github.com/blender/blender/blob/7aa0981da43546354c7fd4ca8907c487279ddb5e/scripts/addons_core/io_scene_gltf2/blender/imp/blender_gltf.py#L69-L73) do.

Fixes https://github.com/ros2/rviz/issues/1229. 

### Is this user-facing behavior change?

Before this patch, a mesh marker bearing a sample glTF like [GearboxAssy](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/GearboxAssy/glTF) would render like:

![nonrotated](https://github.com/user-attachments/assets/2cde4486-064c-43e2-8528-e4b634ef17e9)

After this patch, we get:

![rotated](https://github.com/user-attachments/assets/34b8331b-9225-46dd-af5c-e823ffa679c4)

in line with other tools:

![blender](https://github.com/user-attachments/assets/aebb8e16-625d-4728-9722-190d628a5ea0)

### Did you use Generative AI?

I did not.

### Additional Information

Most visualizers rely on OpenGL frame conventions and do not apply transforms, but those that follow Z-Up frame conventions (Blender, Drake + Meshcat) do and it's this one.

**Important disclaimer**: to test this locally I had to clone and build [resource_retriever](https://github.com/ros/resource_retriever/tree/rolling) from source (latest Rolling debian is 3.6, not 3.8), I had to checkout `rviz` one commit before https://github.com/ros2/rviz/commit/56ab4c93bd9d466c1005994a8b09505c33020d05 (it wouldn't build against Rolling `rclcpp`, probably another binary release <> source release mismatch), and I had to comment out this line https://github.com/ros2/rviz/blob/72813d17395dc84a61c15f89305b0799bc1536b0/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp#L79 (ROS resource retrieve claims it can handle all resources but then fails to find the `/rviz/get_resource` service -- couldn't find any server node either).
