### PR TITLE
Refactor panel deletion logic in VisualizationFrame to prevent issue during bulk-clearing

### DIFF
--- a/rviz_common/src/rviz_common/visualization_frame.cpp
+++ b/rviz_common/src/rviz_common/visualization_frame.cpp
@@ -917,11 +917,19 @@ void VisualizationFrame::saveWindowGeometry(Config config)
 void VisualizationFrame::loadPanels(const Config & config)
 {
   // First destroy any existing custom panels.
-  for (int i = 0; i < custom_panels_.size(); i++) {
-    delete custom_panels_[i].dock;
-    delete custom_panels_[i].delete_action;
+  for (auto & panel_record : custom_panels_) {
+    // Avoid mutating custom_panels_ from onPanelDeleted() while bulk-clearing.
+    disconnect(panel_record.dock, &QObject::destroyed, this, &VisualizationFrame::onPanelDeleted);
+
+    if (panel_record.delete_action) {
+      delete_view_menu_->removeAction(panel_record.delete_action);
+      panel_record.delete_action->deleteLater();
+    }
+
+    delete panel_record.dock;
   }
   custom_panels_.clear();
+  delete_view_menu_->setDisabled(delete_view_menu_->actions().isEmpty());
 
   // Then load the ones in the config.
   int num_custom_panels = config.listLength();


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This fixes a regression where opening a new RViz config could leave panels from the previous config alive, causing panels to accumulate across successive config loads.

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes - someone more familiar with rviz2 and QT should review please

### Additional Information

to be backported to Lyrical
