### PR TITLE
Fix incorrect Qt signal connection in combo box

### DIFF
--- a/rviz_common/src/rviz_common/properties/editable_enum_property.cpp
+++ b/rviz_common/src/rviz_common/properties/editable_enum_property.cpp
@@ -79,11 +79,17 @@ QWidget * EditableEnumProperty::createEditor(QWidget * parent, const QStyleOptio
   EditableComboBox * cb = new EditableComboBox(parent);
   cb->addItems(strings_);
   cb->setEditText(getValue().toString() );
+  #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+  QObject::connect(
+    cb, SIGNAL(currentIndexChanged(const QString&)), this,
+    SLOT(setString(const QString&)));
+  #else
   QObject::connect(
     cb, &QComboBox::currentIndexChanged, this,
     [this, cb](int index) {
       this->setString(cb->itemText(index));
   });
+  #endif
 
   // TODO(unknown): need to better handle string value which is not in list.
   return cb;

--- a/rviz_common/src/rviz_common/properties/editable_enum_property.cpp
+++ b/rviz_common/src/rviz_common/properties/editable_enum_property.cpp
@@ -80,8 +80,10 @@ QWidget * EditableEnumProperty::createEditor(QWidget * parent, const QStyleOptio
   cb->addItems(strings_);
   cb->setEditText(getValue().toString() );
   QObject::connect(
-    cb, SIGNAL(currentIndexChanged(const QString&)), this,
-    SLOT(setString(const QString&)));
+    cb, &QComboBox::currentIndexChanged, this,
+    [this, cb](int index) {
+      this->setString(cb->itemText(index));
+  });
 
   // TODO(unknown): need to better handle string value which is not in list.
   return cb;

--- a/rviz_common/src/rviz_common/properties/enum_property.cpp
+++ b/rviz_common/src/rviz_common/properties/enum_property.cpp
@@ -90,8 +90,10 @@ QWidget * EnumProperty::createEditor(QWidget * parent, const QStyleOptionViewIte
   cb->addItems(strings_);
   cb->setCurrentIndex(strings_.indexOf(getValue().toString() ));
   QObject::connect(
-    cb, SIGNAL(currentIndexChanged(const QString&)), this,
-    SLOT(setString(const QString&)));
+    cb, &QComboBox::currentIndexChanged, this,
+    [this, cb](int index) {
+      this->setString(cb->itemText(index));
+  });
 
   // TODO(anyone): need to better handle string value which is not in list.
   return cb;

--- a/rviz_common/src/rviz_common/properties/enum_property.cpp
+++ b/rviz_common/src/rviz_common/properties/enum_property.cpp
@@ -89,11 +89,17 @@ QWidget * EnumProperty::createEditor(QWidget * parent, const QStyleOptionViewIte
   ComboBox * cb = new ComboBox(parent);
   cb->addItems(strings_);
   cb->setCurrentIndex(strings_.indexOf(getValue().toString() ));
+  #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+  QObject::connect(
+    cb, SIGNAL(currentIndexChanged(const QString&)), this,
+    SLOT(setString(const QString&)));
+  #else
   QObject::connect(
     cb, &QComboBox::currentIndexChanged, this,
     [this, cb](int index) {
       this->setString(cb->itemText(index));
   });
+  #endif
 
   // TODO(anyone): need to better handle string value which is not in list.
   return cb;


### PR DESCRIPTION
## Description

In Qt6, the signature `currentIndexChanged(const Qstring &)` is removed
<img width="477" height="267" alt="image" src="https://github.com/user-attachments/assets/9c259b1f-1260-43af-8598-5a9ca702f37a" />

Thus, when clicking on combo box, I am seeing
```
qt.core.qobject.connect: QObject::connect: No such signal rviz_common::properties::EditableComboBox::currentIndexChanged(const QString&)
qt.core.qobject.connect: QObject::connect:  (receiver name: 'Fixed Frame')
```

In fact, it is also suggested to use `currentIndexChanged(int)` in Qt 5.15 docs https://doc.qt.io/archives/qt-5.15/qcombobox-obsolete.html#currentIndexChanged-1

This PR fixes the above issue

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
