### PR TITLE
Add rendering guard for width and/or height being 0

### DIFF
--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -238,9 +238,6 @@ RenderWindowImpl::initialize()
 void
 RenderWindowImpl::resize(size_t width, size_t height)
 {
-  // Guard against zero dimensions: OGRE's GLXWindow::windowMovedOrResized()
-  // fails to create a drawable for a zero-size window and then XFree()s a bad
-  // pointer, aborting the process. Nothing can be drawn at zero size anyway.
   if (width == 0 || height == 0) {
     this->renderLater();
     return;

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -128,6 +128,10 @@ RenderWindowImpl::renderNow()
     return;
   }
 
+  if (parent_->width() == 0 || parent_->height() == 0) {
+    return;
+  }
+
   if (!render_system_ || !ogre_render_window_) {
     this->initialize();
     if (setup_scene_callback_) {
@@ -234,6 +238,13 @@ RenderWindowImpl::initialize()
 void
 RenderWindowImpl::resize(size_t width, size_t height)
 {
+  // Guard against zero dimensions: OGRE's GLXWindow::windowMovedOrResized()
+  // fails to create a drawable for a zero-size window and then XFree()s a bad
+  // pointer, aborting the process. Nothing can be drawn at zero size anyway.
+  if (width == 0 || height == 0) {
+    this->renderLater();
+    return;
+  }
   if (ogre_render_window_) {
     this->setCameraAspectRatio();
     ogre_render_window_->resize(

--- a/rviz_rendering/src/rviz_rendering/render_window.cpp
+++ b/rviz_rendering/src/rviz_rendering/render_window.cpp
@@ -171,7 +171,9 @@ RenderWindow::exposeEvent(QExposeEvent * expose_event)
 
   if (this->isExposed()) {
     impl_->resize(this->width(), this->height());
-    this->renderNow();
+    if (this->width() > 0 && this->height() > 0) {
+      this->renderNow();
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Fixes crash when width or height is 0

```
[bash-1] [New Thread 0x7fff715df6c0 (LWP 183569)]
[bash-1] [New Thread 0x7fff70dde6c0 (LWP 183570)]
[bash-1] failed to create drawable
[bash-1] failed to create drawable
[bash-1] [INFO 1781878205.291833753] [rviz2]: Stereo is NOT SUPPORTED
[bash-1] failed to create drawable
[bash-1] failed to create drawable
[bash-1] failed to create drawable
[bash-1] failed to create drawable
[bash-1] free(): invalid pointer
[bash-1]
[bash-1] Thread 1 "rviz2" received signal SIGABRT, Aborted.
[bash-1] __pthread_kill_implementation (threadid=<optimized out>, signo=6, no_tid=0) at ./nptl/pthread_kill.c:44
[bash-1] warning: 44 ./nptl/pthread_kill.c: No such file or directory
[bash-1] #0 __pthread_kill_implementation (threadid=<optimized out>, signo=6, no_tid=0) at ./nptl/pthread_kill.c:44
[bash-1] #1 __pthread_kill_internal (threadid=<optimized out>, signo=6) at ./nptl/pthread_kill.c:89
[bash-1] #2 __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:100
[bash-1] #3 0x00007ffff676db7e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
[bash-1] #4 0x00007ffff67508ec in __GI_abort () at ./stdlib/abort.c:77
[bash-1] #5 0x00007ffff6751979 in __libc_message_impl (vma_name=vma_name@entry=0x7ffff6903569 "glibc: fatal", fmt=fmt@entry=0x7ffff6906ba5 "%s\n") at ../sysdeps/posix/libc_fatal.c:138
[bash-1] #6 0x00007ffff67d8bac in __libc_message_wrapper (vmaname=0x7ffff6903569 "glibc: fatal", fmt=0x7ffff6906ba5 "%s\n") at ../include/stdio.h:203
[bash-1] #7 malloc_printerr (str=<optimized out>) at ./malloc/malloc.c:5341
[bash-1] #8 0x00007ffff67d8bc4 in malloc_printerr_tail (str=<optimized out>) at ./malloc/malloc.c:5358
[bash-1] #9 0x00007ffff4516dad in XFree () from /usr/lib/x86_64-linux-gnu/libX11.so.6
f[bash-1] #10 0x00007fffd457abf1 in Ogre::GLXWindow::windowMovedOrResized (this=0x555556e3ea50) at /opt/auto_ws/build/rviz_ogre_vendor/ogre_vendor-prefix/src/ogre_vendor/RenderSystems/GLSupport/src/GLX/OgreGLXWindow.cpp:641
[bash-1] #11 0x00007ffff7ee8142 in rviz_rendering::RenderWindowImpl::resize (this=0x55555688b580, width=591, height=0) at /opt/auto_ws/src/auto-sandbox/src/vendor/rviz/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp:243
[bash-1] #12 0x00007ffff7ef3737 in rviz_rendering::RenderWindow::exposeEvent (this=0x55555684acb0, expose_event=<optimized out>) at /opt/auto_ws/src/auto-sandbox/src/vendor/rviz/rviz_rendering/src/rviz_rendering/render_window.cpp:193
[bash-1] #13 0x00007ffff5beb8fc in QWindow::event(QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt6Gui.so.6
[bash-1] #14 0x00007ffff7ef396b in rviz_rendering::RenderWindow::event (this=<optimized out>, event=<optimized out>) at /opt/auto_ws/src/auto-sandbox/src/vendor/rviz/rviz_rendering/src/rviz_rendering/render_window.cpp:182
[bash-1] #15 0x00007ffff75e0b7f in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
[bash-1] #16 0x00007ffff6feb098 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
[bash-1] #17 0x00007ffff5b8eb72 in QGuiApplicationPrivate::processExposeEvent(QWindowSystemInterfacePrivate::ExposeEvent*) () from /usr/lib/x86_64-linux-gnu/libQt6Gui.so.6
[bash-1] #18 0x00007ffff5bf02dc in QWindowSystemInterface::sendWindowSystemEvents(QFlagsQEventLoop::ProcessEventsFlag) () from /usr/lib/x86_64-linux-gnu/libQt6Gui.so.6
[bash-1] #19 0x00007fffeeffffe6 in ?? () from /usr/lib/x86_64-linux-gnu/libQt6XcbQpa.so.6
[bash-1] #20 0x00007ffff518fb9b in ?? () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
[bash-1] #21 0x00007ffff51911d7 in ?? () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
[bash-1] #22 0x00007ffff51913c3 in g_main_context_iteration () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
```

I don't really know why the width and/or height are 0 but adding these guards helps with rviz2 not crashing without any further consequences .

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
