### PR TITLE
Link against GTest::gmock target

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -361,12 +361,10 @@ if(BUILD_TESTING)
   target_include_directories(test_support_objects PRIVATE
     include
     test
-    ${rviz_common_INCLUDE_DIRS}
-    ${GMOCK_INCLUDE_DIRS}
-    ${GTEST_INCLUDE_DIRS}
   )
   target_link_libraries(test_support_objects PUBLIC
     rviz_common
+    GTest::gmock
     Qt${QT_VERSION_MAJOR}::Widgets
     rviz_ogre_vendor::OgreMain
     rviz_ogre_vendor::OgreOverlay

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -375,10 +375,9 @@ if(BUILD_TESTING)
   target_include_directories(test_fixture_objects PRIVATE
     ${TEST_INCLUDE_DIRS}
     include
-    ${GMOCK_INCLUDE_DIRS}
-    ${GTEST_INCLUDE_DIRS}
   )
   target_link_libraries(test_fixture_objects PUBLIC
+    GTest::gmock
     rclcpp::rclcpp
     rviz_common::rviz_common
     rviz_ogre_vendor::OgreMain


### PR DESCRIPTION

## Description

Linking against the target makes sure GTEST_LINKED_AS_SHARED_LIBRARY=1 is defined, which makes sure the object files and the other tests both expect to get the gtest symbols from another dll on windows.

Without this I get linker errors when upgrading the version of googletest

Part of https://github.com/ament/googletest/issues/37

### Is this user-facing behavior change?

no

### Did you use Generative AI?

no

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
