### PR TITLE
Deprecates update(float, float) methods and provides update(std::chrono::duration, std::chrono::duration) replacements.

### DIFF
--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -32,6 +32,7 @@
 #ifndef RVIZ_COMMON__DISPLAY_HPP_
 #define RVIZ_COMMON__DISPLAY_HPP_
 
+#include <chrono>
 #include <string>
 
 #include <QIcon>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -151,9 +151,19 @@ public:
 
   /// Called periodically by the visualization manager.
   /**
-   * \param wall_dt Wall-clock time, in seconds, since the last time the update list was run through.
-   * \param ros_dt ROS time, in seconds, since the last time the update list was run through.
+   * \param wall_dt Wall-clock time since the last time the update list was run through.
+   * \param ros_dt ROS time since the last time the update list was run through.
    */
+  virtual
+  void
+  update(std::chrono::duration wall_dt, std::chrono::duration ros_dt);
+
+  /// Called periodically by the visualization manager.
+  /**
+   * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
+   * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
+   */
+  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
   virtual
   void
   update(float wall_dt, float ros_dt);

--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -156,14 +156,14 @@ public:
    */
   virtual
   void
-  update(std::chrono::duration wall_dt, std::chrono::duration ros_dt);
+  update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
 
   /// Called periodically by the visualization manager.
   /**
    * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
    * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
    */
-  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual
   void
   update(float wall_dt, float ros_dt);

--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -32,7 +32,6 @@
 #ifndef RVIZ_COMMON__DISPLAY_HPP_
 #define RVIZ_COMMON__DISPLAY_HPP_
 
-#include <chrono>
 #include <string>
 
 #include <QIcon>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__DISPLAY_GROUP_HPP_
 #define RVIZ_COMMON__DISPLAY_GROUP_HPP_
 
+#include <chrono>
+
 #include <QString>
 
 #include "rviz_common/display.hpp"

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -146,6 +146,10 @@ public:
   virtual DisplayGroup * getGroupAt(int index) const;
 
   /// Call update() on all child Displays.
+  void update(std::chrono::duration wall_dt, std::chrono::duration ros_dt) override;
+
+  /// Call update() on all child Displays.
+  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
   void update(float wall_dt, float ros_dt) override;
 
   /// Reset this and all child Displays.

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -146,10 +146,10 @@ public:
   virtual DisplayGroup * getGroupAt(int index) const;
 
   /// Call update() on all child Displays.
-  void update(std::chrono::duration wall_dt, std::chrono::duration ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   /// Call update() on all child Displays.
-  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   void update(float wall_dt, float ros_dt) override;
 
   /// Reset this and all child Displays.

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -32,8 +32,6 @@
 #ifndef RVIZ_COMMON__DISPLAY_GROUP_HPP_
 #define RVIZ_COMMON__DISPLAY_GROUP_HPP_
 
-#include <chrono>
-
 #include <QString>
 
 #include "rviz_common/display.hpp"

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -102,6 +102,18 @@ public:
   virtual void deactivate() = 0;
 
   /// Called periodically, typically at 30Hz.
+  /**
+   * \param wall_dt Wall-clock time since the last time the update list was run through.
+   * \param ros_dt ROS time since the last time the update list was run through.
+   */
+  virtual void update(std::chrono::duration wall_dt, std::chrono::duration ros_dt);
+
+  /// Called periodically, typically at 30Hz.
+  /**
+   * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
+   * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
+   */
+  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
   virtual void update(float wall_dt, float ros_dt);
 
   enum

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -32,6 +32,8 @@
 #ifndef RVIZ_COMMON__TOOL_HPP_
 #define RVIZ_COMMON__TOOL_HPP_
 
+#include <chrono>
+
 #include <QCursor>
 #include <QIcon>
 #include <QObject>

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -106,14 +106,14 @@ public:
    * \param wall_dt Wall-clock time since the last time the update list was run through.
    * \param ros_dt ROS time since the last time the update list was run through.
    */
-  virtual void update(std::chrono::duration wall_dt, std::chrono::duration ros_dt);
+  virtual void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
 
   /// Called periodically, typically at 30Hz.
   /**
    * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
    * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
    */
-  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual void update(float wall_dt, float ros_dt);
 
   enum

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -32,8 +32,6 @@
 #ifndef RVIZ_COMMON__TOOL_HPP_
 #define RVIZ_COMMON__TOOL_HPP_
 
-#include <chrono>
-
 #include <QCursor>
 #include <QIcon>
 #include <QObject>

--- a/rviz_common/include/rviz_common/view_controller.hpp
+++ b/rviz_common/include/rviz_common/view_controller.hpp
@@ -127,6 +127,13 @@ public:
   /**
    * Override with code that needs to run repeatedly.
    */
+  virtual void update(std::chrono::duration dt, std::chrono::duration ros_dt);
+
+  /// Called at 30Hz by ViewManager::update() while this view is active.
+  /**
+   * Override with code that needs to run repeatedly.
+   */
+  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
   virtual void update(float dt, float ros_dt);
 
   /// Called when mouse events are fired.

--- a/rviz_common/include/rviz_common/view_controller.hpp
+++ b/rviz_common/include/rviz_common/view_controller.hpp
@@ -32,6 +32,7 @@
 #ifndef RVIZ_COMMON__VIEW_CONTROLLER_HPP_
 #define RVIZ_COMMON__VIEW_CONTROLLER_HPP_
 
+#include <chrono>
 #include <string>
 #include <memory>
 

--- a/rviz_common/include/rviz_common/view_controller.hpp
+++ b/rviz_common/include/rviz_common/view_controller.hpp
@@ -127,13 +127,13 @@ public:
   /**
    * Override with code that needs to run repeatedly.
    */
-  virtual void update(std::chrono::duration dt, std::chrono::duration ros_dt);
+  virtual void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt);
 
   /// Called at 30Hz by ViewManager::update() while this view is active.
   /**
    * Override with code that needs to run repeatedly.
    */
-  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual void update(float dt, float ros_dt);
 
   /// Called when mouse events are fired.

--- a/rviz_common/include/rviz_common/view_controller.hpp
+++ b/rviz_common/include/rviz_common/view_controller.hpp
@@ -32,7 +32,6 @@
 #ifndef RVIZ_COMMON__VIEW_CONTROLLER_HPP_
 #define RVIZ_COMMON__VIEW_CONTROLLER_HPP_
 
-#include <chrono>
 #include <string>
 #include <memory>
 

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -71,6 +71,8 @@ public:
 
   void initialize();
 
+  void update(std::chrono::duration wall_dt, std::chrono::duration ros_dt);
+  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
   void update(float wall_dt, float ros_dt);
 
   /// Return the current ViewController in use for the main RenderWindow.

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -33,6 +33,7 @@
 #define RVIZ_COMMON__VIEW_MANAGER_HPP_
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
 
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -72,6 +72,7 @@ public:
   void initialize();
 
   void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+
   [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   void update(float wall_dt, float ros_dt);
 

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -71,8 +71,8 @@ public:
 
   void initialize();
 
-  void update(std::chrono::duration wall_dt, std::chrono::duration ros_dt);
-  [[deprecated("Use update(std::chrono::duration, std::chrono::duration)")]]
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   void update(float wall_dt, float ros_dt);
 
   /// Return the current ViewController in use for the main RenderWindow.

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -33,7 +33,6 @@
 #define RVIZ_COMMON__VIEW_MANAGER_HPP_
 
 #include <algorithm>
-#include <chrono>
 #include <memory>
 
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -372,8 +372,8 @@ protected:
 
   rviz_common::properties::ColorProperty * background_color_property_;
 
-  float time_update_timer_;
-  float frame_update_timer_;
+  std::chrono::nanoseconds time_update_timer_;
+  std::chrono::nanoseconds frame_update_timer_;
 
   std::shared_ptr<rviz_common::interaction::HandlerManagerIface> handler_manager_;
   std::shared_ptr<rviz_common::interaction::SelectionManagerIface> selection_manager_;

--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -32,7 +32,6 @@
 #ifndef RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 #define RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 
-#include <chrono>
 #include <deque>
 #include <memory>
 

--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -183,6 +183,12 @@ void Display::setTopic(const QString & topic, const QString & datatype)
   (void) datatype;
 }
 
+void Display::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
+{
+  update(std::chrono::duration_cast<std::chrono::nanoseconds>(wall_dt).count(),
+         std::chrono::duration_cast<std::chrono::nanoseconds>(ros_dt).count());
+}
+
 void Display::update(float wall_dt, float ros_dt)
 {
   (void) wall_dt;

--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -183,10 +183,10 @@ void Display::setTopic(const QString & topic, const QString & datatype)
   (void) datatype;
 }
 
-void Display::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
+void Display::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
-  update(std::chrono::duration_cast<std::chrono::nanoseconds>(wall_dt).count(),
-         std::chrono::duration_cast<std::chrono::nanoseconds>(ros_dt).count());
+  update(wall_dt.count(),
+         ros_dt.count());
 }
 
 void Display::update(float wall_dt, float ros_dt)

--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -185,8 +185,7 @@ void Display::setTopic(const QString & topic, const QString & datatype)
 
 void Display::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
-  update(wall_dt.count(),
-         ros_dt.count());
+  update(wall_dt.count(), ros_dt.count());
 }
 
 void Display::update(float wall_dt, float ros_dt)

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -237,13 +237,7 @@ void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosec
 
 void DisplayGroup::update(float wall_dt, float ros_dt)
 {
-  int num_children = displays_.size();
-  for (int i = 0; i < num_children; i++) {
-    Display * display = displays_.at(i);
-    if (display->isEnabled() ) {
-      display->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
-    }
-  }
+  this->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
 }
 
 void DisplayGroup::reset()

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -224,7 +224,7 @@ void DisplayGroup::fixedFrameChanged()
   }
 }
 
-void DisplayGroup::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
+void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   int num_children = displays_.size();
   for (int i = 0; i < num_children; i++) {

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -237,7 +237,7 @@ void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosec
 
 void DisplayGroup::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
+  this->update(std::chrono::nanoseconds(std::round(wall_dt)), std::chrono::nanoseconds(std::round(ros_dt)));
 }
 
 void DisplayGroup::reset()

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -224,13 +224,24 @@ void DisplayGroup::fixedFrameChanged()
   }
 }
 
-void DisplayGroup::update(float wall_dt, float ros_dt)
+void DisplayGroup::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
 {
   int num_children = displays_.size();
   for (int i = 0; i < num_children; i++) {
     Display * display = displays_.at(i);
     if (display->isEnabled() ) {
       display->update(wall_dt, ros_dt);
+    }
+  }
+}
+
+void DisplayGroup::update(float wall_dt, float ros_dt)
+{
+  int num_children = displays_.size();
+  for (int i = 0; i < num_children; i++) {
+    Display * display = displays_.at(i);
+    if (display->isEnabled() ) {
+      display->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
     }
   }
 }

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -237,7 +237,8 @@ void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosec
 
 void DisplayGroup::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(std::round(wall_dt)), std::chrono::nanoseconds(std::round(ros_dt)));
+  this->update(std::chrono::nanoseconds(static_cast<int>(std::round(wall_dt))), 
+               std::chrono::nanoseconds(static_cast<int>(std::round(ros_dt))));
 }
 
 void DisplayGroup::reset()

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -237,8 +237,8 @@ void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosec
 
 void DisplayGroup::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(static_cast<int>(std::round(wall_dt))), 
-               std::chrono::nanoseconds(static_cast<int>(std::round(ros_dt))));
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)), 
+               std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 
 void DisplayGroup::reset()

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -237,7 +237,7 @@ void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosec
 
 void DisplayGroup::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(std::lround(wall_dt)), 
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)),
                std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 

--- a/rviz_common/src/rviz_common/tool.cpp
+++ b/rviz_common/src/rviz_common/tool.cpp
@@ -79,10 +79,10 @@ bool Tool::accessAllKeys() const
   return access_all_keys_;
 }
 
-void Tool::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
+void Tool::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
-  update(std::chrono::duration_cast<std::chrono::nanoseconds>(wall_dt).count(),
-         std::chrono::duration_cast<std::chrono::nanoseconds>(ros_dt).count());
+  update(wall_dt.count(),
+         ros_dt.count());
 }
 
 void Tool::update(float wall_dt, float ros_dt)

--- a/rviz_common/src/rviz_common/tool.cpp
+++ b/rviz_common/src/rviz_common/tool.cpp
@@ -81,8 +81,7 @@ bool Tool::accessAllKeys() const
 
 void Tool::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
-  update(wall_dt.count(),
-         ros_dt.count());
+  update(wall_dt.count(), ros_dt.count());
 }
 
 void Tool::update(float wall_dt, float ros_dt)

--- a/rviz_common/src/rviz_common/tool.cpp
+++ b/rviz_common/src/rviz_common/tool.cpp
@@ -79,6 +79,12 @@ bool Tool::accessAllKeys() const
   return access_all_keys_;
 }
 
+void Tool::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
+{
+  update(std::chrono::duration_cast<std::chrono::nanoseconds>(wall_dt).count(),
+         std::chrono::duration_cast<std::chrono::nanoseconds>(ros_dt).count());
+}
+
 void Tool::update(float wall_dt, float ros_dt)
 {
   (void) wall_dt;

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -194,8 +194,7 @@ void ViewController::activate()
 
 void ViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
-  update(dt.count(),
-         ros_dt.count());
+  update(dt.count(), ros_dt.count());
 }
 
 void ViewController::update(float dt, float ros_dt)

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -192,6 +192,12 @@ void ViewController::activate()
   onActivate();
 }
 
+void ViewController::update(std::chrono::duration dt, std::chrono::duration ros_dt)
+{
+  update(std::chrono::duration_cast<std::chrono::nanoseconds>(dt).count(),
+         std::chrono::duration_cast<std::chrono::nanoseconds>(ros_dt).count());
+}
+
 void ViewController::update(float dt, float ros_dt)
 {
   (void) dt;

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -192,10 +192,10 @@ void ViewController::activate()
   onActivate();
 }
 
-void ViewController::update(std::chrono::duration dt, std::chrono::duration ros_dt)
+void ViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
-  update(std::chrono::duration_cast<std::chrono::nanoseconds>(dt).count(),
-         std::chrono::duration_cast<std::chrono::nanoseconds>(ros_dt).count());
+  update(dt.count(),
+         ros_dt.count());
 }
 
 void ViewController::update(float dt, float ros_dt)

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -96,9 +96,7 @@ void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseco
 
 void ViewManager::update(float wall_dt, float ros_dt)
 {
-  if (getCurrent()) {
-    getCurrent()->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
-  }
+  this->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
 }
 
 ViewController * ViewManager::create(const QString & class_id)

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -96,7 +96,8 @@ void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseco
 
 void ViewManager::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(std::round(wall_dt)), std::chrono::nanoseconds(std::round(ros_dt)));
+  this->update(std::chrono::nanoseconds(static_cast<int>(std::round(wall_dt))), 
+               std::chrono::nanoseconds(static_cast<int>(std::round(ros_dt))));
 }
 
 ViewController * ViewManager::create(const QString & class_id)

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -87,10 +87,17 @@ void ViewManager::initialize()
   setCurrent(create("rviz_default_plugins/Orbit"), false);
 }
 
-void ViewManager::update(float wall_dt, float ros_dt)
+void ViewManager::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
 {
   if (getCurrent()) {
     getCurrent()->update(wall_dt, ros_dt);
+  }
+}
+
+void ViewManager::update(float wall_dt, float ros_dt)
+{
+  if (getCurrent()) {
+    getCurrent()->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
   }
 }
 

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -87,7 +87,7 @@ void ViewManager::initialize()
   setCurrent(create("rviz_default_plugins/Orbit"), false);
 }
 
-void ViewManager::update(std::chrono::duration wall_dt, std::chrono::duration ros_dt)
+void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   if (getCurrent()) {
     getCurrent()->update(wall_dt, ros_dt);

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -96,7 +96,7 @@ void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseco
 
 void ViewManager::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(wall_dt), std::chrono::nanoseconds(ros_dt));
+  this->update(std::chrono::nanoseconds(std::round(wall_dt)), std::chrono::nanoseconds(std::round(ros_dt)));
 }
 
 ViewController * ViewManager::create(const QString & class_id)

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -96,7 +96,7 @@ void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseco
 
 void ViewManager::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(std::lround(wall_dt)), 
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)),
                std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -96,8 +96,8 @@ void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseco
 
 void ViewManager::update(float wall_dt, float ros_dt)
 {
-  this->update(std::chrono::nanoseconds(static_cast<int>(std::round(wall_dt))), 
-               std::chrono::nanoseconds(static_cast<int>(std::round(ros_dt))));
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)), 
+               std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 
 ViewController * ViewManager::create(const QString & class_id)

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -340,11 +340,11 @@ void VisualizationManager::onUpdate()
   const auto wall_diff = wall_now - last_update_wall_time_;
   const auto wall_dt = std::chrono::duration_cast<std::chrono::nanoseconds>(wall_diff);
   const auto ros_now = clock_->now();
-  const auto ros_dt = std::chrono::nanoseconds(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds());
+  const auto ros_dt = std::chrono::nanoseconds(std::round(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds()));
   last_update_ros_time_ = ros_now;
   last_update_wall_time_ = wall_now;
 
-  if (ros_dt < std::chrono::nanoseconds(0.0)) {
+  if (ros_dt < std::chrono::nanoseconds(0)) {
     resetTime();
   }
 
@@ -362,15 +362,15 @@ void VisualizationManager::onUpdate()
 
   time_update_timer_ += wall_dt;
 
-  if (time_update_timer_ > std::chrono::nanoseconds(0.1f)) {
-    time_update_timer_ = std::chrono::nanoseconds(0.0f);
+  if (time_update_timer_ > std::chrono::nanoseconds(0)) {
+    time_update_timer_ = std::chrono::nanoseconds(0);
     updateTime();
   }
 
   frame_update_timer_ += wall_dt;
 
-  if (frame_update_timer_ > std::chrono::nanoseconds(1.0f)) {
-    frame_update_timer_ = std::chrono::nanoseconds(0.0f);
+  if (frame_update_timer_ > std::chrono::nanoseconds(1)) {
+    frame_update_timer_ = std::chrono::nanoseconds(0);
     updateFrames();
   }
 

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -338,13 +338,13 @@ void VisualizationManager::onUpdate()
 {
   const auto wall_now = std::chrono::system_clock::now();
   const auto wall_diff = wall_now - last_update_wall_time_;
-  const uint64_t wall_dt = std::chrono::duration_cast<std::chrono::nanoseconds>(wall_diff).count();
+  const auto wall_dt = std::chrono::duration_cast<std::chrono::nanoseconds>(wall_diff);
   const auto ros_now = clock_->now();
-  const uint64_t ros_dt = ros_now.nanoseconds() - last_update_ros_time_.nanoseconds();
+  const auto ros_dt = std::chrono::nanoseconds(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds());
   last_update_ros_time_ = ros_now;
   last_update_wall_time_ = wall_now;
 
-  if (ros_dt < 0.0) {
+  if (ros_dt < std::chrono::nanoseconds(0.0)) {
     resetTime();
   }
 
@@ -362,15 +362,15 @@ void VisualizationManager::onUpdate()
 
   time_update_timer_ += wall_dt;
 
-  if (time_update_timer_ > 0.1f) {
-    time_update_timer_ = 0.0f;
+  if (time_update_timer_ > std::chrono::nanoseconds(0.1f)) {
+    time_update_timer_ = std::chrono::nanoseconds(0.0f);
     updateTime();
   }
 
   frame_update_timer_ += wall_dt;
 
-  if (frame_update_timer_ > 1.0f) {
-    frame_update_timer_ = 0.0f;
+  if (frame_update_timer_ > std::chrono::nanoseconds(1.0f)) {
+    frame_update_timer_ = std::chrono::nanoseconds(0.0f);
     updateFrames();
   }
 

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -140,8 +140,8 @@ VisualizationManager::VisualizationManager(
   render_panel_(render_panel),
   wall_clock_elapsed_(0),
   ros_time_elapsed_(0),
-  time_update_timer_(0.0f),
-  frame_update_timer_(0.0f),
+  time_update_timer_(0),
+  frame_update_timer_(0),
   render_requested_(1),
   frame_count_(0),
   window_manager_(wm),
@@ -336,11 +336,13 @@ BitAllocator * VisualizationManager::visibilityBits()
 
 void VisualizationManager::onUpdate()
 {
-  const auto wall_now = std::chrono::system_clock::now();
-  const auto wall_diff = wall_now - last_update_wall_time_;
-  const auto wall_dt = std::chrono::duration_cast<std::chrono::nanoseconds>(wall_diff);
+  const std::chrono::time_point<std::chrono::system_clock> wall_now = 
+    std::chrono::system_clock::now();
+  const std::chrono::nanoseconds wall_dt = 
+    std::chrono::duration_cast<std::chrono::nanoseconds> (wall_now - last_update_wall_time_);
   const auto ros_now = clock_->now();
-  const auto ros_dt = std::chrono::nanoseconds(std::round(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds()));
+  const auto ros_dt = std::chrono::nanoseconds(
+      static_cast<int>(std::round(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds())));
   last_update_ros_time_ = ros_now;
   last_update_wall_time_ = wall_now;
 
@@ -390,7 +392,7 @@ void VisualizationManager::onUpdate()
   }
 
   frame_count_++;
-  if (render_requested_ || wall_diff > std::chrono::milliseconds(10)) {
+  if (render_requested_ || wall_dt > std::chrono::milliseconds(10)) {
     render_requested_ = 0;
     std::lock_guard<std::mutex> lock(private_->render_mutex_);
     ogre_root_->renderOneFrame();

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -336,9 +336,9 @@ BitAllocator * VisualizationManager::visibilityBits()
 
 void VisualizationManager::onUpdate()
 {
-  const std::chrono::time_point<std::chrono::system_clock> wall_now = 
+  const std::chrono::time_point<std::chrono::system_clock> wall_now =
     std::chrono::system_clock::now();
-  const std::chrono::nanoseconds wall_dt = 
+  const std::chrono::nanoseconds wall_dt =
     std::chrono::duration_cast<std::chrono::nanoseconds> (wall_now - last_update_wall_time_);
   const auto ros_now = clock_->now();
   const auto ros_dt = std::chrono::nanoseconds(

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -339,7 +339,7 @@ void VisualizationManager::onUpdate()
   const std::chrono::time_point<std::chrono::system_clock> wall_now =
     std::chrono::system_clock::now();
   const std::chrono::nanoseconds wall_dt =
-    std::chrono::duration_cast<std::chrono::nanoseconds> (wall_now - last_update_wall_time_);
+    std::chrono::duration_cast<std::chrono::nanoseconds>(wall_now - last_update_wall_time_);
   const auto ros_now = clock_->now();
   const auto ros_dt = std::chrono::nanoseconds(
       std::lround(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds()));

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -342,7 +342,7 @@ void VisualizationManager::onUpdate()
     std::chrono::duration_cast<std::chrono::nanoseconds> (wall_now - last_update_wall_time_);
   const auto ros_now = clock_->now();
   const auto ros_dt = std::chrono::nanoseconds(
-      static_cast<int>(std::round(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds())));
+      std::lround(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds()));
   last_update_ros_time_ = ros_now;
   last_update_wall_time_ = wall_now;
 


### PR DESCRIPTION

## Description

As detailed in #1322, when rviz was updated from ros1 to ros2, the units used in `update(wall_dt, ros_dt)` calls were changed from seconds to nanoseconds. This change was not documented, and a lot of downstream classes (including in this repository) were not updated.

This PR attempts to begin rectifying the situation, without introducing breaking changes, by following the ideas listed in #1322. This PR deprecates the `update(float, float)` method, and introduces an `update(std::chrono::duration, std::chrono::duration)` replacement.

 - Fixes #1322 

### Is this user-facing behavior change?

Not unless users treat deprecation warnings as errors.

### Did you use Generative AI?

No

### Additional Information

Can this PR be back-ported to Jazzy and Humble when merged?
