### PR TITLE
Add symbol visibility macros to make*Palette public functions

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
@@ -42,13 +42,13 @@ namespace displays
 {
 
 RVIZ_DEFAULT_PLUGINS_PUBLIC std::vector<unsigned char> makeRawPalette(
-  bool binary = false, 
+  bool binary = false,
   int threshold = 100);
 RVIZ_DEFAULT_PLUGINS_PUBLIC std::vector<unsigned char> makeMapPalette(
-  bool binary = false, 
+  bool binary = false,
   int threshold = 100);
 RVIZ_DEFAULT_PLUGINS_PUBLIC std::vector<unsigned char> makeCostmapPalette(
-  bool binary = false, 
+  bool binary = false,
   int threshold = 100);
 
 class PaletteBuilder : public

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/palette_builder.hpp
@@ -41,9 +41,15 @@ namespace rviz_default_plugins
 namespace displays
 {
 
-std::vector<unsigned char> makeRawPalette(bool binary = false, int threshold = 100);
-std::vector<unsigned char> makeMapPalette(bool binary = false, int threshold = 100);
-std::vector<unsigned char> makeCostmapPalette(bool binary = false, int threshold = 100);
+RVIZ_DEFAULT_PLUGINS_PUBLIC std::vector<unsigned char> makeRawPalette(
+  bool binary = false, 
+  int threshold = 100);
+RVIZ_DEFAULT_PLUGINS_PUBLIC std::vector<unsigned char> makeMapPalette(
+  bool binary = false, 
+  int threshold = 100);
+RVIZ_DEFAULT_PLUGINS_PUBLIC std::vector<unsigned char> makeCostmapPalette(
+  bool binary = false, 
+  int threshold = 100);
 
 class PaletteBuilder : public
   std::enable_shared_from_this<PaletteBuilder>


### PR DESCRIPTION
## Description


Add symbol visibility macros to `make*Palette` public functions. The functions are included in public headers and used in downstream projects (see https://github.com/OctoMap/octomap_rviz_plugins/blob/62ea089afc43801d70dd31dd51a1d35b916416a7/src/occupancy_map_display.cpp#L71C39-L71C57), so I think it make sense to expose them as public functions.

### Is this user-facing behavior change?

Not on Linux or macOS. The only difference is that on Windows the `make*Palette` functions can actually be used.

### Did you use Generative AI?

No.

### Additional Information

Without this fix, downstream packages can fail on Windows with errors like:

~~~
MSBuild version 17.13.15+18b3035f6 for .NET Framework
MSBUILD : error MSB1009: Project file does not exist.
Switch: Release.vcxproj

D:\src\ros-jazzy\output\bld\rattler-build_ros-jazzy-octomap-rviz-plugins_1750498615\work\build>cmake --build . --config Release
MSBuild version 17.13.15+18b3035f6 for .NET Framework

  1>Checking Build System
  Automatic MOC for target octomap_rviz_plugins
  Building Custom Rule D:/src/ros-jazzy/output/bld/rattler-build_ros-jazzy-octomap-rviz-plugins_1750498615/work/ros-jazzy-octomap-rviz-plugins/src/work/CMakeLists.txt
  moc_occupancy_grid_display.cpp
  moc_occupancy_map_display.cpp
  D:/src/ros-jazzy/output/bld/rattler-build_ros-jazzy-octomap-rviz-plugins_1750498615/h_env/Library/opt/rviz_ogre_vendor/include/OGRE\OgreVector3.h is deprecated, migrate to Ogre.h
  Generating Code...
occupancy_map_display.obj : error LNK2019: unresolved external symbol "class std::vector<unsigned char,class std::allocator<unsigned char> > __cdecl rviz_default_plugins::displays::makeRawPalette(bool,int)" (
?makeRawPalette@displays@rviz_default_plugins@@YA?AV?$vector@EV?$allocator@E@std@@@std@@_NH@Z) referenced in function "public: virtual void __cdecl octomap_rviz_plugins::OccupancyMapDisplay::onInitialize(void
)" (?onInitialize@OccupancyMapDisplay@octomap_rviz_plugins@@UEAAXXZ) [D:\src\ros-jazzy\output\bld\rattler-build_ros-jazzy-octomap-rviz-plugins_1750498615\work\build\octomap_rviz_plugins.vcxproj]
occupancy_map_display.obj : error LNK2019: unresolved external symbol "class std::vector<unsigned char,class std::allocator<unsigned char> > __cdecl rviz_default_plugins::displays::makeMapPalette(bool,int)" (
?makeMapPalette@displays@rviz_default_plugins@@YA?AV?$vector@EV?$allocator@E@std@@@std@@_NH@Z) referenced in function "public: virtual void __cdecl octomap_rviz_plugins::OccupancyMapDisplay::onInitialize(void
)" (?onInitialize@OccupancyMapDisplay@octomap_rviz_plugins@@UEAAXXZ) [D:\src\ros-jazzy\output\bld\rattler-build_ros-jazzy-octomap-rviz-plugins_1750498615\work\build\octomap_rviz_plugins.vcxproj]
occupancy_map_display.obj : error LNK2019: unresolved external symbol "class std::vector<unsigned char,class std::allocator<unsigned char> > __cdecl rviz_default_plugins::displays::makeCostmapPalette(bool,int
)" (?makeCostmapPalette@displays@rviz_default_plugins@@YA?AV?$vector@EV?$allocator@E@std@@@std@@_NH@Z) referenced in function "public: virtual void __cdecl octomap_rviz_plugins::OccupancyMapDisplay::onInitial
ize(void)" (?onInitialize@OccupancyMapDisplay@octomap_rviz_plugins@@UEAAXXZ) [D:\src\ros-jazzy\output\bld\rattler-build_ros-jazzy-octomap-rviz-plugins_1750498615\work\build\octomap_rviz_plugins.vcxproj]
D:\src\ros-jazzy\output\bld\rattler-build_ros-jazzy-octomap-rviz-plugins_1750498615\work\build\Release\octomap_rviz_plugins.dll : fatal error LNK1120: 3 unresolved externals [D:\src\ros-jazzy\output\bld\rattl
er-build_ros-jazzy-octomap-rviz-plugins_1750498615\work\build\octomap_rviz_plugins.vcxproj]
~~~
