### PR TITLE
Feature: Load config service

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -44,6 +44,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(resource_retriever REQUIRED)
+find_package(rviz_resource_interfaces REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -260,6 +261,7 @@ target_link_libraries(rviz_common PUBLIC
   tf2::tf2
   tf2_ros::tf2_ros
   yaml-cpp::yaml-cpp
+  ${rviz_resource_interfaces_TARGETS}
 )
 
 target_link_libraries(rviz_common PRIVATE
@@ -286,6 +288,7 @@ ament_export_dependencies(
   tf2_ros
   yaml_cpp_vendor
   yaml-cpp
+  rviz_resource_interfaces
 )
 
 # Export old-style CMake variables

--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -36,19 +36,20 @@
 #include <chrono>
 #include <deque>
 #include <map>
+#include <memory>
 #include <string>
 
 #include <QList>  // NOLINT: cpplint is unable to handle the include order here
 #include <QMainWindow>  // NOLINT: cpplint is unable to handle the include order here
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <Qt>  // NOLINT: cpplint is unable to handle the include order here
-#include <rclcpp/service.hpp>
-#include <rviz_resource_interfaces/srv/load_config.hpp>
 
+#include <rclcpp/service.hpp>
 #include "rviz_common/config.hpp"
-#include "rviz_rendering/render_window.hpp"
 #include "rviz_common/window_manager_interface.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
+#include "rviz_rendering/render_window.hpp"
+#include <rviz_resource_interfaces/srv/load_config.hpp>
 
 class QAction;
 class QActionGroup;
@@ -182,9 +183,9 @@ public:
     const std::shared_ptr<LoadConfig::Request> request,
     std::shared_ptr<LoadConfig::Response> response);
 
-  /// Load display settings from the given file.
+  /// Load display settings from the configuration string.
   /**
-   * \param path The full path of the config file to load from.
+   * \param config_string Can be path to the config file to load from or a yaml configuration string.
    */
   void
   loadDisplayConfig(const QString & config_string);

--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -177,7 +177,7 @@ public:
    * \param path The full path of the config file to load from.
    */
   void
-  loadDisplayConfig(const QString & path);
+  loadDisplayConfig(const QString & config_string);
 
   // TODO(wjwwood): consider changing this function to raise an exception
   //                when there is a failure, rather than the getErrorMessage()

--- a/rviz_common/include/rviz_common/visualization_frame.hpp
+++ b/rviz_common/include/rviz_common/visualization_frame.hpp
@@ -42,6 +42,8 @@
 #include <QMainWindow>  // NOLINT: cpplint is unable to handle the include order here
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <Qt>  // NOLINT: cpplint is unable to handle the include order here
+#include <rclcpp/service.hpp>
+#include <rviz_resource_interfaces/srv/load_config.hpp>
 
 #include "rviz_common/config.hpp"
 #include "rviz_rendering/render_window.hpp"
@@ -83,6 +85,7 @@ class WidgetGeometryChangeDetector;
  */
 class RVIZ_COMMON_PUBLIC VisualizationFrame : public QMainWindow, public WindowManagerInterface
 {
+  using LoadConfig = rviz_resource_interfaces::srv::LoadConfig;
   Q_OBJECT
 
 public:
@@ -171,6 +174,13 @@ public:
    */
   void
   savePersistentSettings();
+
+  rclcpp::Service<LoadConfig>::SharedPtr load_config_service_;
+
+  void
+  loadDisplayConfigService(
+    const std::shared_ptr<LoadConfig::Request> request,
+    std::shared_ptr<LoadConfig::Response> response);
 
   /// Load display settings from the given file.
   /**

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -41,6 +41,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>resource_retriever</depend>
+  <depend>rviz_resource_interfaces</depend>
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>
   <depend>sensor_msgs</depend>

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -670,14 +670,16 @@ void VisualizationFrame::markRecentConfig(const std::string & path)
   updateRecentConfigMenu();
 }
 
-void VisualizationFrame::loadDisplayConfig(const QString & qpath)
+void VisualizationFrame::loadDisplayConfig(const QString & config_string)
 {
-  std::string path = qpath.toStdString();
-  QFileInfo path_info(qpath);
+  std::string path = config_string.toStdString();
+  QFileInfo path_info(config_string);
   std::string actual_load_path = path;
-  if (!path_info.exists() || path_info.isDir()) {
+  bool is_loadable_path = (path_info.exists() && !path_info.isDir());
+  if (!is_loadable_path) {
     actual_load_path = package_path_ + "/default.rviz";
-    if (!QFile(QString::fromStdString(actual_load_path)).exists()) {
+    is_loadable_path = QFile(QString::fromStdString(actual_load_path)).exists();
+    if (!is_loadable_path) {
       RVIZ_COMMON_LOG_ERROR_STREAM(
         "Default display config '" <<
           actual_load_path.c_str() << "' not found.  RViz will be very empty at first.");
@@ -705,7 +707,12 @@ void VisualizationFrame::loadDisplayConfig(const QString & qpath)
 
   YamlConfigReader reader;
   Config config;
+  if (is_loadable_path) {
   reader.readFile(config, QString::fromStdString(actual_load_path));
+  } else { // Treat as yaml string content
+    reader.readString(config, config_string);
+  }
+
   if (!reader.error()) {
     try {
       load(config);
@@ -714,11 +721,11 @@ void VisualizationFrame::loadDisplayConfig(const QString & qpath)
     }
   }
 
+  if (is_loadable_path) {
   markRecentConfig(path);
-
   setDisplayConfigFile(path);
-
   last_config_dir_ = path_info.absolutePath().toStdString();
+  }
 
   post_load_timer_->start(1000);
 }

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -61,10 +61,9 @@
 #include <QTimer>  // NOLINT cpplint cannot handle include order here
 #include <QToolBar>  // NOLINT cpplint cannot handle include order here
 #include <QToolButton>  // NOLINT cpplint cannot handle include order here
-#include <rclcpp/service.hpp>
-#include <rviz_resource_interfaces/srv/load_config.hpp>
 
 #include "rclcpp/clock.hpp"
+#include <rclcpp/service.hpp>
 #include "tf2_ros/buffer.hpp"
 #include "tf2_ros/transform_listener.hpp"
 
@@ -77,6 +76,7 @@
 #include "rviz_common/yaml_config_reader.hpp"
 #include "rviz_common/yaml_config_writer.hpp"
 #include "rviz_rendering/render_window.hpp"
+#include <rviz_resource_interfaces/srv/load_config.hpp>
 
 #include "./env_config.hpp"
 #include "./failed_panel.hpp"

--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -61,6 +61,8 @@
 #include <QTimer>  // NOLINT cpplint cannot handle include order here
 #include <QToolBar>  // NOLINT cpplint cannot handle include order here
 #include <QToolButton>  // NOLINT cpplint cannot handle include order here
+#include <rclcpp/service.hpp>
+#include <rviz_resource_interfaces/srv/load_config.hpp>
 
 #include "rclcpp/clock.hpp"
 #include "tf2_ros/buffer.hpp"
@@ -350,6 +352,14 @@ void VisualizationFrame::initialize(
   } else {
     loadDisplayConfig(QString::fromStdString(default_display_config_file_));
   }
+
+  auto node_abstraction = rviz_ros_node.lock();
+  auto node = node_abstraction->get_raw_node();
+  load_config_service_ = node->create_service<LoadConfig>(
+    node_abstraction->get_node_name() + "/load_config",
+    std::bind(
+      &VisualizationFrame::loadDisplayConfigService, this,
+      std::placeholders::_1, std::placeholders::_2));
 
   // Periodically process events for the splash screen.
   QCoreApplication::processEvents();
@@ -670,6 +680,18 @@ void VisualizationFrame::markRecentConfig(const std::string & path)
   updateRecentConfigMenu();
 }
 
+void VisualizationFrame::loadDisplayConfigService(
+  const std::shared_ptr<LoadConfig::Request> request,
+  std::shared_ptr<LoadConfig::Response> response)
+{
+  RVIZ_COMMON_LOG_INFO_STREAM(
+    "Requested loadConfig" << request->config_string.c_str()
+  );
+  loadDisplayConfig(QString::fromStdString(request->config_string));
+  response->success = true;
+  response->message = "Loaded display config.";
+}
+
 void VisualizationFrame::loadDisplayConfig(const QString & config_string)
 {
   std::string path = config_string.toStdString();
@@ -708,7 +730,7 @@ void VisualizationFrame::loadDisplayConfig(const QString & config_string)
   YamlConfigReader reader;
   Config config;
   if (is_loadable_path) {
-  reader.readFile(config, QString::fromStdString(actual_load_path));
+    reader.readFile(config, QString::fromStdString(actual_load_path));
   } else { // Treat as yaml string content
     reader.readString(config, config_string);
   }
@@ -722,9 +744,9 @@ void VisualizationFrame::loadDisplayConfig(const QString & config_string)
   }
 
   if (is_loadable_path) {
-  markRecentConfig(path);
-  setDisplayConfigFile(path);
-  last_config_dir_ = path_info.absolutePath().toStdString();
+    markRecentConfig(path);
+    setDisplayConfigFile(path);
+    last_config_dir_ = path_info.absolutePath().toStdString();
   }
 
   post_load_timer_->start(1000);

--- a/rviz_resource_interfaces/CMakeLists.txt
+++ b/rviz_resource_interfaces/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetResource.srv"
+  "srv/LoadConfig.srv"
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/rviz_resource_interfaces/srv/LoadConfig.srv
+++ b/rviz_resource_interfaces/srv/LoadConfig.srv
@@ -1,0 +1,4 @@
+string config_string
+---
+bool success
+string message


### PR DESCRIPTION
## Description

These changes implement the feature requested in https://github.com/ros2/rviz/issues/1594, by creating the service when the visualization frame is initialized.

Changes:
* Refactored `loadDisplayConfig` which now receives a string that can be a path to a configuration file or the configuration yaml string
* Created new service file in rviz_resource_interfaces that receives a config_string as a request and responds with a trigger (success and message). The service callback just calls `loadDisplayConfig`
* rviz_common now depends on `rviz_resource_interfaces`