### PR TITLE
fix deprecated #include <ctgmath>

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
@@ -35,7 +35,6 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
-#include <ctgmath>
 #include <memory>
 #include <valarray>
 


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
FIX compile warning:  warning "<ctgmath> is deprecated in C++17, use <complex> or <cmath> instead" 

only the removal of the library <ctgmath> is necessary. It was deprecated in C++17 and <cmath> is already included.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
