### PR TITLE
Fix pointcloud2 display divide by 0

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud2_display.cpp
@@ -105,7 +105,11 @@ sensor_msgs::msg::PointCloud2::ConstSharedPtr PointCloud2Display::filterOutInval
   filtered->header = cloud->header;
   filtered->fields = cloud->fields;
   filtered->height = 1;
-  filtered->width = static_cast<uint32_t>(filtered->data.size() / cloud->point_step);
+  if (cloud->point_step > 0) {
+    filtered->width = static_cast<uint32_t>(filtered->data.size() / cloud->point_step);
+  } else {
+    filtered->width = 0;
+  }
   filtered->is_bigendian = cloud->is_bigendian;
   filtered->point_step = cloud->point_step;
   filtered->row_step = filtered->width;


### PR DESCRIPTION
## Description
The PointCloud2 Display plugin can cause the RViz window to crash when attempting to divide by 0.
Reproduce the issue:

Publish a malformed PointCloud2 message, such as:
```
ros2 topic pub /my_pointcloud sensor_msgs/msg/PointCloud2 "header:
  stamp:
    sec: 0
    nanosec: 0
  frame_id: 'map'
height: 0
width: 0
fields:
- name: x
  offset: 0
  datatype: 7
  count: 1
- name: y
  offset: 4
  datatype: 7
  count: 1
- name: z
  offset: 8
  datatype: 7
  count: 1
is_bigendian: false
point_step: 0
row_step: 0
data: []
is_dense: false"
```

Add the visualization of the `/my_pointcloud` topic and the RViz window will crash:

> QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-user'
> [INFO] [1757678005.544487817] [rviz2]: Stereo is NOT SUPPORTED
> [INFO] [1757678005.544545221] [rviz2]: OpenGl version: 4.6 (GLSL 4.6)
> [INFO] [1757678005.559291965] [rviz2]: Stereo is NOT SUPPORTED
> Floating point exception (core dumped)

Here the full stack trace with valgrind

> ==12170== 
> ==12170== Process terminating with default action of signal 8 (SIGFPE): dumping core
> ==12170==  Integer divide by zero at address 0x1020F079F3
> ==12170==    at 0x40EC7B88: rviz_default_plugins::displays::PointCloud2Display::filterOutInvalidPoints(std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>) const (in /home/antoniobrandi/Workspaces/perception_ws/install/rviz_default_plugins/lib/librviz_default_plugins.so)
> ==12170==    by 0x40EC76F0: rviz_default_plugins::displays::PointCloud2Display::processMessage(std::shared_ptr<sensor_msgs::msg::PointCloud2_<std::allocator<void> > const>) (in /home/antoniobrandi/Workspaces/perception_ws/install/rviz_default_plugins/lib/librviz_default_plugins.so)
> ==12170==    by 0x40ECBA7D: rviz_common::MessageFilterDisplay<sensor_msgs::msg::PointCloud2_<std::allocator<void> > >::processTypeErasedMessage(std::shared_ptr<void const>) (in /home/antoniobrandi/Workspaces/perception_ws/install/rviz_default_plugins/lib/librviz_default_plugins.so)
> ==12170==    by 0x49019AF: ??? (in /opt/ros/humble/lib/librviz_common.so)
> ==12170==    by 0x53AB41D: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
> ==12170==    by 0x4B6F712: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
> ==12170==    by 0x537DE39: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
> ==12170==    by 0x5380F26: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
> ==12170==    by 0x53D7A66: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
> ==12170==    by 0x7096D3A: g_main_context_dispatch (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.4)
> ==12170==    by 0x70EC2B7: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.4)
> ==12170==    by 0x70943E2: g_main_context_iteration (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.4)
> ==12170== 
> ==12170== Events    : Ir
> ==12170== Collected : 8137795897
> ==12170== 
> ==12170== I   refs:      8,137,795,897
> [ros2run]: Floating point exception


Fixes # (issue)

### Is this user-facing behavior change?

### Did you use Generative AI?

No

### Additional Information
It might seem a corner case of the PointCloud2 message, but actually the message above was generated by the [perception_pcl](https://github.com/ros-perception/perception_pcl) package, using the [ExtractIndices](https://github.com/ros-perception/perception_pcl/blob/ros2/pcl_ros/include/pcl_ros/filters/extract_indices.hpp) filter. In fact, when the filtered PointCloud is empty, this filter will initialize the `fields` message anyway.

