### PR TITLE
Fix /rviz/get_resource

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/ros_resource_retriever.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/ros_resource_retriever.cpp
@@ -104,6 +104,10 @@ RosResourceRetriever::get_shared(const std::string & url)
     }
   }
 
+  if (!this->client_->service_is_ready()) {
+    return nullptr;
+  }
+
   // Request the resource with an etag, if it is set.
   RCLCPP_DEBUG(
     this->logger_,


### PR DESCRIPTION
Related with this issue https://github.com/ros2/rviz/issues/1484

This issue was introduced in this PR https://github.com/ros2/rviz/pull/1262, the idea behind this class it's to be able to provide a server that can return resource if required. But this service might be not available. @wjwwood and @mjcarroll is this assumption correct ?

When calling `get_shared`, the client will check if the service (`/rviz/get_resource`) is ready otherwise it will return and it will use the other plugins to try to get the resource.
