### PR TITLE
Remove no-op upper_triangle conditional in TrianglePolygon UV mapping

### DIFF
--- a/rviz_rendering/src/rviz_rendering/objects/triangle_polygon.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/triangle_polygon.cpp
@@ -81,11 +81,7 @@ TrianglePolygon::TrianglePolygon(
     manual_->colour(color);
   }
   manual_->position(B.x, B.y, B.z);
-  if (upper_triangle) {
-    manual_->textureCoord(0, 1);
-  } else {
-    manual_->textureCoord(0, 1);
-  }
+  manual_->textureCoord(0, 1);
   if (use_color) {
     manual_->colour(color);
   }


### PR DESCRIPTION
## Description

Related PR https://github.com/ros2/rviz/issues/1300

