### PR TITLE
Add a patch in rviz_ogre_vendor to build with clang on macOS

### DIFF
--- a/rviz_ogre_vendor/patches/0006-macos-char-traits-fix.patch
+++ b/rviz_ogre_vendor/patches/0006-macos-char-traits-fix.patch
@@ -1,0 +1,137 @@
+--- a/Components/Overlay/include/OgreUTFString.h
++++ b/Components/Overlay/include/OgreUTFString.h
+@@ -32,6 +32,100 @@
+ #include <string>
+ #include <stdexcept>
+
++#if (OGRE_PLATFORM == OGRE_PLATFORM_APPLE || OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS) && __clang_major__ >= 15
++#include <string>
++namespace std {
++    template<>
++    struct char_traits<unsigned short>
++    {
++        using char_type = unsigned short;
++        using int_type = unsigned int;
++        using off_type = streamoff;
++        using pos_type = streampos;
++        using state_type = mbstate_t;
++
++        static void assign(char_type& r, const char_type& a) { r = a; }
++        static bool eq(const char_type& a, const char_type& b) { return a == b; }
++        static bool lt(const char_type& a, const char_type& b) { return a < b; }
++
++        static int compare(const char_type* s1, const char_type* s2, size_t n) {
++            for (size_t i = 0; i < n; ++i) {
++                if (lt(s1[i], s2[i])) return -1;
++                if (lt(s2[i], s1[i])) return 1;
++            }
++            return 0;
++        }
++
++        static size_t length(const char_type* s) {
++            size_t i = 0;
++            while (!eq(s[i], char_type())) ++i;
++            return i;
++        }
++
++        static const char_type* find(const char_type* s, size_t n, const char_type& a) {
++            for (size_t i = 0; i < n; ++i) {
++                if (eq(s[i], a)) return s + i;
++            }
++            return nullptr;
++        }
++
++        static char_type* move(char_type* s1, const char_type* s2, size_t n) {
++            return static_cast<char_type*>(memmove(s1, s2, n * sizeof(char_type)));
++        }
++
++        static char_type* copy(char_type* s1, const char_type* s2, size_t n) {
++            return static_cast<char_type*>(memcpy(s1, s2, n * sizeof(char_type)));
++        }
++
++        static char_type* assign(char_type* s, size_t n, char_type a) {
++            for (size_t i = 0; i < n; ++i) {
++                assign(s[i], a);
++            }
++            return s;
++        }
++
++        static int_type not_eof(const int_type& c) {
++            return !eq_int_type(c, eof()) ? c : 0;
++        }
++
++        static char_type to_char_type(const int_type& c) { return static_cast<char_type>(c); }
++        static int_type to_int_type(const char_type& c) { return static_cast<int_type>(c); }
++        static bool eq_int_type(const int_type& c1, const int_type& c2) { return c1 == c2; }
++        static int_type eof() { return static_cast<int_type>(-1); }
++    };
++}
++#endif
++
++#if (OGRE_PLATFORM == OGRE_PLATFORM_APPLE || OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS) && __clang_major__ >= 15
++#include <string>
++namespace std {
++    template<>
++    struct char_traits<unsigned int>
++    {
++        using char_type = unsigned int;
++        using int_type = unsigned int;
++        using off_type = streamoff;
++        using pos_type = streampos;
++        using state_type = mbstate_t;
++
++        static void assign(char_type& r, const char_type& a) { r = a; }
++        static bool eq(const char_type& a, const char_type& b) { return a == b; }
++        static bool lt(const char_type& a, const char_type& b) { return a < b; }
++
++        static int compare(const char_type* s1, const char_type* s2, size_t n) {
++            for (size_t i = 0; i < n; ++i) {
++                if (lt(s1[i], s2[i])) return -1;
++                if (lt(s2[i], s1[i])) return 1;
++            }
++            return 0;
++        }
++
++        static size_t length(const char_type* s) {
++            size_t i = 0;
++            while (!eq(s[i], char_type())) ++i;
++            return i;
++        }
++
++        static const char_type* find(const char_type* s, size_t n, const char_type& a) {
++            for (size_t i = 0; i < n; ++i) {
++                if (eq(s[i], a)) return s + i;
++            }
++            return nullptr;
++        }
++
++        static char_type* move(char_type* s1, const char_type* s2, size_t n) {
++            return static_cast<char_type*>(memmove(s1, s2, n * sizeof(char_type)));
++        }
++
++        static char_type* copy(char_type* s1, const char_type* s2, size_t n) {
++            return static_cast<char_type*>(memcpy(s1, s2, n * sizeof(char_type)));
++        }
++
++        static char_type* assign(char_type* s, size_t n, char_type a) {
++            for (size_t i = 0; i < n; ++i) {
++                assign(s[i], a);
++            }
++            return s;
++        }
++
++        static int_type not_eof(const int_type& c) {
++            return !eq_int_type(c, eof()) ? c : 0;
++        }
++
++        static char_type to_char_type(const int_type& c) { return static_cast<char_type>(c); }
++        static int_type to_int_type(const char_type& c) { return static_cast<int_type>(c); }
++        static bool eq_int_type(const int_type& c1, const int_type& c2) { return c1 == c2; }
++        static int_type eof() { return static_cast<int_type>(-1); }
++    };
++}
++#endif
++
+ // Workaround for VC7/7.1/8.0/9.0 (2003 - 2008):
+ //      when build with /MD or /MDd, VC have both std::basic_string<unsigned short> and
+ // basic_string<__wchar_t> instantiated in msvcprt[d].lib/MSVCP71[D].dll, but the header


### PR DESCRIPTION
## Description
Tried building `rviz_ogre_vendor` and MacOS 15 (Sequoia) with XCode 16.x and build fails as the newer versions of (apple) `clang` on macOS is does not provide default implementations of `std::char_traits` for non-standard character types like unsigned short and unsigned int. 

The PR adds a patch that provides explicit specializations for std::char_traits<unsigned short> and std::char_traits<unsigned int>. It defines all the necessary types and static member functions (like compare, length, copy, assign, etc.) that std::basic_string needs to operate on these character types.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Is this user-facing behavior change?

Yes
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, patch file generated using Gemini Code Assist extension in VSCode.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
