### PR TITLE
Remove redundant check

### DIFF
--- a/rviz_common/src/rviz_common/properties/property_tree_model.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_model.cpp
@@ -117,9 +117,6 @@ QModelIndex PropertyTreeModel::parentIndex(const Property * child) const
     return QModelIndex();
   }
   Property * parent = child->getParent();
-  if (parent == root_property_ || !parent) {
-    return QModelIndex();
-  }
   return indexOf(parent);
 }
 


### PR DESCRIPTION
Validity is checked in indexOf() as well.

Related with https://github.com/ros-visualization/rviz/commit/c608239e111215169827d1f3bbace0b97c8e9f06

