### PR TITLE
rviz_ogre_vendor: Add RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ option to https://github.com/traversaro/rviz

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -4,6 +4,8 @@ project(rviz_ogre_vendor)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
+option(RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ "If enabled, append a unique name to OgreMain, OgreOverlay and OgreGLSupport." FALSE)
+
 if(WIN32)
   set(FREETYPE_C_FLAGS "${CMAKE_C_FLAGS}")
   if(MSVC)
@@ -104,6 +106,7 @@ ament_vendor(ogre_vendor
     -DOGRE_BUILD_RENDERSYSTEM_D3D11:BOOL=OFF
     -DOGRE_BUILD_RENDERSYSTEM_D3D9:BOOL=OFF
     -DCMAKE_POLICY_DEFAULT_CMP0074=NEW
+    -DOGRE_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ:BOOL=${RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ}
     "-DCMAKE_CXX_FLAGS=${OGRE_CXX_FLAGS}"
     ${OGRE_CMAKE_ARGS}
   PATCHES patches

--- a/rviz_ogre_vendor/patches/0005-mangle-library-names-used-by-rviz.patch
+++ b/rviz_ogre_vendor/patches/0005-mangle-library-names-used-by-rviz.patch
@@ -1,0 +1,59 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f4d8fd4aa..286b80366 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -404,6 +404,8 @@ if (MSVC OR CMAKE_GENERATOR MATCHES Xcode)
+ 	option(OGRE_PROJECT_FOLDERS "Organize project into project folders." TRUE)
+ endif ()
+ 
++option(OGRE_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ "If enabled, append a unique name to OgreMain, OgreOverlay and OgreGLSupport." FALSE)
++
+ # hide advanced options
+ mark_as_advanced(
+   OGRE_BUILD_RTSHADERSYSTEM_CORE_SHADERS
+diff --git a/Components/Overlay/CMakeLists.txt b/Components/Overlay/CMakeLists.txt
+index 64a2a4ed7..014e1a8a7 100644
+--- a/Components/Overlay/CMakeLists.txt
++++ b/Components/Overlay/CMakeLists.txt
+@@ -71,6 +71,10 @@ if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
+     ${IMGUI_DIR}/imconfig.h)
+ endif()
+ 
++if(OGRE_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ)
++  set_target_properties(OgreOverlay PROPERTIES OUTPUT_NAME OgreOverlay_rviz)
++endif()
++
+ generate_export_header(OgreOverlay 
+     EXPORT_MACRO_NAME _OgreOverlayExport
+     EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreOverlayPrerequisites.h)
+diff --git a/OgreMain/CMakeLists.txt b/OgreMain/CMakeLists.txt
+index 918f102ed..631a0225a 100644
+--- a/OgreMain/CMakeLists.txt
++++ b/OgreMain/CMakeLists.txt
+@@ -248,6 +248,11 @@ if (APPLE)
+     set_target_properties(OgreMain PROPERTIES	OUTPUT_NAME Ogre)
+   endif()
+ endif ()
++
++if(OGRE_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ)
++  set_target_properties(OgreMain PROPERTIES	OUTPUT_NAME OgreMain_rviz)
++endif()
++
+ target_link_libraries(OgreMain PUBLIC ${PLATFORM_LIBS} PRIVATE ${LIBRARIES} ${CMAKE_DL_LIBS})
+ 
+ # specify a precompiled header to use
+diff --git a/RenderSystems/GLSupport/CMakeLists.txt b/RenderSystems/GLSupport/CMakeLists.txt
+index 31c750729..e455d75ea 100644
+--- a/RenderSystems/GLSupport/CMakeLists.txt
++++ b/RenderSystems/GLSupport/CMakeLists.txt
+@@ -112,6 +112,10 @@ target_include_directories(OgreGLSupport PUBLIC
+     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/GLSL>"
+     PRIVATE "$<BUILD_INTERFACE:${NATIVE_INCLUDES}>")
+ 
++if(OGRE_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ)
++  set_target_properties(OgreGLSupport PROPERTIES OUTPUT_NAME OgreGLSupport_rviz)
++endif()
++
+ set_property(TARGET OgreGLSupport PROPERTY POSITION_INDEPENDENT_CODE ON)
+ generate_export_header(OgreGLSupport 
+     EXPORT_MACRO_NAME _OgreGLExport

--- a/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
+++ b/rviz_ogre_vendor/rviz_ogre_vendor-extras.cmake.in
@@ -23,12 +23,18 @@ message(STATUS "OGRE_PLUGIN_DIR: ${OGRE_PLUGIN_DIR}")
 list(APPEND OGRE_LIBRARIES ${OGRE_PLUGINS})
 list(APPEND OGRE_LIBRARY_DIRS ${OGRE_PLUGIN_DIR})
 
+if(@RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ@)
+    set(LIBRARY_MANGLING_SUFFIX "_rviz")
+else()
+    set(LIBRARY_MANGLING_SUFFIX "")
+endif()
+
 foreach(_lib IN LISTS OGRE_LIBRARIES)
   # Remove debug suffix from library name for matching
   string(REPLACE "_d" "" _lib ${_lib})
 
   if("OgreMainStatic" STREQUAL ${_lib} OR "OgreMain" STREQUAL ${_lib})
-    find_library(_ogre_main_static_library_abs ${_lib}
+    find_library(_ogre_main_static_library_abs ${_lib}${LIBRARY_MANGLING_SUFFIX}
       PATHS
         ${OGRE_LIBRARY_DIRS}
       NO_DEFAULT_PATH
@@ -38,7 +44,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
       NO_CMAKE_SYSTEM_PATH
       NO_CMAKE_FIND_ROOT_PATH
     )
-    find_library(_ogre_main_static_library_debug_abs ${_lib}_d
+    find_library(_ogre_main_static_library_debug_abs ${_lib}${LIBRARY_MANGLING_SUFFIX}_d
       PATHS
         ${OGRE_LIBRARY_DIRS}
       NO_DEFAULT_PATH
@@ -133,7 +139,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
     )
   endif()
   if("OgreOverlayStatic" STREQUAL ${_lib} OR "OgreOverlay" STREQUAL ${_lib})
-    find_library(_ogre_overlay_static_library_abs ${_lib}
+    find_library(_ogre_overlay_static_library_abs ${_lib}${LIBRARY_MANGLING_SUFFIX}
       PATHS
         ${OGRE_LIBRARY_DIRS}
       NO_DEFAULT_PATH
@@ -143,7 +149,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
       NO_CMAKE_SYSTEM_PATH
       NO_CMAKE_FIND_ROOT_PATH
     )
-    find_library(_ogre_overlay_static_library_debug_abs ${_lib}_d
+    find_library(_ogre_overlay_static_library_debug_abs ${_lib}${LIBRARY_MANGLING_SUFFIX}_d
       PATHS
         ${OGRE_LIBRARY_DIRS}
       NO_DEFAULT_PATH
@@ -185,7 +191,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
     )
   endif()
   if("OgreGLSupportStatic" STREQUAL ${_lib} OR "OgreGLSupport" STREQUAL ${_lib})
-    find_library(_ogre_gl_support_static_library_abs ${_lib}
+    find_library(_ogre_gl_support_static_library_abs ${_lib}${LIBRARY_MANGLING_SUFFIX}
       PATHS
         ${OGRE_LIBRARY_DIRS}
       NO_DEFAULT_PATH
@@ -195,7 +201,7 @@ foreach(_lib IN LISTS OGRE_LIBRARIES)
       NO_CMAKE_SYSTEM_PATH
       NO_CMAKE_FIND_ROOT_PATH
     )
-    find_library(_ogre_gl_support_static_library_debug_abs ${_lib}_d
+    find_library(_ogre_gl_support_static_library_debug_abs ${_lib}${LIBRARY_MANGLING_SUFFIX}_d
       PATHS
         ${OGRE_LIBRARY_DIRS}
       NO_DEFAULT_PATH


### PR DESCRIPTION
## Description

This PR adds a `RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ` option to `rviz_ogre_vendor` that by default is `OFF`, and so by default nothing changes. When the option is enabled, it adds a `_rviz` suffix to the OgreMain, OgreOverlay and OgreGLSupport libraries, that are the one used directly by rviz.

This is useful in cases where two different version of ogre are installed, and we need to make sure that RViz loads the vendored one, and not some other version (see https://github.com/RoboStack/ros-jazzy/issues/57).


### Is this user-facing behavior change?

No, by default nothing changes.

### Did you use Generative AI?

No.

### Additional Information

See https://github.com/RoboStack/ros-jazzy/issues/57 .
