### PR TITLE
SelectionManager::select Function Not Returning Empty Selection Result for Invalid Coordinates

### DIFF
--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -590,6 +590,14 @@ void SelectionManager::pick(
   int y2,
   M_Picked & results)
 {
+  // Reject invalid pick rectangles. Negative screen coordinates can produce
+  // garbage handles when fed to the offscreen render texture, and a degenerate
+  // rectangle (x2 <= x1 or y2 <= y1) selects nothing by definition.
+  if (x1 < 0 || y1 < 0 || x2 <= x1 || y2 <= y1) {
+    results.clear();
+    return;
+  }
+
   auto handler_lock = handler_manager_->lock(std::defer_lock);
   std::lock(selection_mutex_, handler_lock);
   std::lock_guard<std::recursive_mutex> lock(selection_mutex_, std::adopt_lock);

--- a/rviz_common/test/interaction/selection_manager_test.cpp
+++ b/rviz_common/test/interaction/selection_manager_test.cpp
@@ -117,3 +117,14 @@ TEST_F(SelectionManagerTestFixture, subtracting_from_a_selection) {
   EXPECT_THAT(selection, SizeIs(1));
   EXPECT_THAT(selection, Contains(Key(o2.getHandle())));
 }
+
+TEST_F(SelectionManagerTestFixture, select_handles_invalid_coordinates_gracefully) {
+  auto o1 = addVisibleObject(10, 10);
+  auto o2 = addVisibleObject(150, 150);
+
+  selection_manager_->select(
+    render_window_, -10, -10, 100, 100, rviz_common::interaction::SelectionManager::Replace);
+
+  auto selection = selection_manager_->getSelection();
+  EXPECT_THAT(selection, SizeIs(0));
+}


### PR DESCRIPTION
## Description

Related with https://github.com/ros2/rviz/issues/1364


### Did you use Generative AI?

Claude Sonnet 4.6
