### PR TITLE
Fix FrameView/FrameAligned Controller to track orientation of the frame

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/frame/frame_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/frame/frame_view_controller.hpp
@@ -69,9 +69,9 @@ public:
 
   void reset() override;
 
-  void yaw(float angle);
+  void resetOrientation();
 
-  void pitch(float angle);
+  void update(float dt, float ros_dt) override;
 
 protected:
   void onTargetFrameChanged(

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/frame/frame_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/frame/frame_view_controller.cpp
@@ -59,6 +59,15 @@ inline QString fmtAxis(int i)
   return QString("%1%2 axis").arg(QChar(i % 2 ? '+' : '-')).arg(QChar('x' + (i - 1) / 2));
 }
 
+inline Ogre::Vector3 getAxis(int option)
+{
+    Ogre::Vector3 axis(0, 0, 0);
+    if (option >= 1 && option <= 6) {
+        axis[(option - 1) / 2] = (option % 2) ? +1 : -1;
+    }
+    return axis;
+}
+
 static const Ogre::Quaternion ROBOT_TO_CAMERA_ROTATION =
   Ogre::Quaternion(Ogre::Radian(-Ogre::Math::HALF_PI), Ogre::Vector3::UNIT_Y) *
   Ogre::Quaternion(Ogre::Radian(-Ogre::Math::HALF_PI), Ogre::Vector3::UNIT_Z);
@@ -83,6 +92,7 @@ FrameViewController::FrameViewController()
 void FrameViewController::onInitialize()
 {
   FPSViewController::onInitialize();
+  invert_z_->show();
   changedAxis();
 }
 
@@ -118,7 +128,7 @@ void FrameViewController::setAxisFromCamera()
 void FrameViewController::changedAxis()
 {
   rememberAxis(axis_property_->getOptionInt());
-  reset();
+  resetOrientation();
 }
 
 inline void FrameViewController::rememberAxis(int current)
@@ -131,20 +141,40 @@ inline void FrameViewController::rememberAxis(int current)
 void FrameViewController::reset()
 {
   camera_scene_node_->setPosition(Ogre::Vector3::ZERO);
-  Ogre::Vector3 axis(0, 0, 0);
+  resetOrientation();
+}
+
+void FrameViewController::resetOrientation()
+{
   int option = previous_axis_;
-  if (option >= 1 && option <= 6) {
-    axis[(option - 1) / 2] = (option % 2) ? +1 : -1;
-    Ogre::Quaternion q;
-    if (option == 2) {  // special case for the -X axis
-      // Create a rotation of 180 degrees around the Z axis
-      q = Ogre::Quaternion(Ogre::Radian(Ogre::Math::PI), Ogre::Vector3::UNIT_Z);
-    } else {
-      q = Ogre::Vector3::UNIT_X.getRotationTo(axis);
-    }
-    camera_scene_node_->setOrientation(q * ROBOT_TO_CAMERA_ROTATION);
+  Ogre::Quaternion q;
+  if (option == 2) {  // special case for the -X axis
+    // Create a rotation of 180 degrees around the Z axis
+    q = Ogre::Quaternion(Ogre::Radian(Ogre::Math::PI), Ogre::Vector3::UNIT_Z);
+  } else {
+    Ogre::Vector3 axis = getAxis(option);
+    q = Ogre::Vector3::UNIT_X.getRotationTo(axis);
   }
+  camera_scene_node_->setOrientation(q * ROBOT_TO_CAMERA_ROTATION);
   setPropertiesFromCamera(camera_);
+}
+
+void FrameViewController::update(float dt, float ros_dt)
+{
+  FPSViewController::update(dt, ros_dt);
+
+  // continuously track the orientation of the reference frame
+  if (getNewTransform()) {
+    Ogre::Quaternion quat = reference_orientation_;
+
+    // use "z inversion" to switch to flipped frame around current axis
+    if (invert_z_->getBool()) {
+      Ogre::Vector3 axis = getAxis(previous_axis_);
+      quat = quat * Ogre::Quaternion(Ogre::Radian(Ogre::Math::PI), axis);
+    }
+
+    target_scene_node_->setOrientation(quat);
+  }
 }
 
 void FrameViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)


### PR DESCRIPTION
The backported camera in pull request #1453 did not implement the name-giving feature of the frame-aligned camera, to remain aligned with the frame as it rotates.

1) I have recovered this feature from the ROS1 implementation. Camera now rotates with the (moving) frame).

2) I have also fixed the "Invert Z Axis" feature for the frame-aligned view. 

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Fixes #1320 

### Is this user-facing behavior change?

1) The camera stays aligned with the active frame.

2) The "Invert Z Axis" property does technically not flip the Z axis, but always the vertical axis seen from the aligned camera view to the active axis. I.e., 
if +x/-x axis is selected, the z axis is flipped (rotation by 180deg about the x axis).
if +y/-y axis is selected, the z axis is flipped (rotation by 180deg about the y axis).
if +z/-z axis is selected, the x axis is flipped (rotation by 180deg about the z axis).

### Did you use Generative AI?

No AI used.

### Additional Information

Note that, on my ROS Humble, the "Invert Z Axis" property is shown in FPS View, even if it is hidden [here](https://github.com/ros2/rviz/blob/8cd1f498adf1ff63d1a3fb442e5513fd48ab54da/rviz_default_plugins/src/rviz_default_plugins/view_controllers/fps/fps_view_controller.cpp#L85). I don't know why. 

I have therefore [used the "show()" method](https://github.com/jowaibel/rviz/blob/b3194488b1702fb3676b08ef2a438115e69b6e54/rviz_default_plugins/src/rviz_default_plugins/view_controllers/frame/frame_view_controller.cpp#L95) in the child class FrameAligned/FrameView.
