### PR TITLE
ogreQuaternionAngularDistance does not properly handle invalid quaternion input

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/quaternion_helper.hpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/quaternion_helper.hpp
@@ -31,7 +31,9 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__ODOMETRY__QUATERNION_HELPER_HPP_
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__ODOMETRY__QUATERNION_HELPER_HPP_
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <OgreQuaternion.h>
 
@@ -40,6 +42,15 @@ namespace rviz_default_plugins
 
 float ogreQuaternionAngularDistance(Ogre::Quaternion first, Ogre::Quaternion second)
 {
+  // The angular distance between zero / near-zero quaternions is undefined:
+  // normalise() would divide by ~0 and produce NaN/Inf components. Surface
+  // that explicitly so callers can detect it with std::isnan instead of
+  // silently propagating garbage.
+  constexpr float kQuaternionNormEpsilon = 1e-6f;
+  if (first.Norm() < kQuaternionNormEpsilon || second.Norm() < kQuaternionNormEpsilon) {
+    return std::numeric_limits<float>::quiet_NaN();
+  }
+
   first.normalise();
   second.normalise();
   float dot = first.Dot(second);

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/odometry/quaternion_helper_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/odometry/quaternion_helper_test.cpp
@@ -67,3 +67,12 @@ TEST(QuaternionHelper, ogreQuaternionHelper_returns_angle) {
     rviz_default_plugins::ogreQuaternionAngularDistance(quaternion1, quaternion4),
     FloatNear(1.0e-6f, 1.0e-6f));
 }
+
+TEST(QuaternionHelper, ogreQuaternionAngularDistance_returns_nan_for_zero_quaternions) {
+  Ogre::Quaternion zero(0.0f, 0.0f, 0.0f, 0.0f);
+  Ogre::Quaternion identity(1.0f, 0.0f, 0.0f, 0.0f);
+
+  EXPECT_TRUE(std::isnan(rviz_default_plugins::ogreQuaternionAngularDistance(zero, zero)));
+  EXPECT_TRUE(std::isnan(rviz_default_plugins::ogreQuaternionAngularDistance(zero, identity)));
+  EXPECT_TRUE(std::isnan(rviz_default_plugins::ogreQuaternionAngularDistance(identity, zero)));
+}


### PR DESCRIPTION
## Description

Related with https://github.com/ros2/rviz/issues/1382

### Did you use Generative AI?

Claude Sonnet 4.6
