### PR TITLE
Std chrono update in default plugins

### DIFF
--- a/rviz_common/include/rviz_common/frame_position_tracking_view_controller.hpp
+++ b/rviz_common/include/rviz_common/frame_position_tracking_view_controller.hpp
@@ -74,7 +74,7 @@ public:
    */
   void onActivate() override;
 
-  void update(float dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt) override;
 
   /// Configure the settings of this view controller to give a similar view as the source_view.
   /**

--- a/rviz_common/src/rviz_common/frame_position_tracking_view_controller.cpp
+++ b/rviz_common/src/rviz_common/frame_position_tracking_view_controller.cpp
@@ -90,7 +90,9 @@ void FramePositionTrackingViewController::onActivate()
   connect(target_frame_property_, SIGNAL(changed()), this, SLOT(updateTargetFrame()));
 }
 
-void FramePositionTrackingViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
+void FramePositionTrackingViewController::update(
+  std::chrono::nanoseconds dt,
+  std::chrono::nanoseconds ros_dt)
 {
   Q_UNUSED(dt);
   Q_UNUSED(ros_dt);

--- a/rviz_common/src/rviz_common/frame_position_tracking_view_controller.cpp
+++ b/rviz_common/src/rviz_common/frame_position_tracking_view_controller.cpp
@@ -90,7 +90,7 @@ void FramePositionTrackingViewController::onActivate()
   connect(target_frame_property_, SIGNAL(changed()), this, SLOT(updateTargetFrame()));
 }
 
-void FramePositionTrackingViewController::update(float dt, float ros_dt)
+void FramePositionTrackingViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
   Q_UNUSED(dt);
   Q_UNUSED(ros_dt);

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/axes/axes_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/axes/axes_display.hpp
@@ -66,7 +66,7 @@ public:
   void onInitialize() override;
 
   // Overrides from Display
-  void update(float dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt) override;
 
 protected:
   void onEnable() override;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -115,7 +115,7 @@ public:
   // Overrides from Display
   void onInitialize() override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void reset() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera_info/camera_info_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera_info/camera_info_display.hpp
@@ -75,7 +75,7 @@ public:
 protected:
   void processMessage(const sensor_msgs::msg::CameraInfo::ConstSharedPtr msg) override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
   bool isSameCameraInfo(
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info);
   void createCameraInfoShapes(

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
@@ -92,7 +92,7 @@ public:
   void onInitialize() override;
 
   // Overrides from Display
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
   void reset() override;
   void setTopic(const QString & topic, const QString & datatype) override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/effort/effort_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/effort/effort_display.hpp
@@ -104,7 +104,7 @@ public:
 
   void load(const rviz_common::Config & config) override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
 private Q_SLOTS:
   // Helper function to apply color and alpha to all visuals.

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/grid/grid_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/grid/grid_display.hpp
@@ -78,7 +78,7 @@ public:
 
   // Overrides from Display
   void onInitialize() override;
-  void update(float dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt) override;
 
 private Q_SLOTS:
   void updateCellCount();

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
@@ -82,7 +82,7 @@ public:
 
   // Overrides from Display
   void onInitialize() override;
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
   void reset() override;
 
 public Q_SLOTS:

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.hpp
@@ -67,7 +67,7 @@ public:
   InteractiveMarkerDisplay();
 
   // Overrides from Display
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void reset() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
@@ -73,7 +73,7 @@ public:
   ~LaserScanDisplay() override = default;
 
   void reset() override;
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void onDisable() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/map/map_display.hpp
@@ -128,7 +128,7 @@ protected Q_SLOTS:
 
 protected:
   void updateTopic() override;
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void subscribe() override;
   void unsubscribe() override;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_common.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_common.hpp
@@ -98,7 +98,7 @@ public:
   void initialize(rviz_common::DisplayContext * context, Ogre::SceneNode * scene_node);
   void load(const rviz_common::Config & config);
 
-  void update(float wall_dt, float ros_dt);
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
 
   void deleteMarker(MarkerID id);
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_display.hpp
@@ -63,7 +63,7 @@ public:
   void onInitialize() override;
   void load(const rviz_common::Config & config) override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void reset() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker_array/marker_array_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker_array/marker_array_display.hpp
@@ -62,7 +62,7 @@ public:
   void onInitialize() override;
   void load(const rviz_common::Config & config) override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void reset() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/odometry/odometry_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/odometry/odometry_display.hpp
@@ -96,7 +96,7 @@ public:
   void reset() override;
 
   // Overides of Display
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void processMessage(nav_msgs::msg::Odometry::ConstSharedPtr msg) override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud2_display.hpp
@@ -74,7 +74,7 @@ public:
 
   void reset() override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   /**
    * Filter any NAN values out of the cloud.  Any NAN values that make it through to PointCloudBase

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp
@@ -143,7 +143,7 @@ public:
   void initialize(rviz_common::DisplayContext * context, Ogre::SceneNode * scene_node);
 
   void reset();
-  void update(float wall_dt, float ros_dt);
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
 
   void addMessage(sensor_msgs::msg::PointCloud::ConstSharedPtr cloud);
   void addMessage(sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud);

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_display.hpp
@@ -74,7 +74,7 @@ public:
 
   void reset() override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
   void onDisable() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
@@ -110,7 +110,7 @@ private:
     setInitialValues();
   }
 
-  void update(float wall_dt, float ros_dt) override
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override
   {
     point_cloud_common_->update(wall_dt, ros_dt);
     hideUnneededProperties();

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
@@ -134,7 +134,7 @@ protected:
   bool has_new_transforms_;      ///< Callback sets this to tell our update function
   ///< it needs to update the transforms
 
-  float time_since_last_transform_;
+  std::chrono::nanoseconds time_since_last_transform_;
 
   std::string robot_description_;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
@@ -95,7 +95,7 @@ public:
 
   // Overrides from Display
   void onInitialize() override;
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
   void fixedFrameChanged() override;
   void reset() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/tf/tf_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/tf/tf_display.hpp
@@ -101,7 +101,7 @@ public:
 
   ~TFDisplay() override;
 
-  void update(float wall_dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
 
 protected:
   void onInitialize() override;

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/tf/tf_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/tf/tf_display.hpp
@@ -138,7 +138,7 @@ private:
   typedef std::map<std::string, bool> M_EnabledState;
   M_EnabledState frame_config_enabled_state_;
 
-  float update_timer_;
+  std::chrono::nanoseconds update_timer_;
 
   rviz_common::properties::BoolProperty * show_names_property_;
   rviz_common::properties::BoolProperty * show_arrows_property_;

--- a/rviz_default_plugins/include/rviz_default_plugins/tools/select/selection_tool.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/tools/select/selection_tool.hpp
@@ -64,7 +64,7 @@ public:
   virtual int processMouseEvent(rviz_common::ViewportMouseEvent & event);
   virtual int processKeyEvent(QKeyEvent * event, rviz_common::RenderPanel * panel);
 
-  virtual void update(float wall_dt, float ros_dt);
+  virtual void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt);
 
 private:
   MoveTool * move_tool_;

--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/fps/fps_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/fps/fps_view_controller.hpp
@@ -92,7 +92,7 @@ public:
    * @param source_view must return a valid @c Ogre::Camera* from getCamera(). */
   void mimic(rviz_common::ViewController * source_view) override;
 
-  void update(float dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt) override;
 
 protected:
   void onTargetFrameChanged(

--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.hpp
@@ -111,7 +111,7 @@ public:
 
   rviz_common::FocalPointStatus getFocalPointStatus() override;
 
-  void update(float dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt) override;
 
 protected:
   bool setMouseMovementFromEvent(

--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.hpp
@@ -88,7 +88,7 @@ public:
 
   void move(float x, float y);
 
-  void update(float dt, float ros_dt) override;
+  void update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt) override;
 
 protected:
   void onTargetFrameChanged(

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/axes/axes_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/axes/axes_display.cpp
@@ -95,7 +95,7 @@ void AxesDisplay::updateShape()
   context_->queueRender();
 }
 
-void AxesDisplay::update(float dt, float ros_dt)
+void AxesDisplay::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
   (void) dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -428,7 +428,7 @@ void CameraDisplay::clear()
   }
 }
 
-void CameraDisplay::update(float wall_dt, float ros_dt)
+void CameraDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
@@ -162,7 +162,7 @@ void CameraInfoDisplay::processMessage(
   camera_info_ = msg;
 }
 
-void CameraInfoDisplay::update(float /*wall_dt*/, float /*ros_dt*/)
+void CameraInfoDisplay::update(std::chrono::nanoseconds /*wall_dt*/, std::chrono::nanoseconds /*ros_dt*/)
 {
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
@@ -162,7 +162,9 @@ void CameraInfoDisplay::processMessage(
   camera_info_ = msg;
 }
 
-void CameraInfoDisplay::update(std::chrono::nanoseconds /*wall_dt*/, std::chrono::nanoseconds /*ros_dt*/)
+void CameraInfoDisplay::update(
+  std::chrono::nanoseconds /*wall_dt*/,
+  std::chrono::nanoseconds /*ros_dt*/)
 {
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
@@ -437,7 +437,7 @@ void DepthCloudDisplay::clear()
   }
 }
 
-void DepthCloudDisplay::update(float wall_dt, float ros_dt)
+void DepthCloudDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   pointcloud_common_->update(wall_dt, ros_dt);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/effort/effort_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/effort/effort_display.cpp
@@ -256,7 +256,7 @@ void EffortDisplay::load()
   this->subscribeToRobotDescription();
 }
 
-void EffortDisplay::update(float wall_dt, float ros_dt)
+void EffortDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid/grid_display.cpp
@@ -147,7 +147,7 @@ void GridDisplay::onInitialize()
   updatePlane();
 }
 
-void GridDisplay::update(float dt, float ros_dt)
+void GridDisplay::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
   Q_UNUSED(dt);
   Q_UNUSED(ros_dt);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -157,7 +157,7 @@ void ImageDisplay::clear()
   texture_->clear();
 }
 
-void ImageDisplay::update(float wall_dt, float ros_dt)
+void ImageDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
@@ -202,7 +202,7 @@ void InteractiveMarkerDisplay::unsubscribe()
   Display::reset();
 }
 
-void InteractiveMarkerDisplay::update(float wall_dt, float ros_dt)
+void InteractiveMarkerDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
@@ -202,7 +202,9 @@ void InteractiveMarkerDisplay::unsubscribe()
   Display::reset();
 }
 
-void InteractiveMarkerDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
+void InteractiveMarkerDisplay::update(
+  std::chrono::nanoseconds wall_dt,
+  std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -117,7 +117,7 @@ void LaserScanDisplay::processMessage(sensor_msgs::msg::LaserScan::ConstSharedPt
   }
 }
 
-void LaserScanDisplay::update(float wall_dt, float ros_dt)
+void LaserScanDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   if (transformer_guard_->checkTransformer()) {
     point_cloud_common_->update(wall_dt, ros_dt);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -695,7 +695,7 @@ void MapDisplay::reset()
   clear();
 }
 
-void MapDisplay::update(float wall_dt, float ros_dt)
+void MapDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -345,7 +345,7 @@ void MarkerCommon::processDelete(const visualization_msgs::msg::Marker::ConstSha
   context_->queueRender();
 }
 
-void MarkerCommon::update(float wall_dt, float ros_dt)
+void MarkerCommon::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_display.cpp
@@ -112,7 +112,7 @@ void MarkerDisplay::processMessage(const visualization_msgs::msg::Marker::ConstS
   marker_common_->addMessage(msg);
 }
 
-void MarkerDisplay::update(float wall_dt, float ros_dt)
+void MarkerDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   marker_common_->update(wall_dt, ros_dt);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker_array/marker_array_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker_array/marker_array_display.cpp
@@ -66,7 +66,7 @@ void MarkerArrayDisplay::processMessage(visualization_msgs::msg::MarkerArray::Co
   marker_common_->addMessage(msg);
 }
 
-void MarkerArrayDisplay::update(float wall_dt, float ros_dt)
+void MarkerArrayDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   marker_common_->update(wall_dt, ros_dt);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
@@ -384,7 +384,7 @@ std::unique_ptr<rviz_rendering::CovarianceVisual> OdometryDisplay::createAndSetC
   return covariance_visual;
 }
 
-void OdometryDisplay::update(float wall_dt, float ros_dt)
+void OdometryDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -171,7 +171,7 @@ bool PointCloud2Display::validateFloatsAtPosition(
          rviz_common::validateFloats(z);
 }
 
-void PointCloud2Display::update(float wall_dt, float ros_dt)
+void PointCloud2Display::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   point_cloud_common_->update(wall_dt, ros_dt);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -288,7 +288,7 @@ void PointCloudCommon::causeRetransform()
   needs_retransform_ = true;
 }
 
-void PointCloudCommon::update(float wall_dt, float ros_dt)
+void PointCloudCommon::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -59,7 +59,7 @@ void PointCloudDisplay::processMessage(const sensor_msgs::msg::PointCloud::Const
   point_cloud_common_->addMessage(cloud);
 }
 
-void PointCloudDisplay::update(float wall_dt, float ros_dt)
+void PointCloudDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   point_cloud_common_->update(wall_dt, ros_dt);
 }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -331,7 +331,7 @@ void RobotModelDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::na
 
   (void) ros_dt;
   time_since_last_transform_ += wall_dt;
-  std::chrono::nanoseconds rate = std::lround(update_rate_property_->getFloat() * 1e9);
+  std::chrono::nanoseconds rate(std::lround(update_rate_property_->getFloat() * 1e9));
   bool update = rate < std::chrono::microseconds(100) || time_since_last_transform_ >= rate;
 
   if (has_new_transforms_ || update) {
@@ -339,7 +339,7 @@ void RobotModelDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::na
     context_->queueRender();
 
     has_new_transforms_ = false;
-    time_since_last_transform_ = 0;
+    time_since_last_transform_ = std::chrono::nanoseconds(0);
   }
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -323,7 +323,7 @@ void RobotModelDisplay::onDisable()
   clear();
 }
 
-void RobotModelDisplay::update(float wall_dt, float ros_dt)
+void RobotModelDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   if (!transformer_guard_->checkTransformer()) {
     return;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -82,7 +82,7 @@ enum DescriptionSource
 
 RobotModelDisplay::RobotModelDisplay()
 : has_new_transforms_(false),
-  time_since_last_transform_(0.0f),
+  time_since_last_transform_(0),
   transformer_guard_(
     std::make_unique<rviz_default_plugins::transformation::TransformerGuard<
       rviz_default_plugins::transformation::TFFrameTransformer>>(this, "TF"))
@@ -331,15 +331,15 @@ void RobotModelDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::na
 
   (void) ros_dt;
   time_since_last_transform_ += wall_dt;
-  float rate = update_rate_property_->getFloat();
-  bool update = rate < 0.0001f || time_since_last_transform_ >= rate * 1000000000;
+  std::chrono::nanoseconds rate = std::lround(update_rate_property_->getFloat() * 1e9);
+  bool update = rate < std::chrono::microseconds(100) || time_since_last_transform_ >= rate;
 
   if (has_new_transforms_ || update) {
     updateRobot();
     context_->queueRender();
 
     has_new_transforms_ = false;
-    time_since_last_transform_ = 0.0f;
+    time_since_last_transform_ = 0;
   }
 }
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
@@ -280,7 +280,7 @@ void TFDisplay::allEnabledChanged()
   }
 }
 
-void TFDisplay::update(float wall_dt, float ros_dt)
+void TFDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   if (!transformer_guard_->checkTransformer()) {
     return;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
@@ -288,7 +288,7 @@ void TFDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosecond
 
   (void) ros_dt;
   update_timer_ += wall_dt;
-  std::chrono::nanoseconds update_rate(std::roundl(update_rate_property_->getFloat() * 1e9));
+  std::chrono::nanoseconds update_rate = std::chrono::nanoseconds(std::roundl(update_rate_property_->getFloat() * 1e9));
   if (update_rate < std::chrono::microseconds(100) || update_timer_ > update_rate) {
     updateFrames();
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
@@ -91,7 +91,7 @@ namespace displays
 {
 
 TFDisplay::TFDisplay()
-: update_timer_(0.0f),
+: update_timer_(0),
   changing_single_frame_enabled_state_(false),
   transformer_guard_(
     std::make_unique<rviz_default_plugins::transformation::TransformerGuard<
@@ -221,7 +221,7 @@ void TFDisplay::clear()
 
   frames_.clear();
 
-  update_timer_ = 0.0f;
+  update_timer_ = std::chrono::nanoseconds(0);
 
   clearStatuses();
 }
@@ -288,11 +288,11 @@ void TFDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosecond
 
   (void) ros_dt;
   update_timer_ += wall_dt;
-  float update_rate = update_rate_property_->getFloat();
-  if (update_rate < 0.0001f || update_timer_ > update_rate * 1000000000) {
+  std::chrono::nanoseconds update_rate(std::roundl(update_rate_property_->getFloat() * 1e9));
+  if (update_rate < std::chrono::microseconds(100) || update_timer_ > update_rate) {
     updateFrames();
 
-    update_timer_ = 0.0f;
+    update_timer_ = std::chrono::nanoseconds(0);
   }
 }
 
@@ -633,7 +633,7 @@ void TFDisplay::deleteFrame(FrameInfo * frame, bool delete_properties)
 
 void TFDisplay::fixedFrameChanged()
 {
-  update_timer_ = update_rate_property_->getFloat();
+  update_timer_ = std::chrono::nanoseconds(std::roundl(update_rate_property_->getFloat() * 1e9));
 }
 
 void TFDisplay::reset()

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf/tf_display.cpp
@@ -288,7 +288,7 @@ void TFDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanosecond
 
   (void) ros_dt;
   update_timer_ += wall_dt;
-  std::chrono::nanoseconds update_rate = std::chrono::nanoseconds(std::roundl(update_rate_property_->getFloat() * 1e9));
+  std::chrono::nanoseconds update_rate(std::lround(update_rate_property_->getFloat() * 1e9));
   if (update_rate < std::chrono::microseconds(100) || update_timer_ > update_rate) {
     updateFrames();
 
@@ -633,7 +633,7 @@ void TFDisplay::deleteFrame(FrameInfo * frame, bool delete_properties)
 
 void TFDisplay::fixedFrameChanged()
 {
-  update_timer_ = std::chrono::nanoseconds(std::roundl(update_rate_property_->getFloat() * 1e9));
+  update_timer_ = std::chrono::nanoseconds(std::lround(update_rate_property_->getFloat() * 1e9));
 }
 
 void TFDisplay::reset()

--- a/rviz_default_plugins/src/rviz_default_plugins/tools/select/selection_tool.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/tools/select/selection_tool.cpp
@@ -94,7 +94,7 @@ void SelectionTool::deactivate()
   context_->getSelectionManager()->removeHighlight();
 }
 
-void SelectionTool::update(float wall_dt, float ros_dt)
+void SelectionTool::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
 {
   (void) wall_dt;
   (void) ros_dt;

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/fps/fps_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/fps/fps_view_controller.cpp
@@ -208,7 +208,7 @@ void FPSViewController::mimic(rviz_common::ViewController * source_view)
   setPropertiesFromCamera(source_view->getCamera());
 }
 
-void FPSViewController::update(float dt, float ros_dt)
+void FPSViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
   FramePositionTrackingViewController::update(dt, ros_dt);
   updateCamera();

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
@@ -292,7 +292,7 @@ rviz_common::FocalPointStatus OrbitViewController::getFocalPointStatus()
   return {true, focal_point_property_->getVector()};
 }
 
-void OrbitViewController::update(float dt, float ros_dt)
+void OrbitViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
   rviz_common::FramePositionTrackingViewController::update(dt, ros_dt);
   updateCamera();

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.cpp
@@ -161,7 +161,7 @@ void FixedOrientationOrthoViewController::mimic(ViewController * source_view)
   }
 }
 
-void FixedOrientationOrthoViewController::update(float dt, float ros_dt)
+void FixedOrientationOrthoViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
 {
   FramePositionTrackingViewController::update(dt, ros_dt);
   updateCamera();

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/ortho/fixed_orientation_ortho_view_controller.cpp
@@ -161,7 +161,9 @@ void FixedOrientationOrthoViewController::mimic(ViewController * source_view)
   }
 }
 
-void FixedOrientationOrthoViewController::update(std::chrono::nanoseconds dt, std::chrono::nanoseconds ros_dt)
+void FixedOrientationOrthoViewController::update(
+  std::chrono::nanoseconds dt,
+  std::chrono::nanoseconds ros_dt)
 {
   FramePositionTrackingViewController::update(dt, ros_dt);
   updateCamera();

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
@@ -101,7 +101,8 @@ TEST_F(ImageDisplayTestFixture, update_calls_texture_update) {
 
   ImageDisplay imageDisplay(std::move(texture_));
   imageDisplay.initialize(context_.get());
-  imageDisplay.update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  imageDisplay.update(zero, zero);
 }
 
 int main(int argc, char ** argv)

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_common_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_common_test.cpp
@@ -408,7 +408,8 @@ TEST_F(MarkerCommonFixture, update_retransforms_frame_locked_messages) {
     pointCloud->getParentSceneNode()->getOrientation(),
     QuaternionEq(starting_orientation));
 
-  common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  common_->update(zero, zero);
 
   EXPECT_THAT(pointCloud->getParentSceneNode()->getPosition(), Vector3Eq(next_position));
   EXPECT_THAT(
@@ -442,7 +443,8 @@ TEST_F(MarkerCommonFixture, update_does_not_retransform_normal_messages) {
     pointCloud->getParentSceneNode()->getOrientation(),
     QuaternionEq(starting_orientation));
 
-  common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  common_->update(zero, zero);
 
   EXPECT_THAT(pointCloud->getParentSceneNode()->getPosition(), Vector3Eq(starting_position));
   EXPECT_THAT(

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
@@ -80,7 +80,8 @@ TEST_F(PointCloudCommonTestFixture, update_adds_pointcloud_to_scene_graph) {
   mockValidTransform();
 
   point_cloud_common_->addMessage(cloud);
-  point_cloud_common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  point_cloud_common_->update(zero, zero);
 
   auto point_cloud = rviz_default_plugins::findOnePointCloud(scene_manager_->getRootSceneNode());
 
@@ -99,13 +100,14 @@ TEST_F(PointCloudCommonTestFixture, update_removes_old_point_clouds) {
   auto cloud = createPointCloud2WithPoints(std::vector<rviz_default_plugins::Point>{p});
 
   point_cloud_common_->addMessage(cloud);
-  point_cloud_common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  point_cloud_common_->update(zero, zero);
 
   p = {4, 5, 6};
   cloud = createPointCloud2WithPoints(std::vector<rviz_default_plugins::Point>{p});
 
   point_cloud_common_->addMessage(cloud);
-  point_cloud_common_->update(0, 0);
+  point_cloud_common_->update(zero, zero);
 
   auto point_clouds = rviz_default_plugins::findAllPointClouds(scene_manager_->getRootSceneNode());
   ASSERT_THAT(point_clouds.size(), Eq(1u));
@@ -125,7 +127,8 @@ TEST_F(PointCloudCommonTestFixture, update_sets_size_and_alpha_on_renderable) {
   mockValidTransform();
 
   point_cloud_common_->addMessage(cloud);
-  point_cloud_common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  point_cloud_common_->update(zero, zero);
 
   auto point_cloud = rviz_default_plugins::findOnePointCloud(scene_manager_->getRootSceneNode());
   auto size = point_cloud->getRenderables()[0]->getCustomParameter(RVIZ_RENDERING_SIZE_PARAMETER);
@@ -148,7 +151,8 @@ TEST_F(PointCloudCommonTestFixture, update_adds_nothing_if_transform_fails) {
   EXPECT_CALL(*frame_manager_, getTransform(_, _, _, _)).WillRepeatedly(Return(false));  // NOLINT
 
   point_cloud_common_->addMessage(cloud);
-  point_cloud_common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  point_cloud_common_->update(zero, zero);
 
   auto point_cloud = rviz_default_plugins::findOnePointCloud(scene_manager_->getRootSceneNode());
   EXPECT_FALSE(point_cloud);
@@ -172,7 +176,8 @@ TEST_F(PointCloudCommonTestFixture, update_colors_the_points_using_the_selected_
   color_property->setValue(QColor(255, 0, 0));
 
   point_cloud_common_->addMessage(cloud);
-  point_cloud_common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  point_cloud_common_->update(zero, zero);
 
   auto point_cloud = rviz_default_plugins::findOnePointCloud(scene_manager_->getRootSceneNode());
 
@@ -223,7 +228,8 @@ TEST_F(
   }
 
   point_cloud_common_->addMessage(cloud);
-  point_cloud_common_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  point_cloud_common_->update(zero, zero);
 
   auto point_clouds = rviz_default_plugins::findAllPointClouds(scene_manager_->getRootSceneNode());
   ASSERT_THAT(point_clouds.size(), Eq(0u));

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
@@ -80,7 +80,8 @@ public:
     position_property->childAt(0)->setValue(0);
     position_property->childAt(1)->setValue(0);
     position_property->childAt(2)->setValue(0);
-    fps_->update(0, 0);  // Camera now looks in x-direction, located at the origin
+    auto zero = std::chrono::nanoseconds::zero();
+    fps_->update(zero, zero);  // Camera now looks in x-direction, located at the origin
 
     EXPECT_THAT(yaw_property->getValue().toFloat(), FloatNear(0, 0.001f));
     EXPECT_THAT(pitch_property->getValue().toFloat(), FloatNear(0, 0.001f));
@@ -192,10 +193,11 @@ TEST_F(FPSViewControllerTestFixture, mimic_does_not_change_view_when_given_any_v
   old_yaw_property->setValue(1);
   old_pitch_property->setValue(2);
   orbit_view->move(10, 12, 0);
-  orbit_view->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  orbit_view->update(zero, zero);
 
   fps_->mimic(orbit_view.get());
-  fps_->update(0, 0);
+  fps_->update(zero, zero);
 
   // Yaw and Pitch cannot be equal since the orbit view's yaw and pitch are relative to its focal
   // point, while the fps yaw and pitch are absolute. However, the orientation of the camera

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/frame/frame_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/frame/frame_view_controller_test.cpp
@@ -144,7 +144,8 @@ public:
     position_property->childAt(0)->setValue(0);
     position_property->childAt(1)->setValue(0);
     position_property->childAt(2)->setValue(0);
-    frame_->update(0, 0);  // Camera now looks in x-direction, located at the origin
+    auto zero = std::chrono::nanoseconds::zero();
+    frame_->update(zero, zero);  // Camera now looks in x-direction, located at the origin
 
     EXPECT_THAT(yaw_property->getValue().toFloat(), FloatNear(0, 0.001f));
     EXPECT_THAT(pitch_property->getValue().toFloat(), FloatNear(0, 0.001f));
@@ -177,7 +178,8 @@ TEST_F(FrameViewControllerTestFixture, reset_points_camera_along_selected_axis) 
   auto pitch_property = frame_->childAt(5);
   yaw_property->setValue(1.5);
   pitch_property->setValue(0.5);
-  frame_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  frame_->update(zero, zero);
 
   // Reset should align with -z axis (option 6)
   frame_->reset();
@@ -195,7 +197,8 @@ TEST_F(FrameViewControllerTestFixture, default_axis_is_negative_z) {
 TEST_F(FrameViewControllerTestFixture, setting_axis_to_positive_x_points_camera_along_x_axis) {
   // +x axis = option 1
   setAxisPropertyOption(1);
-  frame_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  frame_->update(zero, zero);
 
   checkCameraLooksAlong(Ogre::Vector3(1, 0, 0));
 }
@@ -204,7 +207,8 @@ TEST_F(FrameViewControllerTestFixture,
   setting_axis_to_negative_x_points_camera_along_negative_x_axis) {
   // -x axis = option 2
   setAxisPropertyOption(2);
-  frame_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  frame_->update(zero, zero);
 
   checkCameraLooksAlong(Ogre::Vector3(-1, 0, 0));
 }
@@ -212,7 +216,8 @@ TEST_F(FrameViewControllerTestFixture,
 TEST_F(FrameViewControllerTestFixture, setting_axis_to_positive_y_points_camera_along_y_axis) {
   // +y axis = option 3
   setAxisPropertyOption(3);
-  frame_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  frame_->update(zero, zero);
 
   checkCameraLooksAlong(Ogre::Vector3(0, 1, 0));
 }
@@ -221,7 +226,8 @@ TEST_F(FrameViewControllerTestFixture,
   setting_axis_to_negative_y_points_camera_along_negative_y_axis) {
   // -y axis = option 4
   setAxisPropertyOption(4);
-  frame_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  frame_->update(zero, zero);
 
   checkCameraLooksAlong(Ogre::Vector3(0, -1, 0));
 }
@@ -229,7 +235,8 @@ TEST_F(FrameViewControllerTestFixture,
 TEST_F(FrameViewControllerTestFixture, setting_axis_to_positive_z_points_camera_along_z_axis) {
   // +z axis = option 5
   setAxisPropertyOption(5);
-  frame_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  frame_->update(zero, zero);
 
   checkCameraLooksAlong(Ogre::Vector3(0, 0, 1));
 }
@@ -238,7 +245,8 @@ TEST_F(FrameViewControllerTestFixture,
   setting_axis_to_negative_z_points_camera_along_negative_z_axis) {
   // -z axis = option 6
   setAxisPropertyOption(6);
-  frame_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  frame_->update(zero, zero);
 
   checkCameraLooksAlong(Ogre::Vector3(0, 0, -1));
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
@@ -76,7 +76,8 @@ public:
     auto pitch_property = orbit_->childAt(8);
     yaw_property->setValue(0);  // set to zero to make result easier to check
     pitch_property->setValue(0.5f);  // set to 0.5, because setting it to 0 can cause problems
-    orbit_->update(0, 0);
+    auto zero = std::chrono::nanoseconds::zero();
+    orbit_->update(zero, zero);
   }
 
   std::shared_ptr<rviz_default_plugins::view_controllers::OrbitViewController> orbit_;
@@ -172,10 +173,11 @@ TEST_F(
   old_yaw_property->setValue(0);
   old_pitch_property->setValue(0.5f);
   xy_orbit_view->move(10, 12, 0);
-  xy_orbit_view->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  xy_orbit_view->update(zero, zero);
 
   orbit_->mimic(xy_orbit_view.get());
-  orbit_->update(0, 0);
+  orbit_->update(zero, zero);
 
   auto yaw_property = orbit_->childAt(7);
   auto pitch_property = orbit_->childAt(8);
@@ -192,12 +194,13 @@ TEST_F(
   ortho_view->setClassId("rviz_default_plugins/TopDownOrtho");
   ortho_view->initialize(context_.get());
   ortho_view->move(10, 12);
-  // ortho_view->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  // ortho_view->update(zero, zero);
   auto old_x_value = ortho_view->childAt(6)->getValue().toFloat();
   auto old_y_value = ortho_view->childAt(7)->getValue().toFloat();
 
   orbit_->mimic(ortho_view.get());
-  orbit_->update(0, 0);
+  orbit_->update(zero, zero);
 
   auto yaw_property = orbit_->childAt(7);
   auto pitch_property = orbit_->childAt(8);
@@ -222,13 +225,14 @@ TEST_F(OrbitViewControllerTestFixture, mimic_does_not_move_camera_when_given_sam
   old_yaw_property->setValue(0);
   old_pitch_property->setValue(0.5f);
   old_orbit_view->move(10, 10, 10);
-  old_orbit_view->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  old_orbit_view->update(zero, zero);
   auto old_x_value = old_orbit_view->childAt(9)->childAt(0)->getValue().toFloat();
   auto old_y_value = old_orbit_view->childAt(9)->childAt(1)->getValue().toFloat();
   auto old_z_value = old_orbit_view->childAt(9)->childAt(2)->getValue().toFloat();
 
   orbit_->mimic(old_orbit_view.get());
-  orbit_->update(0, 0);
+  orbit_->update(zero, zero);
 
   auto x_property = orbit_->childAt(9)->childAt(0);
   auto y_property = orbit_->childAt(9)->childAt(1);

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
@@ -136,7 +136,8 @@ TEST_F(OrthoViewControllerTestFixture, moving_the_wheel_zooms) {
 TEST_F(OrthoViewControllerTestFixture, update_sets_camera_to_position_indicated_by_properties) {
   dragMouse(30, 30, 10, 10, Qt::MiddleButton);
 
-  ortho_view_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  ortho_view_->update(zero, zero);
 
   auto camera_parent = ortho_view_->getCamera()->getParentSceneNode();
   EXPECT_THAT(camera_parent->getPosition(), Vector3Eq(Ogre::Vector3(-2, 2, 500)));
@@ -151,7 +152,8 @@ TEST_F(
   orbit_view->move(10, 12, 1);
 
   ortho_view_->mimic(orbit_view.get());
-  ortho_view_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  ortho_view_->update(zero, zero);
 
   auto x_property = ortho_view_->childAt(6);
   EXPECT_THAT(x_property->getNameStd(), StrEq("X"));

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
@@ -74,7 +74,8 @@ public:
     auto pitch_property = xy_orbit_->childAt(8);
     yaw_property->setValue(0);  // set to zero to make result easier to check
     pitch_property->setValue(0.5f);  // set to 0.5, because setting it to 0 can cause problems
-    xy_orbit_->update(0, 0);
+    auto zero = std::chrono::nanoseconds::zero();
+    xy_orbit_->update(zero, zero);
   }
 
   std::shared_ptr<rviz_default_plugins::view_controllers::XYOrbitViewController> xy_orbit_;
@@ -161,7 +162,8 @@ TEST_F(XYOrbitViewControllerTestFixture, moving_the_focal_point_from_above_moves
   auto pitch_property = xy_orbit_->childAt(8);
   yaw_property->setValue(0);
   pitch_property->setValue(Ogre::Math::HALF_PI);  // set camera above view
-  xy_orbit_->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  xy_orbit_->update(zero, zero);
 
   auto x_property = xy_orbit_->childAt(9)->childAt(0);
   EXPECT_THAT(x_property->getNameStd(), StrEq("X"));
@@ -193,7 +195,8 @@ TEST_F(
   old_yaw_property->setValue(1);
   old_pitch_property->setValue(1);
   orbit_view->move(10, 12, 3);
-  orbit_view->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  orbit_view->update(zero, zero);
 
   auto new_orbit_view =
     std::make_shared<rviz_default_plugins::view_controllers::OrbitViewController>();
@@ -201,9 +204,9 @@ TEST_F(
   new_orbit_view->initialize(context_.get());
 
   xy_orbit_->mimic(orbit_view.get());
-  xy_orbit_->update(0, 0);
+  xy_orbit_->update(zero, zero);
   new_orbit_view->mimic(xy_orbit_.get());
-  new_orbit_view->update(0, 0);
+  new_orbit_view->update(zero, zero);
 
   auto new_yaw_value = new_orbit_view->childAt(7)->getValue().toFloat();
   auto new_pitch_value = new_orbit_view->childAt(8)->getValue().toFloat();
@@ -222,12 +225,13 @@ TEST_F(
   ortho_view->setClassId("rviz_default_plugins/TopDownOrtho");
   ortho_view->initialize(context_.get());
   ortho_view->move(10, 12);
-  // ortho_view->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  // ortho_view->update(zero, zero);
   auto old_x_value = ortho_view->childAt(6)->getValue().toFloat();
   auto old_y_value = ortho_view->childAt(7)->getValue().toFloat();
 
   xy_orbit_->mimic(ortho_view.get());
-  xy_orbit_->update(0, 0);
+  xy_orbit_->update(zero, zero);
 
   auto yaw_property = xy_orbit_->childAt(7);
   auto pitch_property = xy_orbit_->childAt(8);
@@ -253,13 +257,14 @@ TEST_F(
   auto old_pitch_property = old_orbit_view->childAt(8);
   old_yaw_property->setValue(0);
   old_pitch_property->setValue(0.5f);
-  old_orbit_view->update(0, 0);
+  auto zero = std::chrono::nanoseconds::zero();
+  old_orbit_view->update(zero, zero);
   auto old_x_value = old_orbit_view->childAt(9)->childAt(0)->getValue().toFloat();
   auto old_y_value = old_orbit_view->childAt(9)->childAt(1)->getValue().toFloat();
   auto old_z_value = old_orbit_view->childAt(9)->childAt(2)->getValue().toFloat();
 
   xy_orbit_->mimic(old_orbit_view.get());
-  xy_orbit_->update(0, 0);
+  xy_orbit_->update(zero, zero);
 
   auto x_property = xy_orbit_->childAt(9)->childAt(0);
   auto y_property = xy_orbit_->childAt(9)->childAt(1);


### PR DESCRIPTION
## Description

Uses `update(std::chrono...)` rather than the deprecated `update(float...)` in default plugins.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

