### PR TITLE
Don't use windeployqt

### DIFF
--- a/rviz2/CMakeLists.txt
+++ b/rviz2/CMakeLists.txt
@@ -26,28 +26,6 @@ else()
   find_package(Qt5 REQUIRED COMPONENTS Widgets)
   set(QT_VERSION_MAJOR 5)
 endif()
-set(QT_VERSION "${Qt${QT_VERSION_MAJOR}_VERSION}")
-# TODO(wjwwood): this block is to setup the windeployqt tool, could be removed later.
-if(Qt${QT_VERSION_MAJOR}_FOUND AND WIN32 AND TARGET Qt${QT_VERSION_MAJOR}::qmake AND NOT TARGET Qt${QT_VERSION_MAJOR}::windeployqt)
-  get_target_property(_qt_qmake_location Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
-
-  execute_process(
-    COMMAND "${_qt_qmake_location}" -query QT${QT_VERSION_MAJOR}_INSTALL_PREFIX
-    RESULT_VARIABLE return_code
-    OUTPUT_VARIABLE qt_install_prefix
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-  set(imported_location "${qt_install_prefix}/bin/windeployqt.exe")
-
-  if(EXISTS ${imported_location})
-    add_executable(Qt${QT_VERSION_MAJOR}::windeployqt IMPORTED)
-
-    set_target_properties(Qt${QT_VERSION_MAJOR}::windeployqt PROPERTIES
-      IMPORTED_LOCATION ${imported_location}
-    )
-  endif()
-endif()
 
 add_executable(${PROJECT_NAME}
   src/main.cpp
@@ -58,35 +36,6 @@ target_link_libraries(${PROJECT_NAME}
   rviz_ogre_vendor::OgreOverlay
   Qt${QT_VERSION_MAJOR}::Widgets
 )
-
-# TODO(wjwwood): find a way to make this optional or to run without "deploying" the
-#                necessary dlls and stuff to the bin folder.
-#                see:
-# https://stackoverflow.com/questions/41193584/deploy-all-qt-dependencies-when-building#41199492
-if(TARGET Qt${QT_VERSION_MAJOR}::windeployqt)
-  # execute windeployqt in a tmp directory after build
-  add_custom_command(TARGET ${PROJECT_NAME}
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
-    COMMAND set PATH=%PATH%$<SEMICOLON>${qt_install_prefix}/bin
-    COMMAND
-    Qt${QT_VERSION_MAJOR}::windeployqt
-    --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
-    "$<TARGET_FILE_DIR:${PROJECT_NAME}>/$<TARGET_FILE_NAME:${PROJECT_NAME}>"
-  )
-
-  # copy deployment directory during installation
-  install(
-    DIRECTORY
-    "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/"
-    DESTINATION bin
-  )
-  install(
-    DIRECTORY
-    "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/"
-    DESTINATION lib/${PROJECT_NAME}
-  )
-endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
Tested on my windows laptop. This bit of code apparently is unnecessary. If I delete it, I can still run RViz fine.

Seems like this was theorized to be unnecessary a while ago:

https://github.com/conda-forge/qt-feedstock/issues/132#issuecomment-1540907508

And robostack has been patching out this code since at least Foxy or Eloquent https://github.com/RoboStack/ros-foxy/blob/master/patch/ros-eloquent-rviz2.patch

Fixes https://github.com/ros2/rviz/issues/44

To be backported to Lyrical in support of https://github.com/ros2/ros2/pull/1834
