### PR TITLE
Replace QRegExp with QRegularExpression to support Qt6

### DIFF
--- a/rviz_common/include/rviz_common/properties/ros_action_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_action_property.hpp
@@ -30,7 +30,7 @@
 #define RVIZ_COMMON__PROPERTIES__ROS_ACTION_PROPERTY_HPP_
 
 #include <QObject>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 
 #include <memory>
@@ -90,20 +90,20 @@ public:
     const QString & default_value = QString(),
     const QString & action_type = QString(),
     const QString & description = QString(),
-    const QRegExp & filter = QRegExp(),
+    const QRegularExpression & filter = QRegularExpression(),
     Property * parent = 0,
     const char * changed_slot = 0,
     QObject * receiver = 0);
 
   void enableFilter(bool enabled);
 
-  QRegExp filter() const;
+  QRegularExpression filter() const;
 
 protected Q_SLOTS:
   void fillActionList() override;
 
 private:
-  QRegExp filter_;
+  QRegularExpression filter_;
   bool filter_enabled_;
 };
 

--- a/rviz_common/include/rviz_common/properties/ros_service_property.hpp
+++ b/rviz_common/include/rviz_common/properties/ros_service_property.hpp
@@ -30,7 +30,7 @@
 #define RVIZ_COMMON__PROPERTIES__ROS_SERVICE_PROPERTY_HPP_
 
 #include <QObject>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 
 #include <memory>
@@ -90,20 +90,20 @@ public:
     const QString & default_value = QString(),
     const QString & service_type = QString(),
     const QString & description = QString(),
-    const QRegExp & filter = QRegExp(),
+    const QRegularExpression & filter = QRegularExpression(),
     Property * parent = 0,
     const char * changed_slot = 0,
     QObject * receiver = 0);
 
   void enableFilter(bool enabled);
 
-  QRegExp filter() const;
+  QRegularExpression filter() const;
 
 protected Q_SLOTS:
   void fillServiceList() override;
 
 private:
-  QRegExp filter_;
+  QRegularExpression filter_;
   bool filter_enabled_;
 };
 

--- a/rviz_common/src/rviz_common/properties/ros_action_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_action_property.cpp
@@ -34,7 +34,7 @@
 
 #include <QApplication>  // NOLINT: cpplint can't handle Qt imports
 #include <QObject>  // NOLINT: cpplint can't handle Qt imports
-#include <QRegExp>  // NOLINT: cpplint can't handle Qt imports
+#include <QRegularExpression>  // NOLINT: cpplint can't handle Qt imports
 #include <QString>  // NOLINT: cpplint can't handle Qt imports
 #include <QStringList>  // NOLINT: cpplint can't handle Qt imports
 
@@ -121,7 +121,7 @@ RosFilteredActionProperty::RosFilteredActionProperty(
   const QString & default_value,
   const QString & action_type,
   const QString & description,
-  const QRegExp & filter,
+  const QRegularExpression & filter,
   Property * parent,
   const char * changed_slot,
   QObject * receiver)
@@ -137,7 +137,7 @@ void RosFilteredActionProperty::enableFilter(bool enabled)
   fillActionList();
 }
 
-QRegExp RosFilteredActionProperty::filter() const
+QRegularExpression RosFilteredActionProperty::filter() const
 {
   return filter_;
 }

--- a/rviz_common/src/rviz_common/properties/ros_service_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_service_property.cpp
@@ -34,7 +34,7 @@
 
 #include <QApplication>  // NOLINT: cpplint can't handle Qt imports
 #include <QObject>  // NOLINT: cpplint can't handle Qt imports
-#include <QRegExp>  // NOLINT: cpplint can't handle Qt imports
+#include <QRegularExpression>  // NOLINT: cpplint can't handle Qt imports
 #include <QString>  // NOLINT: cpplint can't handle Qt imports
 #include <QStringList>  // NOLINT: cpplint can't handle Qt imports
 
@@ -119,7 +119,7 @@ RosFilteredServiceProperty::RosFilteredServiceProperty(
   const QString & default_value,
   const QString & service_type,
   const QString & description,
-  const QRegExp & filter,
+  const QRegularExpression & filter,
   Property * parent,
   const char * changed_slot,
   QObject * receiver)
@@ -135,7 +135,7 @@ void RosFilteredServiceProperty::enableFilter(bool enabled)
   fillServiceList();
 }
 
-QRegExp RosFilteredServiceProperty::filter() const
+QRegularExpression RosFilteredServiceProperty::filter() const
 {
   return filter_;
 }


### PR DESCRIPTION
## Description

#1548 and #1549 uses the syntax
```
#include <QRegExp>
```
which is deprecated in qt6, causing build failure

This PR replaces `QRegExp` with `QRegularExpression`, this is how it is handled in #1187 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
