### PR TITLE
add resourceExists check to loadEmbeddedTexture before loading texture

### DIFF
--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -375,6 +375,7 @@ void AssimpLoader::setLightColorsFromAssimp(
 void AssimpLoader::loadEmbeddedTexture(
   const aiTexture * texture, const std::string & resource_path)
 {
+  // Check for an already existing texture before proceeding to load it
   if (!Ogre::TextureManager::getSingleton().resourceExists(resource_path, ROS_PACKAGE_NAME)) {
     if (texture == nullptr) {
       RVIZ_RENDERING_LOG_ERROR_STREAM("null texture!");

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -375,7 +375,8 @@ void AssimpLoader::setLightColorsFromAssimp(
 void AssimpLoader::loadEmbeddedTexture(
   const aiTexture * texture, const std::string & resource_path)
 {
-  // Check for an already existing texture before proceeding to load it
+  // Check if the embedded texture already exists within TextureManager before proceeding to
+  // load it.
   if (!Ogre::TextureManager::getSingleton().resourceExists(resource_path, ROS_PACKAGE_NAME)) {
     if (texture == nullptr) {
       RVIZ_RENDERING_LOG_ERROR_STREAM("null texture!");

--- a/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
+++ b/rviz_rendering/src/rviz_rendering/mesh_loader_helpers/assimp_loader.cpp
@@ -375,29 +375,31 @@ void AssimpLoader::setLightColorsFromAssimp(
 void AssimpLoader::loadEmbeddedTexture(
   const aiTexture * texture, const std::string & resource_path)
 {
-  if (texture == nullptr) {
-    RVIZ_RENDERING_LOG_ERROR_STREAM("null texture!");
-    return;
-  }
+  if (!Ogre::TextureManager::getSingleton().resourceExists(resource_path, ROS_PACKAGE_NAME)) {
+    if (texture == nullptr) {
+      RVIZ_RENDERING_LOG_ERROR_STREAM("null texture!");
+      return;
+    }
 
-  // use the format hint to try to load the image
-  std::string format_hint(
-    texture->achFormatHint,
-    strnlen(texture->achFormatHint, sizeof(texture->achFormatHint)));
+    // use the format hint to try to load the image
+    std::string format_hint(
+      texture->achFormatHint,
+      strnlen(texture->achFormatHint, sizeof(texture->achFormatHint)));
 
-  Ogre::DataStreamPtr stream(
-    new Ogre::MemoryDataStream(
-      (unsigned char *)texture->pcData, texture->mWidth));
+    Ogre::DataStreamPtr stream(
+      new Ogre::MemoryDataStream(
+        (unsigned char *)texture->pcData, texture->mWidth));
 
-  try {
-    Ogre::Image image;
-    image.load(stream, format_hint.c_str());
-    Ogre::TextureManager::getSingleton().loadImage(
-      resource_path, ROS_PACKAGE_NAME, image);
-  } catch (Ogre::Exception & e) {
-    RVIZ_RENDERING_LOG_ERROR_STREAM(
-      "Could not load texture [" << resource_path.c_str() <<
-        "] with format hint [" << format_hint << "]: " << e.what());
+    try {
+      Ogre::Image image;
+      image.load(stream, format_hint.c_str());
+      Ogre::TextureManager::getSingleton().loadImage(
+        resource_path, ROS_PACKAGE_NAME, image);
+    } catch (Ogre::Exception & e) {
+      RVIZ_RENDERING_LOG_ERROR_STREAM(
+        "Could not load texture [" << resource_path.c_str() <<
+          "] with format hint [" << format_hint << "]: " << e.what());
+    }
   }
 }
 


### PR DESCRIPTION
## Description

This PR is identical to #1539 which targets the `jazzy` branch. This PR targets the `rolling` branch given that both branches face the same issue #1538.

This PR addresses an issue when loading embedded textures, where an exception is thrown from loading an already existing OGRE texture from a .glb file as described in issue #1538.

This issue presents itself when publishing multiple identical visualization_msgs::msg::Marker messages referring to the same mesh_resource and with the mesh_use_embedded_materials set to TRUE, resulting in the following exception within RVIZ:
```
[rviz2-20] [ERROR] [1753857423.783175640] [rviz2]: Could not load texture [<MESH_RESOURCE>.glb*0] with format hint [png]: ItemIdentityException: Texture with the name <MESH_RESOURCE>..glb*0 already exists. in ResourceManager::add at ./.obj-x86_64-linux-gnu/ogre_vendor-prefix/src/ogre_vendor/OgreMain/src/OgreResourceManager.cpp (line 148)
```

Fixes #1538 

### Is this user-facing behavior change?

Yes, this prevents the printing of the exception mentioned above and potentially fixes issues associated with loading embedded textures.

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
