### PR TITLE
`XYOrbitViewController` support Z translation using Shift + Mouse Wheel

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.hpp
@@ -94,8 +94,6 @@ protected:
   void handleRightClick(
     rviz_common::ViewportMouseEvent & event, float distance, int32_t diff_y) override;
 
-  void setShiftOrbitStatus() override;
-
   void setNewFocalPointKeepingViewIfPossible(ViewController * source_view);
 
   void calculateNewCameraPositionAndOrientation(

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/orbit/orbit_view_controller.cpp
@@ -163,10 +163,7 @@ void OrbitViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & eve
 
 void OrbitViewController::setShiftOrbitStatus()
 {
-  setStatus(
-    "<b>Left-Click:</b> Move X/Y.  "
-    "<b>Right-Click:</b> Move Z.  "
-    "<b>Mouse Wheel:</b> Zoom.");
+  setStatus("<b>Left-Click:</b> Move X/Y.  <b>Right-Click/Mouse Wheel:</b> Move Z.");
 }
 
 void OrbitViewController::setDefaultOrbitStatus()

--- a/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller.cpp
@@ -127,16 +127,12 @@ void XYOrbitViewController::lookAt(const Ogre::Vector3 & point)
   Ogre::Vector3 camera_position = camera_->getParentSceneNode()->getPosition();
   Ogre::Vector3 new_focal_point =
     target_scene_node_->getOrientation().Inverse() * (point - target_scene_node_->getPosition());
-  new_focal_point.z = 0;
+  // Preserve the current focal point Z value
+  new_focal_point.z = focal_point_property_->getVector().z;
   distance_property_->setFloat(new_focal_point.distance(camera_position));
   focal_point_property_->setVector(new_focal_point);
 
   calculatePitchYawFromPosition(camera_position);
-}
-
-void XYOrbitViewController::setShiftOrbitStatus()
-{
-  setStatus("<b>Left-Click:</b> Move X/Y.  <b>Right-Click:</b> Zoom.");
 }
 
 void XYOrbitViewController::moveFocalPoint(
@@ -189,16 +185,28 @@ std::pair<bool, Ogre::Vector3> XYOrbitViewController::intersectGroundPlane(Ogre:
 void XYOrbitViewController::handleRightClick(
   rviz_common::ViewportMouseEvent & event, float distance, int32_t diff_y)
 {
-  (void) event;
-  setCursor(Zoom);
-  zoom(-diff_y * 0.1f * (distance / 10.0f));
+  if (event.shift()) {
+    setCursor(MoveZ);
+    Ogre::Vector3 focal = focal_point_property_->getVector();
+    focal.z += diff_y * 0.001f * distance;
+    focal_point_property_->setVector(focal);
+  } else {
+    setCursor(Zoom);
+    zoom(-diff_y * 0.1f * (distance / 10.0f));
+  }
 }
 
 void XYOrbitViewController::handleWheelEvent(
   rviz_common::ViewportMouseEvent & event, float distance)
 {
   int diff = event.wheel_delta;
-  zoom(diff * 0.001f * distance);
+  if (event.shift()) {
+    Ogre::Vector3 focal = focal_point_property_->getVector();
+    focal.z += -diff * 0.001f * distance;
+    focal_point_property_->setVector(focal);
+  } else {
+    zoom(diff * 0.001f * distance);
+  }
 }
 
 void XYOrbitViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & event)


### PR DESCRIPTION
## Description

### Current situation
The current `XYOrbitViewController`'s focal point position can only be changed in the 'Views' panel, while for several applications it's actually useful that one can easily change the focal point's Z-pose. The current `OrbitViewController` already offers that, however, it lacks `XYOrbitViewController`'s ability to keep the focal point in the XY plane, which is advantageous when moving around in semi-flat environments.

### Proposed change
Therefore this commit brings the ability to change the focal point's z-coordinate to `XYOrbitViewController`, using the combinations Shift + Right-Click and Shift + Mouse Wheel (staying in line with what's used for `OrbitViewController`).

### Related changes
This commit also changes the behavior of `ThirdPersonFollowerViewController` as it inherits from `XYOrbitViewController`, from what I observe in a welcome way. I updated the `setStatus` message in the `OrbitViewController` because it was incorrect - it mentioned that while pressing Shift, Right-Click and Mouse Wheel have different behavior, while actually their behavior is identical.

Concerning the change around line 130 in `xy_orbit_view_controller.cpp`, I'm not fully sure of that one but I think it makes more sense to keep the focal point's current height rather than resetting it to zero.

### Is this user-facing behavior change?

**Yes**, see above.

Concerning the `XYOrbitViewController` and `ThirdPersonFollowerViewController`, it changes the behavior of the following actions:
| Actions | Old behavior | New behavior | Why this is acceptable |
| --------- | ------------------- | -------------------- | --------------------------------- |
| Shift + Mouse Wheel, Shift + Right-Click | plain zoom | translate focal point along fixed frame z-axis | The standard approach to zoom, [as documented in the RViz User Guide](https://docs.ros.org/en/rolling/Tutorials/Intermediate/RViz/RViz-User-Guide/RViz-User-Guide.html), is to use the Mouse Wheel or Right-Click (concerning view controllers, it does not mention pressing Shift anywhere). Given that pressing shift is more tiring than not pressing shift, I assume almost all users are currently not using this action. |

Concerning `XYOrbitViewController` and `ThirdPersonFollowerViewController`, it changes the status message (help message shown bottom left) to reflect the new behavior. Also, in case of `OrbitViewController`, changes it to reflect behavior that was already present.

### Did you use Generative AI?

GitHub Copilot with GPT 4.1 assisted with exploring the repository and the code changes.

### Additional Information

- I tested these changes by building `rviz_default_plugins` from source and trying out the affected view controllers.
- This is my first PR to the rviz repo, please let know if I accidentally missed anything.
