### PR TITLE
fix crash(segmentation fault) in propertyHiddenChanged

### DIFF
--- a/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
@@ -103,7 +103,7 @@ void PropertyTreeWidget::setModel(PropertyTreeModel * model)
   if (model_) {
     connect(
       model_, SIGNAL(propertyHiddenChanged(const Property*)),
-      this, SLOT(propertyHiddenChanged(const Property*)), Qt::QueuedConnection);
+      this, SLOT(propertyHiddenChanged(const Property*)), Qt::DirectConnection);
     connect(
       model_, SIGNAL(expand(const QModelIndex&)),
       this, SLOT(expand(const QModelIndex&)));
@@ -119,12 +119,14 @@ void PropertyTreeWidget::setModel(PropertyTreeModel * model)
 void PropertyTreeWidget::propertyHiddenChanged(const Property * property)
 {
   if (model_) {
-    const auto & parent_index = model_->parentIndex(property);
-    if (parent_index.isValid()) {
-      setRowHidden(property->rowNumberInParent(), parent_index, property->getHidden());
-    } else {
-      printf("Trying to hide property '%s' that is not part of the model.\n",
-        qPrintable(property->getName()));
+    if (property->parent() != nullptr) {
+      const auto & parent_index = model_->parentIndex(property);
+      if (parent_index.isValid()) {
+        setRowHidden(property->rowNumberInParent(), parent_index, property->getHidden());
+      } else {
+        printf("Trying to hide property '%s' that is not part of the model.\n",
+          qPrintable(property->getName()));
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

RViz2 crashes with segmentation fault when reloading robot description (can be reproduce with rapidly toggling the RobotModel display on/off). The crash occurs in PropertyTreeWidget::propertyHiddenChanged()


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

This PR implements a two-part fix:

1. Change from `QueueConnection` to `DirectConnection` as suggested in https://github.com/ros2/rviz/pull/1033
2. Add safety check for Property validity to avoid accessing destroyed object


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
