### PR TITLE
Fix QoS profile loading for InitialPoseTool from rviz config files

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/pose_estimate/initial_pose_tool.cpp
@@ -77,7 +77,10 @@ void InitialPoseTool::onInitialize()
 {
   PoseTool::onInitialize();
   qos_profile_property_->initialize(
-    [this](rclcpp::QoS profile) {this->qos_profile_ = profile;});
+    [this](rclcpp::QoS profile) {
+      this->qos_profile_ = profile;
+      updateTopic();
+    });
   setName("2D Pose Estimate");
   updateTopic();
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Previously, when a .rviz configuration specified QoS settings like Durability Policy: Transient Local for the SetInitialPose tool, the publisher was created with default QoS settings (Volatile durability) instead of the configured values. This happened because the publisher was created during tool initialization before QoS settings were loaded from the configuration file.

The fix ensures that the publisher is recreated whenever QoS settings are updated by calling updateTopic() in the QoS profile change callback.

Fixes #1543 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes. Users can now properly configure QoS settings for the SetInitialPose tool through .rviz configuration files. Previously specified QoS settings (particularly Durability Policy) will now be correctly applied to the published topics.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes, GitHub Copilot was used to assist with 
- debugging
- code modification
- PR description

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

Although I only tested on the Humble branch, I think the same issue will occur on rolling because the implementation of the initial_pose_tool is the same for both.