### PR TITLE
Backport kilted/use chrono durations in update methods

### DIFF
--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -151,9 +151,19 @@ public:
 
   /// Called periodically by the visualization manager.
   /**
-   * \param wall_dt Wall-clock time, in seconds, since the last time the update list was run through.
-   * \param ros_dt ROS time, in seconds, since the last time the update list was run through.
+   * \param wall_dt Wall-clock time since the last time the update list was run through.
+   * \param ros_dt ROS time since the last time the update list was run through.
    */
+  virtual
+  void
+  update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+
+  /// Called periodically by the visualization manager.
+  /**
+   * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
+   * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
+   */
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual
   void
   update(float wall_dt, float ros_dt);

--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -163,7 +163,6 @@ public:
    * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
    * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
    */
-  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual
   void
   update(float wall_dt, float ros_dt);

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -146,6 +146,10 @@ public:
   virtual DisplayGroup * getGroupAt(int index) const;
 
   /// Call update() on all child Displays.
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
+
+  /// Call update() on all child Displays.
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   void update(float wall_dt, float ros_dt) override;
 
   /// Reset this and all child Displays.

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -149,7 +149,6 @@ public:
   void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   /// Call update() on all child Displays.
-  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   void update(float wall_dt, float ros_dt) override;
 
   /// Reset this and all child Displays.

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -102,6 +102,18 @@ public:
   virtual void deactivate() = 0;
 
   /// Called periodically, typically at 30Hz.
+  /**
+   * \param wall_dt Wall-clock time since the last time the update list was run through.
+   * \param ros_dt ROS time since the last time the update list was run through.
+   */
+  virtual void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+
+  /// Called periodically, typically at 30Hz.
+  /**
+   * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
+   * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
+   */
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual void update(float wall_dt, float ros_dt);
 
   enum

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -113,7 +113,6 @@ public:
    * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
    * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
    */
-  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual void update(float wall_dt, float ros_dt);
 
   enum

--- a/rviz_common/include/rviz_common/view_controller.hpp
+++ b/rviz_common/include/rviz_common/view_controller.hpp
@@ -127,6 +127,13 @@ public:
   /**
    * Override with code that needs to run repeatedly.
    */
+  virtual void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt);
+
+  /// Called at 30Hz by ViewManager::update() while this view is active.
+  /**
+   * Override with code that needs to run repeatedly.
+   */
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual void update(float dt, float ros_dt);
 
   /// Called when mouse events are fired.

--- a/rviz_common/include/rviz_common/view_controller.hpp
+++ b/rviz_common/include/rviz_common/view_controller.hpp
@@ -133,7 +133,6 @@ public:
   /**
    * Override with code that needs to run repeatedly.
    */
-  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   virtual void update(float dt, float ros_dt);
 
   /// Called when mouse events are fired.

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -71,6 +71,9 @@ public:
 
   void initialize();
 
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+
+  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   void update(float wall_dt, float ros_dt);
 
   /// Return the current ViewController in use for the main RenderWindow.

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -73,7 +73,6 @@ public:
 
   void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
 
-  [[deprecated("Use update(std::chrono::nanoseconds, std::chrono::nanoseconds)")]]
   void update(float wall_dt, float ros_dt);
 
   /// Return the current ViewController in use for the main RenderWindow.

--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -32,7 +32,6 @@
 #ifndef RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 #define RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 
-#include <chrono>
 #include <deque>
 #include <memory>
 
@@ -372,8 +371,8 @@ protected:
 
   rviz_common::properties::ColorProperty * background_color_property_;
 
-  float time_update_timer_;
-  float frame_update_timer_;
+  std::chrono::nanoseconds time_update_timer_;
+  std::chrono::nanoseconds frame_update_timer_;
 
   std::shared_ptr<rviz_common::interaction::HandlerManagerIface> handler_manager_;
   std::shared_ptr<rviz_common::interaction::SelectionManagerIface> selection_manager_;

--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -183,6 +183,11 @@ void Display::setTopic(const QString & topic, const QString & datatype)
   (void) datatype;
 }
 
+void Display::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
+{
+  update(wall_dt.count(), ros_dt.count());
+}
+
 void Display::update(float wall_dt, float ros_dt)
 {
   (void) wall_dt;

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -224,7 +224,7 @@ void DisplayGroup::fixedFrameChanged()
   }
 }
 
-void DisplayGroup::update(float wall_dt, float ros_dt)
+void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   int num_children = displays_.size();
   for (int i = 0; i < num_children; i++) {
@@ -233,6 +233,12 @@ void DisplayGroup::update(float wall_dt, float ros_dt)
       display->update(wall_dt, ros_dt);
     }
   }
+}
+
+void DisplayGroup::update(float wall_dt, float ros_dt)
+{
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)),
+               std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 
 void DisplayGroup::reset()

--- a/rviz_common/src/rviz_common/tool.cpp
+++ b/rviz_common/src/rviz_common/tool.cpp
@@ -79,6 +79,11 @@ bool Tool::accessAllKeys() const
   return access_all_keys_;
 }
 
+void Tool::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
+{
+  update(wall_dt.count(), ros_dt.count());
+}
+
 void Tool::update(float wall_dt, float ros_dt)
 {
   (void) wall_dt;

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -192,6 +192,11 @@ void ViewController::activate()
   onActivate();
 }
 
+void ViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
+{
+  update(dt.count(), ros_dt.count());
+}
+
 void ViewController::update(float dt, float ros_dt)
 {
   (void) dt;

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -87,11 +87,17 @@ void ViewManager::initialize()
   setCurrent(create("rviz_default_plugins/Orbit"), false);
 }
 
-void ViewManager::update(float wall_dt, float ros_dt)
+void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   if (getCurrent()) {
     getCurrent()->update(wall_dt, ros_dt);
   }
+}
+
+void ViewManager::update(float wall_dt, float ros_dt)
+{
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)),
+               std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 
 ViewController * ViewManager::create(const QString & class_id)


### PR DESCRIPTION
## Description

Backports https://github.com/ros2/rviz/pull/1533 to kilted, removing deprecation warnings.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

