### PR TITLE
Overcome 16384 size limit

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/map/map_display.cpp
@@ -446,6 +446,12 @@ void MapDisplay::createSwatches()
         width << " x " << height << " using " << number_swatches << " swatches");
     swatches_.clear();
     try {
+      // OpenGL size limit is 16384x16384
+      // TODO(Guillaume): find a cleaner way and autodetect size limit
+      if (swatch_width > 16384 || swatch_height > 16384) {
+        doubleSwatchNumber(swatch_width, swatch_height, number_swatches);
+        continue;
+      }
       tryCreateSwatches(width, height, resolution, swatch_width, swatch_height, number_swatches);
       updateDrawUnder();
       return;

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/map/map_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/map/map_display_test.cpp
@@ -210,5 +210,5 @@ TEST_F(MapTestFixture, createSwatches_creates_more_swatches_if_map_is_too_big) {
   auto manual_objects = rviz_default_plugins::findAllOgreObjectByType<Ogre::ManualObject>(
     scene_manager_->getRootSceneNode(), "ManualObject");
 
-  EXPECT_THAT(manual_objects, SizeIs(2));
+  EXPECT_THAT(manual_objects, SizeIs(8));
 }


### PR DESCRIPTION
## Description

Rebase of https://github.com/ros2/rviz/pull/1535 to target `rolling`

When trying to display a map (OccupancyGrid) with an edge greater than 16384, the map displayed is empty.
It seems that the texture rendering fails silently. That specific limit is the OpenGL texture size limit on my machine.
This draft PR it by doubling the Swatch number in that case.
Potential better/proper fix would be to query the system texture size limit.
Any ideas on how to best do that (and multi-platform/arch)?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
