### PR TITLE
Add topic name filtering when adding new visualizations

### DIFF
--- a/rviz_common/src/rviz_common/add_display_dialog.hpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.hpp
@@ -192,6 +192,7 @@ private Q_SLOTS:
   void stateChanged(int state);
   void onCurrentItemChanged(QTreeWidgetItem * curr);
   void onComboBoxClicked(QTreeWidgetItem * curr);
+  void applyFilter();
 
 private:
   void findPlugins(DisplayFactory *);
@@ -205,6 +206,8 @@ private:
 
   QTreeWidget * tree_;
   QCheckBox * enable_hidden_box_;
+  QLabel * filter_text;
+  QLineEdit * filter_box_;
 
   // Map from ROS topic type to all displays that can visualize it.
   // One key may have multiple values.


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1624 by adding a 'Filter by name' textbox, allowing users to search for topics by name or substring, displaying only matching results. 
<p float="left">
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/3b80bd61-a151-4b0a-b1ec-dcb747f64e9f" />
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/6f7a82d1-4bb7-4125-969d-544c0721dd7a" />
</p>


Note: unlike the original proposal for a top-level namespace filter, this implementation matches any substring in the entire topic name, not just the prefix.

### Is this user-facing behavior change?
Yes, users will see a new textbox and will be able to specify filters
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes, some parts of the `TopicDisplayWidget::applyFilter()` method were written with GitHub Copilot, GPT5.3-codex. 
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

