### PR TITLE
Implement destructor for PointCloud2TransportDisplay to unsubscribe on destruction

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_transport_display.hpp
@@ -55,6 +55,12 @@ public:
   /// the long templated class name to refer to their super class.
   typedef PointCloud2TransportDisplay<MessageType> PC2RDClass;
 
+  // Ensure subscriber_filter_ outlives tf_filter_ during destruction.
+  ~PointCloud2TransportDisplay() override
+  {
+    unsubscribe();
+  }
+
 protected:
   void subscribe() override
   {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Fixes occasional crash `[bash-1] free(): chunks in smallbin corrupted` when switching from one rviz config to another 

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
