### PR TITLE
Fix Translation Issue in XYOrbitViewController

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
@@ -78,6 +78,9 @@ public:
    */
   void mimic(ViewController * source_view) override;
 
+  //Override to handle motion in XY plane, with proper mouse position access
+  void handleMouseEvent(rviz_common::ViewportMouseEvent & event) override;
+
 protected:
   void updateCamera() override;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
@@ -78,7 +78,7 @@ public:
    */
   void mimic(ViewController * source_view) override;
 
-  //Override to handle motion in XY plane, with proper mouse position access
+  // Override to handle motion in XY plane, with proper mouse position access
   void handleMouseEvent(rviz_common::ViewportMouseEvent & event) override;
 
 protected:

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
@@ -210,11 +210,11 @@ void XYOrbitViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & e
     bool moved = OrbitViewController::setMouseMovementFromEvent(event, diff_x, diff_y);
     if (moved && (event.type == QEvent::MouseMove)) {
       float distance = distance_property_->getFloat();
-      //Pass the last mouse position to maintain consistent motion
+      // Pass the last mouse position to maintain consistent motion
       moveFocalPoint(distance, diff_x, diff_y, event.last_x, event.last_y);
       context_->queueRender();
       return;
-    } 
+    }
   }
   // For other mouse events, delegate to the base class
   OrbitViewController::handleMouseEvent(event);

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
@@ -201,6 +201,25 @@ void XYOrbitViewController::handleWheelEvent(
   zoom(diff * 0.001f * distance);
 }
 
+void XYOrbitViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)
+{
+  // Handle XY movement with proper mouse position access
+  if (event.middle() || (event.shift() && event.left())) {
+    int32_t diff_x = 0;
+    int32_t diff_y = 0;
+    bool moved = OrbitViewController::setMouseMovementFromEvent(event, diff_x, diff_y);
+    if (moved && (event.type == QEvent::MouseMove)) {
+      float distance = distance_property_->getFloat();
+      //Pass the last mouse position to maintain consistent motion
+      moveFocalPoint(distance, diff_x, diff_y, event.last_x, event.last_y);
+      context_->queueRender();
+      return;
+    } 
+  }
+  // For other mouse events, delegate to the base class
+  OrbitViewController::handleMouseEvent(event);
+}
+
 }  // namespace view_controllers
 }  // namespace rviz_default_plugins
 

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
@@ -30,6 +30,7 @@
 
 #include <gmock/gmock.h>
 
+#include <cmath>
 #include <memory>
 
 #include <QApplication>  // NOLINT cpplint cannot handle include order
@@ -59,6 +60,7 @@ public:
     xy_orbit_ = std::make_shared<rviz_default_plugins::view_controllers::XYOrbitViewController>();
     xy_orbit_->initialize(context_.get());
     testing_environment_->createOgreRenderWindow()->addViewport(xy_orbit_->getCamera());
+    setOSIndependentDimensions(xy_orbit_->getCamera()->getViewport(), 100, 100);
   }
 
   void dragMouse(
@@ -276,6 +278,34 @@ TEST_F(
   EXPECT_THAT(z_property->getValue().toFloat(), FloatNear(old_z_value, 0.001f));
   EXPECT_THAT(yaw_property->getValue().toFloat(), FloatNear(0, 0.001f));
   EXPECT_THAT(pitch_property->getValue().toFloat(), FloatNear(0.5f, 0.001f));
+}
+
+TEST_F(
+  XYOrbitViewControllerTestFixture,
+  focal_point_moves_proportionally_with_mouse_drag)
+{
+  setCameraToDefaultYawPitch();
+  
+  auto x_property = xy_orbit_->childAt(9)->childAt(0);
+  auto y_property = xy_orbit_->childAt(9)->childAt(1);
+  auto z_property = xy_orbit_->childAt(9)->childAt(2);
+  
+  EXPECT_THAT(x_property->getValue().toFloat(), FloatNear(0.0f, 0.001f));
+  EXPECT_THAT(y_property->getValue().toFloat(), FloatNear(0.0f, 0.001f));
+  EXPECT_THAT(z_property->getValue().toFloat(), FloatNear(0.0f, 0.001f));
+
+  dragMouse(30, 30, 10, 10, Qt::LeftButton, Qt::ShiftModifier);
+
+  float new_x = x_property->getValue().toFloat();
+  float new_y = y_property->getValue().toFloat();
+  float new_z = z_property->getValue().toFloat();
+
+  EXPECT_THAT(new_z, FloatNear(0.0f, 0.001f));
+  EXPECT_THAT(new_x, Not(FloatNear(0.0f, 0.001f)));
+  EXPECT_THAT(new_y, Not(FloatNear(0.0f, 0.001f)));
+  
+  float motion_magnitude = std::sqrt(new_x * new_x + new_y * new_y);
+  EXPECT_THAT(motion_magnitude, Le(1.1f));
 }
 
 int main(int argc, char ** argv)

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
@@ -285,11 +285,11 @@ TEST_F(
   focal_point_moves_proportionally_with_mouse_drag)
 {
   setCameraToDefaultYawPitch();
-  
+
   auto x_property = xy_orbit_->childAt(9)->childAt(0);
   auto y_property = xy_orbit_->childAt(9)->childAt(1);
   auto z_property = xy_orbit_->childAt(9)->childAt(2);
-  
+
   EXPECT_THAT(x_property->getValue().toFloat(), FloatNear(0.0f, 0.001f));
   EXPECT_THAT(y_property->getValue().toFloat(), FloatNear(0.0f, 0.001f));
   EXPECT_THAT(z_property->getValue().toFloat(), FloatNear(0.0f, 0.001f));
@@ -303,7 +303,7 @@ TEST_F(
   EXPECT_THAT(new_z, FloatNear(0.0f, 0.001f));
   EXPECT_THAT(new_x, Not(FloatNear(0.0f, 0.001f)));
   EXPECT_THAT(new_y, Not(FloatNear(0.0f, 0.001f)));
-  
+
   float motion_magnitude = std::sqrt(new_x * new_x + new_y * new_y);
   EXPECT_THAT(motion_magnitude, Le(1.1f));
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1617 

### Is this user-facing behavior change?

Yes, XY Orbit translation at steep camera angles is fixed

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Test was generated using Cursor (Sonnet 4.5)

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->


https://github.com/user-attachments/assets/ca6e28ee-bafc-4bdf-8e87-2ce5ff4a3480


