### PR TITLE
Disable cursor-pixel readout in `CameraDisplay`

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
@@ -119,8 +119,8 @@ protected:
   std::unique_ptr<rviz_common::RenderPanel> render_panel_;
 
   // Latest image for pixel-value readout under the mouse pointer. Exposed to
-  // subclasses (e.g. CameraDisplay) so they can keep it in sync when they
-  // override processMessage.
+  // subclasses so they can keep it in sync when they override processMessage,
+  // or leave it unset to disable the pixel-value readout feature.
   sensor_msgs::msg::Image::ConstSharedPtr last_msg_;
 
 private:

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp
@@ -665,7 +665,11 @@ Ogre::Matrix4 CameraDisplay::calculateProjectionMatrix(
 
 void CameraDisplay::processMessage(sensor_msgs::msg::Image::ConstSharedPtr msg)
 {
-  last_msg_ = msg;
+  // Do not set last_msg_ here to disable the cursor-pixel readout inherited
+  // from ImageDisplay because it's broken for CameraDisplay because its mapping
+  // ignores the Zoom Factor and some more in calculateScreenCorners().
+  // With last_msg_ left unset, mapWidgetPosToImagePixel() returns false
+  // and the tooltip/status stay empty instead of reporting wrong pixel values.
   texture_->addMessage(msg);
 }
 


### PR DESCRIPTION
## Description

The pixel-value readout added in e6813d8d ("Show pixel co-ordinate with their pixel value in image", #1716) lives in ImageDisplay and maps cursor position to image pixel coordinates assuming the image fills the panel with plain aspect-preserving letterboxing. CameraDisplay inherits this mapping but lays out its background image rectangle differently — via calculateScreenCorners(), which scales the rectangle by the user-controlled "Zoom Factor", applies a FOV-derived (not pixel-derived) aspect ratio, and honors CameraInfo.roi. None of that is taken into account by the inherited mapping, so the reported pixel value is wrong whenever the zoom factor is not 1 (and slightly off in some other cases too).

Rather than duplicate or generalize the mapping for CameraDisplay, disable the readout there by no longer populating last_msg_ in CameraDisplay::processMessage(). With last_msg_ left unset, mapWidgetPosToImagePixel() short-circuits and the tooltip/status stay empty — silence is better than a plausible-looking but incorrect value. ImageDisplay itself is unaffected.

Fixes https://github.com/ros2/rviz/issues/1747

### Is this user-facing behavior change?

Yes, this fixes a user-facing bug.

### Did you use Generative AI?

Claude Opus 4.7
