### PR TITLE
Backport humble/use chrono durations in update methods

### DIFF
--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -149,8 +149,17 @@ public:
 
   /// Called periodically by the visualization manager.
   /**
-   * \param wall_dt Wall-clock time, in seconds, since the last time the update list was run through.
-   * \param ros_dt ROS time, in seconds, since the last time the update list was run through.
+   * \param wall_dt Wall-clock time since the last time the update list was run through.
+   * \param ros_dt ROS time since the last time the update list was run through.
+   */
+  virtual
+  void
+  update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+
+  /// Called periodically by the visualization manager.
+  /**
+   * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
+   * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
    */
   virtual
   void

--- a/rviz_common/include/rviz_common/display_group.hpp
+++ b/rviz_common/include/rviz_common/display_group.hpp
@@ -143,6 +143,9 @@ public:
   virtual DisplayGroup * getGroupAt(int index) const;
 
   /// Call update() on all child Displays.
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
+
+  /// Call update() on all child Displays.
   void update(float wall_dt, float ros_dt) override;
 
   /// Reset this and all child Displays.

--- a/rviz_common/include/rviz_common/tool.hpp
+++ b/rviz_common/include/rviz_common/tool.hpp
@@ -101,6 +101,17 @@ public:
   virtual void deactivate() = 0;
 
   /// Called periodically, typically at 30Hz.
+  /**
+   * \param wall_dt Wall-clock time since the last time the update list was run through.
+   * \param ros_dt ROS time since the last time the update list was run through.
+   */
+  virtual void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+
+  /// Called periodically, typically at 30Hz.
+  /**
+   * \param wall_dt Wall-clock time, in nanoseconds, since the last time the update list was run through.
+   * \param ros_dt ROS time, in nanoseconds, since the last time the update list was run through.
+   */
   virtual void update(float wall_dt, float ros_dt);
 
   enum

--- a/rviz_common/include/rviz_common/view_controller.hpp
+++ b/rviz_common/include/rviz_common/view_controller.hpp
@@ -123,6 +123,12 @@ public:
   /**
    * Override with code that needs to run repeatedly.
    */
+  virtual void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt);
+
+  /// Called at 30Hz by ViewManager::update() while this view is active.
+  /**
+   * Override with code that needs to run repeatedly.
+   */
   virtual void update(float dt, float ros_dt);
 
   /// Called when mouse events are fired.

--- a/rviz_common/include/rviz_common/view_manager.hpp
+++ b/rviz_common/include/rviz_common/view_manager.hpp
@@ -69,6 +69,8 @@ public:
 
   void initialize();
 
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
+
   void update(float wall_dt, float ros_dt);
 
   /// Return the current ViewController in use for the main RenderWindow.

--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -31,7 +31,6 @@
 #ifndef RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 #define RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 
-#include <chrono>
 #include <deque>
 #include <memory>
 
@@ -378,8 +377,8 @@ protected:
 
   rviz_common::properties::ColorProperty * background_color_property_;
 
-  float time_update_timer_;
-  float frame_update_timer_;
+  std::chrono::nanoseconds time_update_timer_;
+  std::chrono::nanoseconds frame_update_timer_;
 
   std::shared_ptr<rviz_common::interaction::HandlerManagerIface> handler_manager_;
   std::shared_ptr<rviz_common::interaction::SelectionManagerIface> selection_manager_;

--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -181,6 +181,11 @@ void Display::setTopic(const QString & topic, const QString & datatype)
   (void) datatype;
 }
 
+void Display::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
+{
+  update(wall_dt.count(), ros_dt.count());
+}
+
 void Display::update(float wall_dt, float ros_dt)
 {
   (void) wall_dt;

--- a/rviz_common/src/rviz_common/display_group.cpp
+++ b/rviz_common/src/rviz_common/display_group.cpp
@@ -222,7 +222,7 @@ void DisplayGroup::fixedFrameChanged()
   }
 }
 
-void DisplayGroup::update(float wall_dt, float ros_dt)
+void DisplayGroup::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   int num_children = displays_.size();
   for (int i = 0; i < num_children; i++) {
@@ -231,6 +231,12 @@ void DisplayGroup::update(float wall_dt, float ros_dt)
       display->update(wall_dt, ros_dt);
     }
   }
+}
+
+void DisplayGroup::update(float wall_dt, float ros_dt)
+{
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)),
+               std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 
 void DisplayGroup::reset()

--- a/rviz_common/src/rviz_common/tool.cpp
+++ b/rviz_common/src/rviz_common/tool.cpp
@@ -77,6 +77,11 @@ bool Tool::accessAllKeys() const
   return access_all_keys_;
 }
 
+void Tool::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
+{
+  update(wall_dt.count(), ros_dt.count());
+}
+
 void Tool::update(float wall_dt, float ros_dt)
 {
   (void) wall_dt;

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -179,6 +179,11 @@ void ViewController::activate()
   onActivate();
 }
 
+void ViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
+{
+  update(dt.count(), ros_dt.count());
+}
+
 void ViewController::update(float dt, float ros_dt)
 {
   (void) dt;

--- a/rviz_common/src/rviz_common/view_manager.cpp
+++ b/rviz_common/src/rviz_common/view_manager.cpp
@@ -84,11 +84,17 @@ void ViewManager::initialize()
   setCurrent(create("rviz_default_plugins/Orbit"), false);
 }
 
-void ViewManager::update(float wall_dt, float ros_dt)
+void ViewManager::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   if (getCurrent()) {
     getCurrent()->update(wall_dt, ros_dt);
   }
+}
+
+void ViewManager::update(float wall_dt, float ros_dt)
+{
+  this->update(std::chrono::nanoseconds(std::lround(wall_dt)),
+               std::chrono::nanoseconds(std::lround(ros_dt)));
 }
 
 ViewController * ViewManager::create(const QString & class_id)

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -149,8 +149,8 @@ VisualizationManager::VisualizationManager(
   render_panel_(render_panel),
   wall_clock_elapsed_(0),
   ros_time_elapsed_(0),
-  time_update_timer_(0.0f),
-  frame_update_timer_(0.0f),
+  time_update_timer_(0),
+  frame_update_timer_(0),
   render_requested_(1),
   frame_count_(0),
   window_manager_(wm),
@@ -391,15 +391,17 @@ BitAllocator * VisualizationManager::visibilityBits()
 
 void VisualizationManager::onUpdate()
 {
-  const auto wall_now = std::chrono::system_clock::now();
-  const auto wall_diff = wall_now - last_update_wall_time_;
-  const uint64_t wall_dt = std::chrono::duration_cast<std::chrono::nanoseconds>(wall_diff).count();
+  const std::chrono::time_point<std::chrono::system_clock> wall_now =
+    std::chrono::system_clock::now();
+  const std::chrono::nanoseconds wall_dt =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(wall_now - last_update_wall_time_);
   const auto ros_now = clock_->now();
-  const uint64_t ros_dt = ros_now.nanoseconds() - last_update_ros_time_.nanoseconds();
+  const auto ros_dt = std::chrono::nanoseconds(
+      std::lround(ros_now.nanoseconds() - last_update_ros_time_.nanoseconds()));
   last_update_ros_time_ = ros_now;
   last_update_wall_time_ = wall_now;
 
-  if (ros_dt < 0.0) {
+  if (ros_dt < std::chrono::nanoseconds(0)) {
     resetTime();
   }
 
@@ -417,17 +419,15 @@ void VisualizationManager::onUpdate()
 
   time_update_timer_ += wall_dt;
 
-  if (time_update_timer_ > 0.1f) {
-    time_update_timer_ = 0.0f;
-
+  if (time_update_timer_ > std::chrono::nanoseconds(0)) {
+    time_update_timer_ = std::chrono::nanoseconds(0);
     updateTime();
   }
 
   frame_update_timer_ += wall_dt;
 
-  if (frame_update_timer_ > 1.0f) {
-    frame_update_timer_ = 0.0f;
-
+  if (frame_update_timer_ > std::chrono::nanoseconds(1)) {
+    frame_update_timer_ = std::chrono::nanoseconds(0);
     updateFrames();
   }
 
@@ -447,7 +447,7 @@ void VisualizationManager::onUpdate()
   }
 
   frame_count_++;
-  if (render_requested_ || wall_diff > std::chrono::milliseconds(10)) {
+  if (render_requested_ || wall_dt > std::chrono::milliseconds(10)) {
     render_requested_ = 0;
     std::lock_guard<std::mutex> lock(private_->render_mutex_);
     ogre_root_->renderOneFrame();


### PR DESCRIPTION
## Description

Backports https://github.com/ros2/rviz/pull/1533 to humble, removing deprecation warnings.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information


