### PR TITLE
Removed warning ros_image_texture.cpp

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
@@ -226,7 +226,7 @@ bool ROSImageTexture::update()
       data_size = repacked.size();
       // Reflect the repack so any downstream code reading stride_ sees the
       // new (packed) layout.
-      stride_ = packed_row;
+      stride_ = static_cast<uint32_t>(packed_row);
     }
   }
 


### PR DESCRIPTION
## Description

Related with https://ci.ros2.org/job/ci_windows/28204/msbuild/folder.-26622514/

