### PR TITLE
Fix crash with no tools

### DIFF
--- a/rviz_common/src/rviz_common/tool_manager.cpp
+++ b/rviz_common/src/rviz_common/tool_manager.cpp
@@ -175,7 +175,7 @@ int ToolManager::handleChar(QKeyEvent * event, RenderPanel * panel)
         setCurrentTool(tool);
       }
     }
-  } else {
+  } else if (current_tool_) {
     // if the incoming key triggers no other tool,
     // just hand down the key event
     flags = current_tool_->processKeyEvent(event, panel);


### PR DESCRIPTION
## Description

If there are no tools defined in an RViz configuration, pressing any key will crash all of RViz. 

### Is this user-facing behavior change?

Yes, resulting in fewer crashes. 

### Did you use Generative AI?

No

### Additional Information

To test, use an RViz config that is just an empty dictionary:
```yaml
{}
```
and press any key. 