### PR TITLE
use QPointer in QTimer::singleShot to prevent use-after-free

### DIFF
--- a/rviz_common/src/rviz_common/properties/property.cpp
+++ b/rviz_common/src/rviz_common/properties/property.cpp
@@ -38,6 +38,7 @@
 #include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
 #include <QPalette>  // NOLINT: cpplint is unable to handle the include order here
 #include <QLineEdit>  // NOLINT: cpplint is unable to handle the include order here
+#include <QPointer>  // NOLINT: cpplint is unable to handle the include order here
 #include <QSpinBox>  // NOLINT: cpplint is unable to handle the include order here
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTimer>  // NOLINT: cpplint is unable to handle the include order here
@@ -387,10 +388,12 @@ void Property::setModel(PropertyTreeModel * model)
 {
   model_ = model;
   if (model_ && hidden_) {
-    // process propertyHiddenChanged after insertion into model has finishedAdd commentMore actions
-    QTimer::singleShot(0, model_, [this]() {
-        if (model_) {
-          model_->emitPropertyHiddenChanged(this);
+    // process propertyHiddenChanged after insertion into model has finished
+    // Use QPointer to track Property lifetime and avoid use-after-free
+    QPointer<Property> self = this;
+    QTimer::singleShot(0, model_, [self]() {
+        if (self && self->model_) {
+          self->model_->emitPropertyHiddenChanged(self);
         }
     });
   }


### PR DESCRIPTION
## Description

The `QTimer::singleShot` in `Property::setModel` used `model_` as context but captured `this`. If the Property was destroyed before the timer fired, this caused a use-after-free crash in the propertyHiddenChanged signal emission.

Fix by capturing QPointer guarding 'this' instead of raw pointer. Semantic stays the same - Qt automatically cancels the timer if the model_ is destroyed but QPointer on Property provides extra protection.

The bug manifests as a crash in MoveIt Setup Assistant when loading robot models - crashing in `PropertyTreeModel::propertyHiddenChanged()`, some relevant issues in MoveIt2 Setup Assistant are linked:

- [3546](https://github.com/moveit/moveit2/issues/3546)
- [3553](https://github.com/moveit/moveit2/issues/3553)
- [3541](https://github.com/moveit/moveit2/issues/3541)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

I used Claude Opus 4.5 to narrow-down the crash and search existing issues.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
