### PR TITLE
added option to change filemode

### DIFF
--- a/rviz_common/include/rviz_common/properties/file_picker_property.hpp
+++ b/rviz_common/include/rviz_common/properties/file_picker_property.hpp
@@ -31,12 +31,11 @@
 #ifndef RVIZ_COMMON__PROPERTIES__FILE_PICKER_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__FILE_PICKER_PROPERTY_HPP_
 
+#include <QFileDialog>
 #include <QString>
 
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"
-
-#include <QFileDialog>
 
 namespace rviz_common
 {

--- a/rviz_common/include/rviz_common/properties/file_picker_property.hpp
+++ b/rviz_common/include/rviz_common/properties/file_picker_property.hpp
@@ -32,7 +32,10 @@
 #define RVIZ_COMMON__PROPERTIES__FILE_PICKER_PROPERTY_HPP_
 
 #include <QFileDialog>
+#include <QObject>
 #include <QString>
+#include <QStyleOptionViewItem>
+#include <QWidget>
 
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"

--- a/rviz_common/include/rviz_common/properties/file_picker_property.hpp
+++ b/rviz_common/include/rviz_common/properties/file_picker_property.hpp
@@ -36,6 +36,8 @@
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"
 
+#include <QFileDialog>
+
 namespace rviz_common
 {
 namespace properties
@@ -49,9 +51,13 @@ public:
     const QString & description = QString(),
     Property * parent = nullptr,
     const char * changed_slot = nullptr,
-    QObject * receiver = nullptr);
+    QObject * receiver = nullptr,
+    QFileDialog::FileMode mode = QFileDialog::AnyFile);
 
   QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option) override;
+
+private:
+  QFileDialog::FileMode mode_;
 };
 
 }  // namespace properties

--- a/rviz_common/src/rviz_common/properties/file_picker.cpp
+++ b/rviz_common/src/rviz_common/properties/file_picker.cpp
@@ -32,6 +32,7 @@
 
 #include <QFileDialog>
 #include <QString>
+#include <QWidget>
 
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/properties/file_picker.cpp
+++ b/rviz_common/src/rviz_common/properties/file_picker.cpp
@@ -41,14 +41,17 @@ namespace properties
 
 FilePicker::FilePicker(
   StringProperty * file_name_property,
-  QWidget * parent)
+  QWidget * parent,
+  QFileDialog::FileMode mode)
 : LineEditWithButton(parent),
-  file_name_property_(file_name_property)
+  file_name_property_(file_name_property),
+  mode_(mode)
 {}
 
 void FilePicker::onButtonClick()
 {
   auto dialog = new QFileDialog(parentWidget());
+  dialog->setFileMode(mode_);
 
   connect(
     dialog, SIGNAL(fileSelected(const QString&)),

--- a/rviz_common/src/rviz_common/properties/file_picker.hpp
+++ b/rviz_common/src/rviz_common/properties/file_picker.hpp
@@ -32,6 +32,7 @@
 #define RVIZ_COMMON__PROPERTIES__FILE_PICKER_HPP_
 
 #include <QFileDialog>
+#include <QWidget>
 
 #include "rviz_common/properties/line_edit_with_button.hpp"
 #include "rviz_common/properties/string_property.hpp"

--- a/rviz_common/src/rviz_common/properties/file_picker.hpp
+++ b/rviz_common/src/rviz_common/properties/file_picker.hpp
@@ -35,6 +35,8 @@
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"
 
+#include <QFileDialog>
+
 namespace rviz_common
 {
 namespace properties
@@ -45,13 +47,15 @@ class FilePicker : public LineEditWithButton
 public:
   explicit FilePicker(
     StringProperty * file_name_property = nullptr,
-    QWidget * parent = nullptr);
+    QWidget * parent = nullptr,
+    QFileDialog::FileMode mode = QFileDialog::AnyFile);
 
 protected:
   void onButtonClick() override;
 
 private:
   StringProperty * file_name_property_;
+  QFileDialog::FileMode mode_;
 };
 
 }  // namespace properties

--- a/rviz_common/src/rviz_common/properties/file_picker.hpp
+++ b/rviz_common/src/rviz_common/properties/file_picker.hpp
@@ -31,11 +31,11 @@
 #ifndef RVIZ_COMMON__PROPERTIES__FILE_PICKER_HPP_
 #define RVIZ_COMMON__PROPERTIES__FILE_PICKER_HPP_
 
+#include <QFileDialog>
+
 #include "rviz_common/properties/line_edit_with_button.hpp"
 #include "rviz_common/properties/string_property.hpp"
 #include "rviz_common/visibility_control.hpp"
-
-#include <QFileDialog>
 
 namespace rviz_common
 {

--- a/rviz_common/src/rviz_common/properties/file_picker_property.cpp
+++ b/rviz_common/src/rviz_common/properties/file_picker_property.cpp
@@ -30,7 +30,11 @@
 
 #include "rviz_common/properties/file_picker_property.hpp"
 
+#include <QFileDialog>
+#include <QObject>
 #include <QString>
+#include <QStyleOptionViewItem>
+#include <QWidget>
 
 #include "file_picker.hpp"
 

--- a/rviz_common/src/rviz_common/properties/file_picker_property.cpp
+++ b/rviz_common/src/rviz_common/properties/file_picker_property.cpp
@@ -45,14 +45,15 @@ FilePickerProperty::FilePickerProperty(
   const QString & description,
   Property * parent,
   const char * changed_slot,
-  QObject * receiver)
-: StringProperty(name, default_value, description, parent, changed_slot, receiver)
+  QObject * receiver,
+  QFileDialog::FileMode mode)
+: StringProperty(name, default_value, description, parent, changed_slot, receiver), mode_(mode)
 {}
 
 QWidget * FilePickerProperty::createEditor(QWidget * parent, const QStyleOptionViewItem & option)
 {
   (void) option;
-  auto file_picker = new FilePicker(this, parent);
+  auto file_picker = new FilePicker(this, parent, mode_);
   file_picker->setFrame(false);
   return file_picker;
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1528 

I apologize it took this long. I was busy this couple of weeks and had finally got the time to work on this.
I'm not sure if I set the correct branch but I wanted this feature on ROS2 jazzy hence I set the branch to jazzy (please correct me I'm mistaken).

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

~~Added the option to set the file mode for `rviz_common::properties::FilePickerProperty`. User can set the file mode as documented [here](https://doc.qt.io/archives/qt-5.15/qfiledialog.html#FileMode-enum). By default, the file mode is `QFileDialog::AnyFile` this change probably does not break anything.~~ 

https://github.com/ros2/rviz/pull/1537#pullrequestreview-3127665862

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
no

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
none