### PR TITLE
Only add to display dialog if publisher > 0

### DIFF
--- a/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction.hpp
+++ b/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction.hpp
@@ -85,6 +85,14 @@ public:
   std::map<std::string, std::vector<std::string>>
   get_topic_names_and_types() const override;
 
+  /// Count the number of publishers for a given topic.
+  /**
+   * \param topic_name the name of the topic to count publishers for
+   * \return the number of publishers for the given topic
+   */
+  RVIZ_COMMON_PUBLIC
+  size_t count_publishers(const std::string & topic_name) const override;
+
   /// Return a map with service names mapped to a list of types for that service.
   /**
    * The node name is what was given when initializing this API.

--- a/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction_iface.hpp
+++ b/rviz_common/include/rviz_common/ros_integration/ros_node_abstraction_iface.hpp
@@ -56,6 +56,8 @@ public:
   virtual std::map<std::string, std::vector<std::string>>
   get_topic_names_and_types() const = 0;
 
+  virtual size_t count_publishers(const std::string & topic_name) const = 0;
+
   virtual std::map<std::string, std::vector<std::string>>
   get_service_names_and_types() const = 0;
 

--- a/rviz_common/src/rviz_common/add_display_dialog.cpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.cpp
@@ -168,6 +168,11 @@ void getPluginGroups(
     }
     QString datatype = QString::fromStdString(map_pair.second[0]);
 
+    // Check if there is a publisher for this topic, if not we skip it
+    if (!rviz_ros_node.lock()->count_publishers(map_pair.first)) {
+      continue;
+    }
+
     if (datatype_plugins.contains(datatype)) {
       if (
         groups->empty() ||

--- a/rviz_common/src/rviz_common/ros_integration/ros_node_abstraction.cpp
+++ b/rviz_common/src/rviz_common/ros_integration/ros_node_abstraction.cpp
@@ -62,6 +62,11 @@ RosNodeAbstraction::get_topic_names_and_types() const
   return raw_node_->get_topic_names_and_types();
 }
 
+size_t RosNodeAbstraction::count_publishers(const std::string & topic_name) const
+{
+  return raw_node_->count_publishers(topic_name);
+}
+
 std::map<std::string, std::vector<std::string>>
 RosNodeAbstraction::get_service_names_and_types() const
 {


### PR DESCRIPTION
## Description

When creating visualization, only add to the dialog if publisher > 0 since we are subscribing to these topics


### Is this user-facing behavior change?

Yes, previously all topics were shown even if there is only subscribers

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
