### PR TITLE
Stop using, and deprecate rviz_ogre_vendor

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(ament_cmake REQUIRED)
 
 find_package(rviz_common REQUIRED)
 
-find_package(rviz_ogre_vendor REQUIRED)
+find_package(OGRE REQUIRED)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
@@ -47,8 +47,8 @@ add_executable(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
   rviz_common::rviz_common
-  rviz_ogre_vendor::OgreMain
-  rviz_ogre_vendor::OgreOverlay
+  OgreMain
+  OgreOverlay
   Qt${QT_VERSION_MAJOR}::Widgets
 )
 

--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -28,8 +28,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-# do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
-find_package(rviz_ogre_vendor REQUIRED)
+find_package(OGRE REQUIRED)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
@@ -66,7 +65,6 @@ set(ENV_CONFIG_CPP ${CMAKE_CURRENT_BINARY_DIR}/src/rviz_common/env_config.cpp)
 ament_package_xml()
 set(RVIZ_VERSION "${rviz_common_VERSION}")
 set(ROS_DISTRO "ROS 2")
-set(OGRE_PLUGIN_PATH "rviz_ogre_vendor")
 configure_file(src/rviz_common/env_config.cpp.in ${ENV_CONFIG_CPP} @ONLY)
 
 # These need to be added in the add_library() call
@@ -251,8 +249,8 @@ target_link_libraries(rviz_common PUBLIC
   pluginlib::pluginlib
   Qt${QT_VERSION_MAJOR}::Widgets
   rclcpp::rclcpp
-  rviz_ogre_vendor::OgreMain
-  rviz_ogre_vendor::OgreOverlay
+  OgreMain
+  OgreOverlay
   rviz_rendering::rviz_rendering
   ${sensor_msgs_TARGETS}
   ${std_msgs_TARGETS}
@@ -277,7 +275,7 @@ ament_export_dependencies(
   pluginlib
   Qt${QT_VERSION_MAJOR}
   rclcpp
-  rviz_ogre_vendor
+  OGRE
   rviz_rendering
   sensor_msgs
   std_msgs
@@ -361,8 +359,8 @@ if(BUILD_TESTING)
   target_link_libraries(test_support_objects PUBLIC
     rviz_common
     Qt${QT_VERSION_MAJOR}::Widgets
-    rviz_ogre_vendor::OgreMain
-    rviz_ogre_vendor::OgreOverlay
+    OgreMain
+    OgreOverlay
   )
 
   set(TEST_SUPPORT_OBJECTS $<TARGET_OBJECTS:test_support_objects>)
@@ -385,8 +383,8 @@ if(BUILD_TESTING)
     target_include_directories(rviz_common_core_tests PRIVATE test)
     target_link_libraries(rviz_common_core_tests
       rviz_common
-      rviz_ogre_vendor::OgreMain
-      rviz_ogre_vendor::OgreOverlay
+      OgreMain
+      OgreOverlay
       Qt${QT_VERSION_MAJOR}::Widgets
       yaml-cpp::yaml-cpp
     )
@@ -403,8 +401,8 @@ if(BUILD_TESTING)
     target_include_directories(rviz_common_interaction_tests PRIVATE test)
     target_link_libraries(rviz_common_interaction_tests
       rviz_common
-      rviz_ogre_vendor::OgreMain
-      rviz_ogre_vendor::OgreOverlay
+      OgreMain
+      OgreOverlay
     )
   endif()
 
@@ -431,8 +429,8 @@ if(BUILD_TESTING)
   if(TARGET frame_manager_test)
     target_link_libraries(frame_manager_test
       rviz_common
-      rviz_ogre_vendor::OgreMain
-      rviz_ogre_vendor::OgreOverlay
+      OgreMain
+      OgreOverlay
     )
   endif()
 endif()

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -41,7 +41,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>resource_retriever</depend>
-  <depend>rviz_ogre_vendor</depend>
+  <depend>libogre-1.12-dev</depend>
   <depend>rviz_rendering</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>

--- a/rviz_common/src/rviz_common/env_config.cpp.in
+++ b/rviz_common/src/rviz_common/env_config.cpp.in
@@ -50,11 +50,12 @@ std::string get_distro()
   return "@ROS_DISTRO@";
 }
 
+[[deprecated("rviz no longer uses rviz_ogre_vendor")]]
 std::string get_ogre_plugin_path()
 {
   // The return string here is replaced at compile time by
   // CMakeLists.txt in this directory.
-  return "@OGRE_PLUGIN_PATH@";
+  return "rviz_ogre_vendor";
 }
 
 }

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(rviz_common REQUIRED)
 find_package(rviz_rendering REQUIRED)
-find_package(rviz_ogre_vendor REQUIRED)
+find_package(OGRE REQUIRED)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Test Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test Widgets)
@@ -264,8 +264,8 @@ target_link_libraries(rviz_default_plugins PUBLIC
   Qt${QT_VERSION_MAJOR}::Widgets
   rclcpp::rclcpp
   rviz_common::rviz_common
-  rviz_ogre_vendor::OgreMain
-  rviz_ogre_vendor::OgreOverlay
+  OgreMain
+  OgreOverlay
   rviz_rendering::rviz_rendering
   ${sensor_msgs_TARGETS}
   tf2::tf2
@@ -304,7 +304,7 @@ ament_export_dependencies(
   Qt${QT_VERSION_MAJOR}
   rclcpp
   rviz_common
-  rviz_ogre_vendor
+  OGRE
   rviz_rendering
   sensor_msgs
   tf2
@@ -351,7 +351,7 @@ if(BUILD_TESTING)
   ament_find_gmock()
 
   add_library(ogre_testing_environment STATIC test/rviz_default_plugins/ogre_testing_environment.cpp)
-  target_link_libraries(ogre_testing_environment PRIVATE rviz_ogre_vendor::OgreMain rviz_rendering::rviz_rendering)
+  target_link_libraries(ogre_testing_environment PRIVATE OgreMain rviz_rendering::rviz_rendering)
 
   # We can't compile these fixtures into a library to be used by every test because that would
   # require linking against gtest/gmock libraries, which would cause ODR violations down the line
@@ -374,7 +374,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_fixture_objects PUBLIC
     rclcpp::rclcpp
     rviz_common::rviz_common
-    rviz_ogre_vendor::OgreMain
+    OgreMain
     ogre_testing_environment
     Qt${QT_VERSION_MAJOR}::Widgets
   )
@@ -384,7 +384,7 @@ if(BUILD_TESTING)
   set(TEST_FIXTURE_WITH_MOCK_LIBRARIES
     rclcpp::rclcpp
     rviz_common::rviz_common
-    rviz_ogre_vendor::OgreMain
+    OgreMain
     ogre_testing_environment
   )
 
@@ -462,7 +462,7 @@ if(BUILD_TESTING)
     rclcpp::rclcpp
     ${std_msgs_TARGETS}
     ${visualization_msgs_TARGETS}
-    rviz_ogre_vendor::OgreMain
+    OgreMain
   )
 
   ament_add_gmock(marker_test

--- a/rviz_default_plugins/package.xml
+++ b/rviz_default_plugins/package.xml
@@ -27,15 +27,15 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>qt6-base-dev</build_depend>
-  <build_depend>rviz_ogre_vendor</build_depend>
+  <build_depend>libogre-1.12-dev</build_depend>
 
-  <build_export_depend>rviz_ogre_vendor</build_export_depend>
+  <build_export_depend>libogre-1.12-dev</build_export_depend>
 
   <exec_depend>libqt6-core</exec_depend>
   <exec_depend>libqt6gui6t64</exec_depend>
   <exec_depend>libqt6opengl6t64</exec_depend>
   <exec_depend>libqt6widgets6t64</exec_depend>
-  <exec_depend>rviz_ogre_vendor</exec_depend>
+  <exec_depend>libogre-1.12.10</exec_depend>
 
   <depend>geometry_msgs</depend>
   <depend>gz_math_vendor</depend>

--- a/rviz_ogre_vendor/package.xml
+++ b/rviz_ogre_vendor/package.xml
@@ -37,6 +37,7 @@
   <test_depend>ament_lint_auto</test_depend>
 
   <export>
+    <deprecated>Use the rosdep keys libogre-1-12-dev and libogre-1.12.10 instead</deprecated>
     <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/rviz_rendering/CMakeLists.txt
+++ b/rviz_rendering/CMakeLists.txt
@@ -29,8 +29,7 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 
-# do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
-find_package(rviz_ogre_vendor REQUIRED)
+find_package(OGRE REQUIRED)
 find_package(assimp REQUIRED)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
@@ -108,8 +107,8 @@ add_library(rviz_rendering SHARED
 
 target_link_libraries(rviz_rendering PUBLIC
   Qt${QT_VERSION_MAJOR}::Widgets
-  rviz_ogre_vendor::OgreMain
-  rviz_ogre_vendor::OgreOverlay
+  OgreMain
+  OgreOverlay
 )
 if(TARGET Eigen3::Eigen)
   # TODO(sloretz) require target to exist when https://github.com/ros2/choco-packages/issues/19 is addressed
@@ -136,7 +135,7 @@ target_compile_definitions(rviz_rendering PRIVATE "RVIZ_RENDERING_BUILDING_LIBRA
 ament_export_dependencies(
   Eigen3
   Qt${QT_VERSION_MAJOR}
-  rviz_ogre_vendor
+  OGRE
 )
 
 # Export old-style CMake variables
@@ -184,7 +183,7 @@ if(BUILD_TESTING)
     "TEST_RVIZ_RENDERING_BUILDING_LIBRARY")
   target_link_libraries(rviz_rendering_test_utils
     PUBLIC
-    rviz_ogre_vendor::OgreMain
+    OgreMain
     rviz_rendering
   )
 
@@ -198,7 +197,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_test_target)
     target_link_libraries(point_cloud_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -210,7 +209,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET point_cloud_renderable_test_target)
     target_link_libraries(point_cloud_renderable_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -222,7 +221,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET billboard_line_test_target)
     target_link_libraries(billboard_line_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -234,7 +233,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET covariance_visual_test_target)
     target_link_libraries(covariance_visual_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -246,7 +245,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET effort_visual_test_target)
     target_link_libraries(effort_visual_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -258,7 +257,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET grid_test_target)
     target_link_libraries(grid_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -270,8 +269,8 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET movable_text_test_target)
     target_link_libraries(movable_text_test_target
-      rviz_ogre_vendor::OgreMain
-      rviz_ogre_vendor::OgreOverlay
+      OgreMain
+      OgreOverlay
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets
@@ -283,7 +282,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET line_test_target)
     target_link_libraries(line_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -295,7 +294,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET screw_visual_test_target)
     target_link_libraries(screw_visual_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -307,7 +306,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET triangle_polygon_visual_test_target)
     target_link_libraries(triangle_polygon_visual_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -319,7 +318,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET wrench_visual_test_target)
     target_link_libraries(wrench_visual_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)
@@ -331,7 +330,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET mesh_shape_visual_test_target)
     target_link_libraries(mesh_shape_visual_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering
       rviz_rendering_test_utils
       Qt${QT_VERSION_MAJOR}::Widgets  # explicitly do this for include directories (not necessary for external use)

--- a/rviz_rendering/package.xml
+++ b/rviz_rendering/package.xml
@@ -34,11 +34,11 @@
   <build_depend>qt6-base-dev</build_depend>
   <build_depend>resource_retriever</build_depend>
   <build_depend>assimp-dev</build_depend>
-  <build_depend>rviz_ogre_vendor</build_depend>
+  <build_depend>libogre-1.12-dev</build_depend>
 
   <build_export_depend>eigen</build_export_depend>
   <build_export_depend>qt6-base-dev</build_export_depend>
-  <build_export_depend>rviz_ogre_vendor</build_export_depend>
+  <build_export_depend>libogre-1.12-dev</build_export_depend>
 
   <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>libqt6-core</exec_depend>
@@ -47,7 +47,7 @@
   <exec_depend>libqt6svg6</exec_depend>
   <exec_depend>resource_retriever</exec_depend>
   <exec_depend>assimp</exec_depend>
-  <exec_depend>rviz_ogre_vendor</exec_depend>
+  <exec_depend>libogre-1.12.10</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/rviz_rendering_tests/CMakeLists.txt
+++ b/rviz_rendering_tests/CMakeLists.txt
@@ -30,8 +30,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
-  # do find_package(rviz_ogre_vendor) first to make sure the custom OGRE is found
-  find_package(rviz_ogre_vendor REQUIRED)
+  find_package(OGRE REQUIRED)
   find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
   find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
   if(${QT_VERSION} VERSION_LESS 5.15.0)
@@ -68,7 +67,7 @@ if(BUILD_TESTING)
     ${SKIP_DISPLAY_TESTS})
   if(TARGET mesh_loader_test_target)
     target_link_libraries(mesh_loader_test_target
-      rviz_ogre_vendor::OgreMain
+      OgreMain
       rviz_rendering::rviz_rendering
       resource_retriever::resource_retriever
     )

--- a/rviz_rendering_tests/package.xml
+++ b/rviz_rendering_tests/package.xml
@@ -24,6 +24,7 @@
 
   <build_depend>qt6-base-dev</build_depend>
 
+  <depend>libogre-1.12-dev</depend>
   <depend>rviz_rendering</depend>
   <depend>resource_retriever</depend>
 

--- a/rviz_visual_testing_framework/CMakeLists.txt
+++ b/rviz_visual_testing_framework/CMakeLists.txt
@@ -30,7 +30,6 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Test Widgets)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rviz_common REQUIRED)
-find_package(rviz_ogre_vendor REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -77,7 +76,7 @@ target_link_libraries(rviz_visual_testing_framework PUBLIC
   rclcpp::rclcpp
   rcutils::rcutils
   rviz_common::rviz_common
-  rviz_ogre_vendor::OgreMain
+  OgreMain
   rviz_rendering::rviz_rendering
   ${std_msgs_TARGETS}
   tf2::tf2
@@ -91,7 +90,7 @@ ament_export_dependencies(
   rclcpp
   rcutils
   rviz_common
-  rviz_ogre_vendor
+  OGRE
   rviz_rendering
   std_msgs
   tf2

--- a/rviz_visual_testing_framework/package.xml
+++ b/rviz_visual_testing_framework/package.xml
@@ -30,7 +30,7 @@
   <depend>rclcpp</depend>
   <depend>rcutils</depend>
   <depend>rviz_common</depend>
-  <depend>rviz_ogre_vendor</depend>
+  <depend>libogre-1.12-dev</depend>
   <depend>rviz_rendering</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
## Description

This makes rviz2 use ogre from system packages instead of vendoring it.

Fixes https://github.com/ros2/rviz/issues/876

Lowering priority since we worked around issues in rviz_ogre_vendor https://github.com/ros2/rviz/pull/1684

### Is this user-facing behavior change?


### Did you use Generative AI?

No
### Additional Information

I have only tested that this builds. I have not ran rviz yet.