### PR TITLE
Fix setHidden regression in PropertyTreeWidget 

### DIFF
--- a/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
+++ b/rviz_common/src/rviz_common/properties/property_tree_widget.cpp
@@ -119,14 +119,12 @@ void PropertyTreeWidget::setModel(PropertyTreeModel * model)
 void PropertyTreeWidget::propertyHiddenChanged(const Property * property)
 {
   if (model_) {
-    if (property->parent() != nullptr) {
-      const auto & parent_index = model_->parentIndex(property);
-      if (parent_index.isValid()) {
-        setRowHidden(property->rowNumberInParent(), parent_index, property->getHidden());
-      } else {
-        printf("Trying to hide property '%s' that is not part of the model.\n",
-          qPrintable(property->getName()));
-      }
+    const auto & parent_index = model_->parentIndex(property);
+    if (parent_index.isValid()) {
+      setRowHidden(property->rowNumberInParent(), parent_index, property->getHidden());
+    } else {
+      printf("Trying to hide property '%s' that is not part of the model.\n",
+        qPrintable(property->getName()));
     }
   }
 }


### PR DESCRIPTION
  ## Description                                                                   
                                                                                                                                        
  PR #1587 added a `property->parent() != nullptr` guard in `propertyHiddenChanged()`, but Property objects use rviz's own `getParent()`
   hierarchy rather than Qt's `parent()`. Since `parent()` always returns nullptr for these properties, the guard prevented all
  `setHidden` calls from taking effect.

  Remove the guard and rely on `parentIndex().isValid()` which already uses `getParent()` internally and handles null correctly.

  Fixes #1620

  ### Is this user-facing behavior change?

  Yes. PointCloud2 display properties (e.g., Size (Pixels), Min/Max Intensity, Min/Max Color) were all shown simultaneously regardless
  of the selected Style or Color Transformer options. After this fix, only the properties relevant to the current selection are shown.

  **Before (bug):**
![WS000007](https://github.com/user-attachments/assets/b2505c24-134c-42d0-b19d-57b09bad12e4)

  **After (fix):**
![WS000008](https://github.com/user-attachments/assets/fa99281d-ce9a-4f20-820e-719104934287)

  ### Did you use Generative AI?

Yes. Claude (Claude Code) was used to assist with root cause investigation.

  ### Additional Information

  The issue was introduced in commit 9fc8054 (PR #1587). The `property->parent()` check was intended to prevent a crash, but `parent()`
  returns the Qt QObject parent which is always null for rviz Property objects. The `parentIndex()` method already uses `getParent()`
  (rviz's own hierarchy) and returns an invalid index for unparented properties, making the removed guard redundant.

  Verified on jazzy with before/after testing using PointCloud2 display.