### PR TITLE
Add tests for shallow and deep cpoy in Config

### DIFF
--- a/rviz_common/test/config_test.cpp
+++ b/rviz_common/test/config_test.cpp
@@ -87,6 +87,49 @@ TEST(Config, handle_mixed_type_values_for_keys) {
   EXPECT_EQ(string_value, "123abc");
 }
 
+TEST(Config, Config_copy_constructor_shallow_copy_check) {
+  rviz_common::Config c1;
+  c1.mapSetValue("key", "value");
+  rviz_common::Config c2 = c1;
+  c1.mapSetValue("key", "new_value");
+  QString value;
+  EXPECT_TRUE(c2.mapGetString("key", &value));
+  EXPECT_EQ(value, "new_value");
+}
+
+TEST(Config, Config_copy_method_deep_copy_check) {
+  rviz_common::Config source;
+  source.mapSetValue("name", "before");
+
+  rviz_common::Config child = source.mapMakeChild("child");
+  child.mapSetValue("leaf", "leaf_before");
+
+  rviz_common::Config list = source.mapMakeChild("list");
+  list.listAppendNew().setValue("item0");
+  list.listAppendNew().setValue("item1");
+
+  rviz_common::Config copied;
+  copied.copy(source);
+
+  source.mapSetValue("name", "after");
+  child.mapSetValue("leaf", "leaf_after");
+  list.listChildAt(0).setValue("changed_item0");
+
+  QString name_value;
+  EXPECT_TRUE(copied.mapGetString("name", &name_value));
+  EXPECT_EQ(name_value, "before");
+
+  QString leaf_value;
+  EXPECT_TRUE(copied.mapGetChild("child").mapGetString("leaf", &leaf_value));
+  EXPECT_EQ(leaf_value, "leaf_before");
+
+  rviz_common::Config copied_list = copied.mapGetChild("list");
+  ASSERT_EQ(copied_list.listLength(), 2);
+  EXPECT_EQ(copied_list.listChildAt(0).getValue().toString(), "item0");
+  EXPECT_EQ(copied_list.listChildAt(1).getValue().toString(), "item1");
+}
+
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/rviz_common/test/config_test.cpp
+++ b/rviz_common/test/config_test.cpp
@@ -87,7 +87,7 @@ TEST(Config, handle_mixed_type_values_for_keys) {
   EXPECT_EQ(string_value, "123abc");
 }
 
-TEST(Config, Config_copy_constructor_shallow_copy_check) {
+TEST(Config, copy_constructor_shallow_copy_check) {
   rviz_common::Config c1;
   c1.mapSetValue("key", "value");
   rviz_common::Config c2 = c1;
@@ -97,7 +97,7 @@ TEST(Config, Config_copy_constructor_shallow_copy_check) {
   EXPECT_EQ(value, "new_value");
 }
 
-TEST(Config, Config_copy_method_deep_copy_check) {
+TEST(Config, copy_method_deep_copy_check) {
   rviz_common::Config source;
   source.mapSetValue("name", "before");
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1356 

### Is this user-facing behavior change?

### Additional Information

The failed test provided in #1356 was designed for shallow copy test , so it should be verify `EXPECT_EQ(value, "new_value")` instead of `EXPECT_EQ(value, "value")`. If want to verify deep copy should call `copy()` to verify.

I add two new tests for `Config.cc` , one is for shallow copy and another is for deep copy(`Config::copy()`)