### PR TITLE
Removed support for yaml-cpp lower than 0.5

### DIFF
--- a/rviz_common/src/rviz_common/yaml_config_reader.cpp
+++ b/rviz_common/src/rviz_common/yaml_config_reader.cpp
@@ -31,13 +31,13 @@
 
 #include "rviz_common/yaml_config_reader.hpp"
 
+#include <yaml-cpp/yaml.h>
+
 #include <fstream>
 #include <sstream>
 #include <string>
 
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
-
-#include <yaml-cpp/yaml.h>
 
 namespace rviz_common
 {
@@ -78,8 +78,7 @@ void YamlConfigReader::readYamlNode(Config & config, const YAML::Node & yaml_nod
   switch (yaml_node.Type() ) {
     case YAML::NodeType::Map:
       {
-        for (YAML::const_iterator it = yaml_node.begin(); it != yaml_node.end(); ++it)
-        {
+        for (YAML::const_iterator it = yaml_node.begin(); it != yaml_node.end(); ++it) {
           std::string key;
           key = it->first.as<std::string>();
           Config child = config.mapMakeChild(QString::fromStdString(key));
@@ -89,8 +88,7 @@ void YamlConfigReader::readYamlNode(Config & config, const YAML::Node & yaml_nod
       }
     case YAML::NodeType::Sequence:
       {
-        for (YAML::const_iterator it = yaml_node.begin(); it != yaml_node.end(); ++it)
-        {
+        for (YAML::const_iterator it = yaml_node.begin(); it != yaml_node.end(); ++it) {
           Config child = config.listAppendNew();
           readYamlNode(child, *it);
         }

--- a/rviz_common/src/rviz_common/yaml_config_reader.cpp
+++ b/rviz_common/src/rviz_common/yaml_config_reader.cpp
@@ -37,15 +37,7 @@
 
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
-// TODO(wjwwood): consider restoring support for yamlcpp < 0.5, force 0.5 for now
-#define RVIZ_HAVE_YAMLCPP_05 1
-
-#ifdef RVIZ_HAVE_YAMLCPP_05
 #include <yaml-cpp/yaml.h>
-#else
-#include <yaml-cpp/node.h>
-#include <yaml-cpp/parser.h>
-#endif
 
 namespace rviz_common
 {
@@ -71,12 +63,7 @@ void YamlConfigReader::readStream(Config & config, std::istream & in, const QStr
   (void) filename;
   try {
     YAML::Node yaml_node;
-#ifdef RVIZ_HAVE_YAMLCPP_05
     yaml_node = YAML::Load(in);
-#else
-    YAML::Parser parser(in);
-    parser.GetNextDocument(yaml_node);
-#endif
     error_ = false;
     message_ = "";
     readYamlNode(config, yaml_node);
@@ -91,34 +78,18 @@ void YamlConfigReader::readYamlNode(Config & config, const YAML::Node & yaml_nod
   switch (yaml_node.Type() ) {
     case YAML::NodeType::Map:
       {
-#ifdef RVIZ_HAVE_YAMLCPP_05
         for (YAML::const_iterator it = yaml_node.begin(); it != yaml_node.end(); ++it)
-#else
-        for (YAML::Iterator it = yaml_node.begin(); it != yaml_node.end(); ++it)
-#endif
         {
           std::string key;
-#ifdef RVIZ_HAVE_YAMLCPP_05
           key = it->first.as<std::string>();
-#else
-          it.first() >> key;
-#endif
           Config child = config.mapMakeChild(QString::fromStdString(key));
-#ifdef RVIZ_HAVE_YAMLCPP_05
           readYamlNode(child, it->second);
-#else
-          readYamlNode(child, it.second() );
-#endif
         }
         break;
       }
     case YAML::NodeType::Sequence:
       {
-#ifdef RVIZ_HAVE_YAMLCPP_05
         for (YAML::const_iterator it = yaml_node.begin(); it != yaml_node.end(); ++it)
-#else
-        for (YAML::Iterator it = yaml_node.begin(); it != yaml_node.end(); ++it)
-#endif
         {
           Config child = config.listAppendNew();
           readYamlNode(child, *it);
@@ -128,11 +99,7 @@ void YamlConfigReader::readYamlNode(Config & config, const YAML::Node & yaml_nod
     case YAML::NodeType::Scalar:
       {
         std::string s;
-#ifdef RVIZ_HAVE_YAMLCPP_05
         s = yaml_node.as<std::string>();
-#else
-        yaml_node >> s;
-#endif
         config.setValue(QString::fromStdString(s));
         break;
       }


### PR DESCRIPTION
pixi and debians install yamp-cpp bigger than 0.5, also the define is hardcoded. It's better to remove this