### PR TITLE
Bump cmake version and suppress warning for rviz_ogre_vendor

### DIFF
--- a/rviz_ogre_vendor/CMakeLists.txt
+++ b/rviz_ogre_vendor/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
   set(OGRE_CXX_FLAGS "-Wno-range-loop-construct ${OGRE_CXX_FLAGS}")
   set(OGRE_CXX_FLAGS "-Wno-undef ${OGRE_CXX_FLAGS}")
   set(OGRE_CXX_FLAGS "-Wno-misleading-indentation ${OGRE_CXX_FLAGS}")
+  set(OGRE_CXX_FLAGS "-Wno-format-truncation ${OGRE_CXX_FLAGS}")
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(OGRE_CXX_FLAGS "-Wno-implicit-const-int-float-conversion ${OGRE_CXX_FLAGS}")

--- a/rviz_ogre_vendor/patches/0006-cmake-3-10.patch
+++ b/rviz_ogre_vendor/patches/0006-cmake-3-10.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dff54c2da..2e6b2a986 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,7 +14,7 @@
+ # and provide build configuration options.
+ ######################################################################
+ 
+-cmake_minimum_required(VERSION 3.3.0)
++cmake_minimum_required(VERSION 3.10)
+ 
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Description

This is the minimum required changes to get `rviz_ogre_vendor` building without warnings on Ubuntu Resolute

* Add patch to bump CMake minimum version to 3.10 (this was causing the build to fail)
* Suppress `-Wformat-truncation`

### Is this user-facing behavior change?

no
### Did you use Generative AI?

no

### Additional Information


The warning this supresses:

```
/workspaces/lyrical/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/RenderSystems/GLSupport/src/GLSL/OgreGLSLPreprocessor.cpp: In member function ‘Ogre::CPreprocessor::Token Ogre::CPreprocessor::ExpandMacro(const Token&)’:
/workspaces/lyrical/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/RenderSystems/GLSupport/src/GLSL/OgreGLSLPreprocessor.cpp:436:70: warning: ‘ arguments, but takes just ’ directive output may be truncated writing 27 bytes into a region of size between 0 and 43 [-Wformat-truncation=]
  436 |                 snprintf (tmp, sizeof (tmp), "Macro `%.*s' passed %zu arguments, but takes just %zu",
      |                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/workspaces/lyrical/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/RenderSystems/GLSupport/src/GLSL/OgreGLSLPreprocessor.cpp:436:46: note: directive argument in the range [0, 288230376151711743]
  436 |                 snprintf (tmp, sizeof (tmp), "Macro `%.*s' passed %zu arguments, but takes just %zu",
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:970,
                 from /usr/include/c++/15/cstdio:47,
                 from /usr/include/c++/15/ext/string_conversions.h:47,
                 from /usr/include/c++/15/bits/basic_string.h:4444,
                 from /usr/include/c++/15/string:56,
                 from /workspaces/lyrical/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/OgreMain/include/OgrePrerequisites.h:37,
                 from /workspaces/lyrical/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/OgreMain/include/OgreLogManager.h:32,
                 from /workspaces/lyrical/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/RenderSystems/GLSupport/src/GLSL/OgreGLSLPreprocessor.cpp:30:
In function ‘int snprintf(char*, size_t, const char*, ...)’,
    inlined from ‘Ogre::CPreprocessor::Token Ogre::CPreprocessor::ExpandMacro(const Token&)’ at /workspaces/lyrical/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/RenderSystems/GLSupport/src/GLSL/OgreGLSLPreprocessor.cpp:436:26:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:68:35: note: ‘__builtin___snprintf_chk’ output between 46 and 2147483727 bytes into a destination of size 60
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
---
```
