### PR TITLE
Fix std::binary_function usage in OgreLodStrategy for macOS compilation

### DIFF
--- a/rviz_ogre_vendor/patches/0006-remove-binary_function.patch
+++ b/rviz_ogre_vendor/patches/0006-remove-binary_function.patch
@@ -1,0 +1,24 @@
+diff --git a/OgreMain/src/OgreLodStrategy.cpp b/OgreMain/src/OgreLodStrategy.cpp
+index bce3d3e6d..9c4b0c814 100644
+--- a/OgreMain/src/OgreLodStrategy.cpp
++++ b/OgreMain/src/OgreLodStrategy.cpp
+@@ -85,8 +85,7 @@ namespace Ogre {
+         return true;
+     }
+     //---------------------------------------------------------------------
+-    struct LodUsageSortLess :
+-    public std::binary_function<const MeshLodUsage&, const MeshLodUsage&, bool>
++    struct LodUsageSortLess
+     {
+         bool operator() (const MeshLodUsage& mesh1, const MeshLodUsage& mesh2)
+         {
+@@ -100,8 +99,7 @@ namespace Ogre {
+         std::sort(meshLodUsageList.begin(), meshLodUsageList.end(), LodUsageSortLess());
+     }
+     //---------------------------------------------------------------------
+-    struct LodUsageSortGreater :
+-    public std::binary_function<const MeshLodUsage&, const MeshLodUsage&, bool>
++    struct LodUsageSortGreater
+     {
+         bool operator() (const MeshLodUsage& mesh1, const MeshLodUsage& mesh2)
+         {


### PR DESCRIPTION
### Background / Issue
  - In recent versions of Xcode (16+) and macOS SDKs, `std::binary_function` has been removed from the C++ standard library.
  - Building `rviz_ogre_vendor` fails with errors like:

    ```
    error: no template named 'binary_function' in namespace 'std'; did you mean '__binary_function'?
    ```

  - This affects all ROS 2 distributions on macOS (Humble, Jazzy, Kilted).

  ### Solution
  - Removed `public std::binary_function<…>` from the comparator structs `LodUsageSortLess` and `LodUsageSortGreater`.
  - The operator overloads are still valid and allow sorting with `std::sort`.

    ```cpp
    struct LodUsageSortLess
    {
        bool operator() (const MeshLodUsage& mesh1, const MeshLodUsage& mesh2)
        {
            return mesh1.fromDepth < mesh2.fromDepth;
        }
    };

    struct LodUsageSortGreater
    {
        bool operator() (const MeshLodUsage& mesh1, const MeshLodUsage& mesh2)
        {
            return mesh1.fromDepth > mesh2.fromDepth;
        }
    };
    ```

  ### Impact
  - Allows successful compilation of `rviz_ogre_vendor` on macOS across Humble,Jazzy, and Kilted distributions.
  - No change in runtime behavior, purely a compilation fix.

  ### References
  - Working Demo: [ros2_macOS Ogre fix](https://github.com/idesign0/ros2_macOS?tab=readme-ov-file#1-ros-2--gazebo-integration)
  - Error logs included in PR description.