### PR TITLE
Removed _buf_cpu topic from Image display selection

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -213,6 +213,7 @@ set(rviz_common_source_files
   src/rviz_common/ros_integration/ros_client_abstraction.cpp
   src/rviz_common/ros_integration/ros_node_abstraction.cpp
   src/rviz_common/ros_topic_display.cpp
+  src/rviz_common/ros_topic_utils.cpp
   src/rviz_common/scaled_image_widget.cpp
   src/rviz_common/screenshot_dialog.cpp
   src/rviz_common/selection_panel.cpp
@@ -387,6 +388,7 @@ if(BUILD_TESTING)
     test/properties/qos_profile_property_test.cpp
     test/visualizer_app_test.cpp
     test/ros_node_abstraction_test.cpp
+    test/ros_topic_utils_test.cpp
     test/transformation/identity_frame_transformer_test.cpp
     ${TEST_SUPPORT_OBJECTS}
     ${SKIP_DISPLAY_TESTS}

--- a/rviz_common/include/rviz_common/ros_topic_utils.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_utils.hpp
@@ -27,44 +27,28 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "rviz_common/properties/ros_topic_multi_type_property.hpp"
+#ifndef RVIZ_COMMON__ROS_TOPIC_UTILS_HPP_
+#define RVIZ_COMMON__ROS_TOPIC_UTILS_HPP_
 
-#include <QApplication>  // NOLINT: cpplint can't handle Qt imports
-#include <algorithm>
-#include <map>
 #include <string>
-#include <vector>
 
-#include "rviz_common/ros_topic_utils.hpp"
+#include "rviz_common/visibility_control.hpp"
 
 namespace rviz_common
 {
-namespace properties
-{
 
-void RosTopicMultiTypeProperty::fillTopicList()
-{
-  QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  clearOptions();
+/// Return true if the given topic or service name is hidden.
+/**
+ * Following the ROS 2 naming conventions, a name is hidden if any of its
+ * '/'-separated tokens starts with an underscore, e.g. the internal
+ * "<topic>/_buf_cpu" channels created by buffer-aware rmw implementations or
+ * the "<action>/_action/feedback" topics used by actions.
+ * This mirrors rclpy's topic_or_service_is_hidden(), which is what
+ * "ros2 topic list" uses to hide such names by default.
+ */
+RVIZ_COMMON_PUBLIC
+bool isTopicOrServiceHidden(const std::string & name);
 
-  std::map<std::string, std::vector<std::string>> published_topics =
-    rviz_ros_node_.lock()->get_topic_names_and_types();
+}  // namespace rviz_common
 
-  for (const auto & topic : published_topics) {
-    if (isTopicOrServiceHidden(topic.first)) {
-      continue;
-    }
-    // Only add topics whose type matches one of the allowed types.
-    for (const auto & type : topic.second) {
-      if (message_types_.contains(QString::fromStdString(type))) {
-        addOptionStd(topic.first);
-        break;  // avoid duplicates if the topic matches more than one allowed type
-      }
-    }
-  }
-  sortOptions();
-  QApplication::restoreOverrideCursor();
-}
-
-}  // end namespace properties
-}  // end namespace rviz_common
+#endif  // RVIZ_COMMON__ROS_TOPIC_UTILS_HPP_

--- a/rviz_common/src/rviz_common/add_display_dialog.cpp
+++ b/rviz_common/src/rviz_common/add_display_dialog.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <format>  // NOLINT(build/include_order) cpplint predates C++20 headers
+#include <iostream>
 #include <map>
 #include <memory>
 #include <string>
@@ -60,6 +61,7 @@
 #include "rviz_common/load_resource.hpp"
 #include "rviz_common/logging.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction.hpp"
+#include "rviz_common/ros_topic_utils.hpp"
 
 namespace rviz_common
 {
@@ -151,6 +153,10 @@ void getPluginGroups(
 {
   std::map<std::string, std::vector<std::string>> topic_names_and_types =
     rviz_ros_node.lock()->get_topic_names_and_types();
+
+  std::erase_if(
+    topic_names_and_types,
+    [](const auto & map_pair) {return isTopicOrServiceHidden(map_pair.first);});
 
   for (const auto & map_pair : topic_names_and_types) {
     QString topic = QString::fromStdString(map_pair.first);

--- a/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
+++ b/rviz_common/src/rviz_common/properties/ros_topic_property.cpp
@@ -37,6 +37,7 @@
 
 #include "rviz_common/properties/ros_topic_property.hpp"
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
+#include "rviz_common/ros_topic_utils.hpp"
 
 namespace rviz_common
 {
@@ -80,6 +81,9 @@ void RosTopicProperty::fillTopicList()
     rviz_ros_node_.lock()->get_topic_names_and_types();
 
   for (const auto & topic : published_topics) {
+    if (isTopicOrServiceHidden(topic.first)) {
+      continue;
+    }
     // Only add topics whose type matches.
     for (const auto & type : topic.second) {
       if (type == std_message_type) {

--- a/rviz_common/src/rviz_common/ros_topic_utils.cpp
+++ b/rviz_common/src/rviz_common/ros_topic_utils.cpp
@@ -27,44 +27,27 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "rviz_common/properties/ros_topic_multi_type_property.hpp"
-
-#include <QApplication>  // NOLINT: cpplint can't handle Qt imports
-#include <algorithm>
-#include <map>
-#include <string>
-#include <vector>
-
 #include "rviz_common/ros_topic_utils.hpp"
+
+#include <string>
 
 namespace rviz_common
 {
-namespace properties
+
+bool isTopicOrServiceHidden(const std::string & name)
 {
-
-void RosTopicMultiTypeProperty::fillTopicList()
-{
-  QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  clearOptions();
-
-  std::map<std::string, std::vector<std::string>> published_topics =
-    rviz_ros_node_.lock()->get_topic_names_and_types();
-
-  for (const auto & topic : published_topics) {
-    if (isTopicOrServiceHidden(topic.first)) {
-      continue;
+  size_t start = 0;
+  while (start < name.size()) {
+    size_t end = name.find('/', start);
+    if (end == std::string::npos) {
+      end = name.size();
     }
-    // Only add topics whose type matches one of the allowed types.
-    for (const auto & type : topic.second) {
-      if (message_types_.contains(QString::fromStdString(type))) {
-        addOptionStd(topic.first);
-        break;  // avoid duplicates if the topic matches more than one allowed type
-      }
+    if (end > start && name[start] == '_') {
+      return true;
     }
+    start = end + 1;
   }
-  sortOptions();
-  QApplication::restoreOverrideCursor();
+  return false;
 }
 
-}  // end namespace properties
-}  // end namespace rviz_common
+}  // namespace rviz_common

--- a/rviz_common/test/ros_topic_utils_test.cpp
+++ b/rviz_common/test/ros_topic_utils_test.cpp
@@ -27,44 +27,30 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "rviz_common/properties/ros_topic_multi_type_property.hpp"
 
-#include <QApplication>  // NOLINT: cpplint can't handle Qt imports
-#include <algorithm>
-#include <map>
-#include <string>
-#include <vector>
+#include <gmock/gmock.h>
 
 #include "rviz_common/ros_topic_utils.hpp"
 
-namespace rviz_common
-{
-namespace properties
-{
+using rviz_common::isTopicOrServiceHidden;
 
-void RosTopicMultiTypeProperty::fillTopicList()
-{
-  QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  clearOptions();
-
-  std::map<std::string, std::vector<std::string>> published_topics =
-    rviz_ros_node_.lock()->get_topic_names_and_types();
-
-  for (const auto & topic : published_topics) {
-    if (isTopicOrServiceHidden(topic.first)) {
-      continue;
-    }
-    // Only add topics whose type matches one of the allowed types.
-    for (const auto & type : topic.second) {
-      if (message_types_.contains(QString::fromStdString(type))) {
-        addOptionStd(topic.first);
-        break;  // avoid duplicates if the topic matches more than one allowed type
-      }
-    }
-  }
-  sortOptions();
-  QApplication::restoreOverrideCursor();
+TEST(IsTopicOrServiceHidden, regular_topics_are_not_hidden) {
+  EXPECT_FALSE(isTopicOrServiceHidden("/camera/image"));
+  EXPECT_FALSE(isTopicOrServiceHidden("/camera/image/compressed"));
+  EXPECT_FALSE(isTopicOrServiceHidden("relative/topic"));
+  EXPECT_FALSE(isTopicOrServiceHidden(""));
+  EXPECT_FALSE(isTopicOrServiceHidden("/"));
 }
 
-}  // end namespace properties
-}  // end namespace rviz_common
+TEST(IsTopicOrServiceHidden, underscore_inside_a_token_is_not_hidden) {
+  EXPECT_FALSE(isTopicOrServiceHidden("/foo_bar/baz"));
+  EXPECT_FALSE(isTopicOrServiceHidden("/foo/bar_baz"));
+}
+
+TEST(IsTopicOrServiceHidden, token_starting_with_underscore_is_hidden) {
+  EXPECT_TRUE(isTopicOrServiceHidden("/camera/image/_buf_cpu"));
+  EXPECT_TRUE(isTopicOrServiceHidden("/_private/topic"));
+  EXPECT_TRUE(isTopicOrServiceHidden("/fibonacci/_action/feedback"));
+  EXPECT_TRUE(isTopicOrServiceHidden("relative/_hidden"));
+  EXPECT_TRUE(isTopicOrServiceHidden("_hidden"));
+}


### PR DESCRIPTION
## Description

When selecting the topic in Image/Camera/DepthCloud I can see some topic `/<topic_name>/_buf_cpu`

This should fix the issue

### Did you use Generative AI?

Claude Opus 4.7
