### PR TITLE
Make sure to disconnect subscription callback when unsubscribing

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -302,6 +302,7 @@ void ImageDisplay::resetSubscription()
 
 void ImageDisplay::unsubscribe()
 {
+  subscription_callback_.disconnect();
   if (subscription_) {
     subscription_->unsubscribe();
   }


### PR DESCRIPTION
## Description

Before this change the subscription_callback_ would not be reset when unsubscribing. Thus when later resubscribing both the new and old callbacks would be called. This resulted in the processMessage being called multiple times for each message. This would also be reflected in the FPS estimate under the Status.

### Is this user-facing behavior change?

Image Callbacks are no longer processed multiple times. Topic FPS estimates are more accurate.

### Did you use Generative AI?

No

### Additional Information

Only tested on kilted, but this should be the equivalent for rolling, see: https://github.com/ros2/rviz/pull/1741
