### PR TITLE
Add CameraInfo topic property to DepthCloudDisplay

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
@@ -172,6 +172,7 @@ protected:
   rviz_common::properties::FloatProperty * auto_size_factor_property_;
   rviz_common::properties::RosFilteredTopicProperty * depth_topic_property_;
   rviz_common::properties::EnumProperty * depth_transport_property_;
+  rviz_common::properties::RosFilteredTopicProperty * camera_info_topic_property_;
   rviz_common::properties::RosFilteredTopicProperty * color_topic_property_;
   rviz_common::properties::EnumProperty * color_transport_property_;
   rviz_common::properties::BoolProperty * use_occlusion_compensation_property_;


### PR DESCRIPTION
## Description
This PR adds the ability to see and change the topic for the CameraInfo in the DepthCloudDisplay.

### Is this user-facing behavior change?
By default nothing will change for the user, except that the automatically selected CameraInfo topic will be displayed. The user can then change the topic if necessary. 

### Did you use Generative AI?
No.

### Additional Information
