### PR TITLE
FPS view controller looks at reference frame instead of global origin

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/fps/fps_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/fps/fps_view_controller.cpp
@@ -87,15 +87,15 @@ void FPSViewController::onInitialize()
 
 void FPSViewController::reset()
 {
-  camera_scene_node_->setPosition(DEFAULT_FPS_POSITION);
-  camera_scene_node_->lookAt(Ogre::Vector3::ZERO, Ogre::Node::TransformSpace::TS_WORLD);
+  camera_scene_node_->setPosition(reference_position_ + DEFAULT_FPS_POSITION);
+  camera_scene_node_->lookAt(Ogre::Vector3::ZERO, Ogre::Node::TransformSpace::TS_LOCAL);
   setPropertiesFromCamera(camera_);
 
   // The following is necessary due to gimbal lock and/or fixed axis problems of yaw/pitch axis.
   // This happens for instance when changing from the TopDownOrthoViewController to
   // FPSViewController.
   updateCamera();
-  camera_scene_node_->lookAt(Ogre::Vector3::ZERO, Ogre::Node::TransformSpace::TS_WORLD);
+  camera_scene_node_->lookAt(Ogre::Vector3::ZERO, Ogre::Node::TransformSpace::TS_LOCAL);
   setPropertiesFromCamera(camera_);
 }
 


### PR DESCRIPTION
## Description

I suggest the FPS view should look at the local origin of the active frame, not at the global origin. This is more practical for the user.

### Is this user-facing behavior change?

FPS View looks at currently active frame when getting active/reset.

### Did you use Generative AI?

No AI.

### Additional Information

-