### PR TITLE
Fix for undefined behavior in test.

### DIFF
--- a/rviz_rendering/test/rviz_rendering/mesh_shape_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/mesh_shape_test.cpp
@@ -82,6 +82,9 @@ TEST_F(MeshShapeTestFixture, mesh_shape_test) {
 
   std::vector<Ogre::Vector3> normals = {
     {0.0f, 0.0f, 1.0f},
+    {0.0f, 0.0f, 1.0f},
+    {0.0f, 0.0f, 1.0f},
+    {0.0f, 0.0f, 1.0f},
     {0.0f, 0.0f, 1.0f}
   };
 


### PR DESCRIPTION
## Description

Indexing into normal vector was undefined behavior. Caught with gcc15 debug on ubuntu26.

https://github.com/ros2/ci/issues/838#issuecomment-4118939903

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
