### PR TITLE
Add support for ffmpeg_image_transport to Image/Camera displays and point_cloud_transport/cloudini to PointCloud2 display

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -70,6 +70,7 @@
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/load_resource.hpp"
 
+#include "rviz_default_plugins/displays/image/get_transport_from_topic.hpp"
 #include "rviz_default_plugins/displays/image/ros_image_texture.hpp"
 
 namespace rviz_default_plugins
@@ -187,7 +188,6 @@ void CameraDisplay::onInitialize()
 
   this->addChild(visibility_property_, 0);
 }
-
 
 void CameraDisplay::setupSceneNodes()
 {
@@ -349,7 +349,7 @@ void CameraDisplay::createCameraInfoSubscription()
     // TODO(anyone) Store this in a member variable
 
     std::string camera_info_topic = image_transport::getCameraInfoTopic(
-      topic_property_->getTopicStd());
+      getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
     rclcpp::SubscriptionOptions sub_opts;
     sub_opts.event_callbacks.message_lost_callback =
@@ -412,7 +412,7 @@ void CameraDisplay::clear()
   current_caminfo_.reset();
 
   std::string camera_info_topic =
-    image_transport::getCameraInfoTopic(topic_property_->getTopicStd());
+    image_transport::getCameraInfoTopic(getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
   setStatus(
     StatusLevel::Warn, CAM_INFO_STATUS,
@@ -459,7 +459,7 @@ bool CameraDisplay::updateCamera()
 
   if (!info) {
     std::string camera_info_topic = image_transport::getCameraInfoTopic(
-      topic_property_->getTopicStd());
+      getBaseTopicFromTopic(topic_property_->getTopicStd()));
 
     setStatus(
       StatusLevel::Warn, CAM_INFO_STATUS,

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/get_transport_from_topic.cpp
@@ -40,8 +40,10 @@ namespace displays
 bool isRawTransport(const std::string & topic)
 {
   std::string last_subtopic = topic.substr(topic.find_last_of('/') + 1);
-  return last_subtopic != "compressed" && last_subtopic != "compressedDepth" &&
-         last_subtopic != "theora";
+  return last_subtopic != "compressed" &&
+         last_subtopic != "compressedDepth" &&
+         last_subtopic != "theora" &&
+         last_subtopic != "ffmpeg";
 }
 
 std::string getTransportFromTopic(const std::string & topic)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/get_transport_from_topic.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/get_transport_from_topic.cpp
@@ -41,7 +41,8 @@ bool isPointCloud2RawTransport(const std::string & topic)
 {
   std::string last_subtopic = topic.substr(topic.find_last_of('/') + 1);
   return last_subtopic != "draco" && last_subtopic != "zlib" &&
-         last_subtopic != "pcl" && last_subtopic != "zstd";
+         last_subtopic != "pcl" && last_subtopic != "zstd" &&
+         last_subtopic != "cloudini";
 }
 
 std::string getPointCloud2TransportFromTopic(const std::string & topic)


### PR DESCRIPTION
## Description

- fix topic handling in *Camera* display to support images compressed by any supported `image_transport`
- make *Image* and *Camera* display support images compressed by `ffmpeg_image_transport`
- make *PointCloud2* display support point clouds compressed by [`cloudini`](https://github.com/facontidavide/cloudini)

### Is this user-facing behavior change?

- users can now select ffmpeg-compressed images in *Image* and *Camera* displays
- users can now select cloudini-compressed point clouds in *PointCloud2* displays

### Did you use Generative AI?

Yes, GitHub Copilot auto-completion.

### Additional Information

Related to https://github.com/ros2/rviz/pull/1288?