### PR TITLE
Persist per-link/per-joint properties across RobotModel reloads

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/robot_model/robot_model_display.hpp
@@ -39,6 +39,7 @@
 
 #include "std_msgs/msg/string.hpp"
 
+#include "rviz_common/config.hpp"
 #include "rviz_common/ros_topic_display.hpp"
 
 #include "rviz_default_plugins/transformation/transformer_guard.hpp"
@@ -95,6 +96,7 @@ public:
 
   // Overrides from Display
   void onInitialize() override;
+  void load(const rviz_common::Config & config) override;
   void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
   void fixedFrameChanged() override;
   void reset() override;
@@ -152,6 +154,10 @@ protected:
 
   std::unique_ptr<rviz_default_plugins::transformation::TransformerGuard<
       rviz_default_plugins::transformation::TFFrameTransformer>> transformer_guard_;
+
+  // Cache of the "Links" subtree of the saved config, applied to per-link
+  // and per-joint properties once the URDF is parsed and they are created.
+  rviz_common::Config saved_robot_config_;
 };
 
 }  // namespace displays

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/robot_model/robot_model_display.cpp
@@ -50,6 +50,7 @@
 #include "rviz_common/properties/string_property.hpp"
 
 #include "rviz_default_plugins/robot/robot.hpp"
+#include "rviz_default_plugins/robot/robot_joint.hpp"
 #include "rviz_default_plugins/robot/robot_link.hpp"
 #include "rviz_default_plugins/robot/tf_link_updater.hpp"
 
@@ -161,6 +162,14 @@ void RobotModelDisplay::onInitialize()
   updatePropertyVisibility();
 
   transformer_guard_->initialize(context_);
+}
+
+void RobotModelDisplay::load(const rviz_common::Config & config)
+{
+  // Cache the "Links" subtree and replay it once the URDF has been parsed
+  // and the per-link / per-joint properties exist (done in display_urdf_content).
+  RTDClass::load(config);
+  saved_robot_config_ = config.mapGetChild("Links");
 }
 
 void RobotModelDisplay::updateAlpha()
@@ -287,6 +296,26 @@ void RobotModelDisplay::display_urdf_content()
 
   setStatus(StatusProperty::Ok, "URDF", "URDF parsed OK");
   robot_->load(descr);
+
+  // Re-apply per-link / per-joint settings from the saved config that were
+  // dropped during initial load() because the URDF had not yet been parsed.
+  if (saved_robot_config_.isValid()) {
+    for (const auto & name_link_pair : robot_->getLinks()) {
+      rviz_common::Config link_cfg =
+        saved_robot_config_.mapGetChild(QString::fromStdString(name_link_pair.first));
+      if (link_cfg.isValid()) {
+        name_link_pair.second->getLinkProperty()->load(link_cfg);
+      }
+    }
+    for (const auto & name_joint_pair : robot_->getJoints()) {
+      rviz_common::Config joint_cfg =
+        saved_robot_config_.mapGetChild(QString::fromStdString(name_joint_pair.first));
+      if (joint_cfg.isValid()) {
+        name_joint_pair.second->getJointProperty()->load(joint_cfg);
+      }
+    }
+  }
+
   std::stringstream ss;
   for (const auto & name_link_pair : robot_->getLinks()) {
     const std::string err = name_link_pair.second->getGeometryErrors();


### PR DESCRIPTION
## Description

Fixes #870 (which was closed prematurely as a MoveIt issue but reproduces with the stock `rviz_default_plugins/RobotModel` display, as confirmed in the later comment thread).

When you change a per-link property in a `RobotModel` display — for example `Show Axes`, `Show Trail`, `Alpha`, or the link's visibility checkbox `Value` — the change is correctly written to the saved `.rviz` config, but it is **not restored** the next time the config is loaded. Per-joint `Show Axes` / `Value` have the same problem. 
This was identified to be because when `Display::load` runs, the URDF has not arrived yet. The `Links` property has only its 5 fixed children (`Link Tree Style`, `Expand Tree`, `Expand Link Details`, `Expand Joint Details`, `All Links Enabled`). The per-link / per-joint blocks are read from the YAML and discarded.

This PR implements a fix to load these parameters when the urdf topic is received (if still valid), mirroring the pattern already used for `TFDisplay` for dynamically-created frames.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

Yes, saved link-specific properties will now be reloaded when rviz is relaunched with a saved config.

### Did you use Generative AI?

Yes, Claude code used to clean up original implementation.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
