### PR TITLE
Fix LaserScan reset not invalidating the time_tolerance_

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
@@ -87,6 +87,8 @@ protected:
   /** create a status warning when tolerance is larger than 1s */
   void checkTolerance(rclcpp::Duration tolerance);
 
+  void subscribe() override;
+
   std::unique_ptr<PointCloudCommon> point_cloud_common_;
   std::unique_ptr<laser_geometry::LaserProjection> projector_;
   rclcpp::Duration filter_tolerance_;

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp
@@ -137,6 +137,13 @@ void LaserScanDisplay::onDisable()
   point_cloud_common_->onDisable();
 }
 
+void LaserScanDisplay::subscribe()
+{
+  MFDClass::subscribe();
+  // Subscribe resets the tf_filter_, so update filter_tolerance_ to reflect that.
+  filter_tolerance_ = rclcpp::Duration{0, 0};
+}
+
 }  // namespace displays
 }  // namespace rviz_default_plugins
 


### PR DESCRIPTION
## Description

Fix the LaserScanDisplay not working after a reset (disable-enable, change topic, etc...).

In order to transform a LaserScan, the LaserScanDisplay tf_filter is configured with a time tolerance in order to call processMessage only if the transform is known for the beginning and the end of the scan.

LaserScanDisplay only wants to increase the tolerance, and because tf2_ros::MessageFilter doesn't have a `getTolerance()` accessor, LaserScanDisplay stores it locally to only update it when the required tolerance is greater than the configured one:

https://github.com/ros2/rviz/blob/5f7848c3688e1fd38f761640ec127bbc51e6638b/rviz_default_plugins/src/rviz_default_plugins/displays/laser_scan/laser_scan_display.cpp#L91-L95

However, when re-subscribing, [MessageFilterDisplay resets the tf filter](https://github.com/ros2/rviz/blob/5f7848c3688e1fd38f761640ec127bbc51e6638b/rviz_common/include/rviz_common/message_filter_display.hpp#L132-L137), thus setting its time_tolerance back to 0. This is not caught in LaserScanFilter, which never updates the tolerance on the new filter again.

This fix sets the cached copy filter_tolerance_ back to 0. after subscribing.

### Is this user-facing behavior change?

This doesn't introduce unwanted behavior, it is only a fix.

### Did you use Generative AI?

Only 100% human brain juice was used.

### Additional Information

A back-port down to jazzy would be great.
