### PR TITLE
Fix disabled displays (addresses #1773)

### DIFF
--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -411,6 +411,11 @@ void Display::setAssociatedWidget(QWidget * widget)
         SLOT(associatedPanelVisibilityChange(bool)));
       connect(associated_widget_panel_, SIGNAL(closed()), this, SLOT(disable()));
       associated_widget_panel_->setIcon(getIcon());
+
+      // If this display is not enabled, hide this panel immediately so it won't appear on startup
+      if (!isEnabled()) {
+        associated_widget_panel_->hide();
+      }
     } else {
       associated_widget_panel_ = nullptr;
       associated_widget_->setWindowTitle(getName());

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display.cpp
@@ -209,7 +209,9 @@ void PoseWithCovarianceDisplay::updateShapeVisibility()
 
 void PoseWithCovarianceDisplay::updateCovariance()
 {
-  covariance_->updateUserData(covariance_property_->getUserData());
+  auto user_data = covariance_property_->getUserData();
+  user_data.visible = isEnabled() && user_data.visible;
+  covariance_->updateUserData(user_data);
   context_->queueRender();
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue with displays inside disabled groups being shown on startup. This only occurs with "fresh" configs with no `WindowState` field in them. See the bug report for screenshots.

We had a similar issue with the covariance ellipses being displayed inside disabled groups in the `PoseWithCovarianceDisplay`. I've included that fix here. Please tell me if I should make another PR instead.

Fixes #1773 

### Is this user-facing behavior change?

Yes. When opening a "fresh" rviz config via the command line (e.g., `ros2 run rviz2 rviz2 -d /path/to/config.rviz`), if that config has a disabled group with an enabled display beneath it, the display will (correctly) not appear.

### Did you use Generative AI?

No.

### Additional Information

I am not certain I've gone about this in the most effective way, so please tell me if there's a preferred approach.
