### PR TITLE
Overcome 16384 texture size limit for displaying maps

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -429,6 +429,12 @@ void MapDisplay::createSwatches()
         width << " x " << height << " using " << number_swatches << " swatches");
     swatches_.clear();
     try {
+      // OpenGL size limit is 16384x16384
+      // TODO(Guillaume): find a cleaner way and autodetect size limit
+      if (swatch_width > 16384 || swatch_height > 16384) {
+        doubleSwatchNumber(swatch_width, swatch_height, number_swatches);
+        continue;
+      }
       tryCreateSwatches(width, height, resolution, swatch_width, swatch_height, number_swatches);
       updateDrawUnder();
       return;


### PR DESCRIPTION
## Description

(Draft to collect ideas)

When trying to display a map (OccupancyGrid) with an edge greater than 16384, the map displayed is empty.
It seems that the texture rendering fails silently. That specific limit is the OpenGL texture size limit on my machine.
This draft PR fixes it by doubling the Swatch number in that case.
Potential better/proper fix would be to query the system texture size limit.
Any ideas on how to best do that (and multi-platform/arch)?

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

Tested the limit (and the fix) on multiple 13th Gen x86 intel CPU / iGPU. Potentially this limit is different for other platforms.
