### PR TITLE
Removed windows warning

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -215,7 +215,7 @@ Ogre::MeshPtr AssimpLoader::meshFromAssimpScene(const std::string & name, const 
     // by applying a 90 degree rotation about the X-axis,
     // effectively going from (x, y, z) to (x, -z, y)
     aiMatrix4x4 transform;
-    aiMatrix4x4::RotationX(AI_MATH_HALF_PI, transform);
+    aiMatrix4x4::RotationX(static_cast<float>(AI_MATH_HALF_PI), transform);
     scene->mRootNode->mTransformation = scene->mRootNode->mTransformation * transform;
   }
 


### PR DESCRIPTION
Related with https://ci.ros2.org/job/ci_windows/24627/msbuild/fileName.1670348943/category.63475591/

Warning introduced in this PR https://github.com/ros2/rviz/pull/1482/files