### PR TITLE
Make sure to disconnect subscription callback when unsubscribing

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_transport_display.hpp
@@ -150,6 +150,7 @@ protected:
 
   virtual void unsubscribe()
   {
+    subscription_callback_.disconnect();
     subscription_->unsubscribe();
   }
 


### PR DESCRIPTION
## Description

Before this change the subscription_callback_ would not be reset when unsubscribing. Thus when later resubscribing both the new and old callbacks would be called. This resulted in the processMessage being called multiple times for each message. This would also be reflected in the FPS estimate under the Status.

### Is this user-facing behavior change?

Image Callbacks are no longer processed multiple times. Topic FPS estimates are more accurate.

### Did you use Generative AI?

No

### Additional Information

