### PR TITLE
Don't export Qt6::widgets

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -275,7 +275,6 @@ ament_export_dependencies(
   geometry_msgs
   message_filters
   pluginlib
-  Qt${QT_VERSION_MAJOR}
   rclcpp
   rviz_ogre_vendor
   rviz_rendering

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -135,7 +135,6 @@ target_compile_definitions(rviz_rendering PRIVATE "RVIZ_RENDERING_BUILDING_LIBRA
 
 ament_export_dependencies(
   Eigen3
-  Qt${QT_VERSION_MAJOR}
   rviz_ogre_vendor
 )
 


### PR DESCRIPTION
Don't export `Qt6::widgets`

Getting issue in downstream packages