### PR TITLE
Optimize ogre headers

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
@@ -33,7 +33,8 @@
 
 #ifndef Q_MOC_RUN
 #include <QObject>  // NOLINT: cpplint cannot handle the include order here
-#include <Ogre.h>
+#include <OgreQuaternion.h>
+#include <OgreVector.h>
 
 #include <memory>
 #include <mutex>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.cpp
@@ -30,7 +30,9 @@
 
 #include "rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp"
 
-#include <Ogre.h>
+#include <OgreMath.h>
+#include <OgreQuaternion.h>
+#include <OgreVector.h>
 
 #include <QRegularExpression>
 #include <QString>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_display.cpp
@@ -32,8 +32,6 @@
 #include <memory>
 #include <utility>
 
-#include <Ogre.h>
-
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
@@ -35,8 +35,13 @@
 #include <memory>
 #include <vector>
 
-#include <Ogre.h>  // NOLINT
+#include <OgreHardwarePixelBuffer.h>  // NOLINT
+#include <OgreImage.h>  // NOLINT
+#include <OgrePixelFormat.h>  // NOLINT
+#include <OgreResourceGroupManager.h>  // NOLINT
+#include <OgreTexture.h>  // NOLINT
 #include <OgreTextureManager.h>  // NOLINT
+#include <OgreTextureUnitState.h>  // NOLINT
 
 #include "sensor_msgs/image_encodings.hpp"
 

--- a/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/covariance_visual_test.cpp
@@ -36,7 +36,11 @@
 #include <tuple>
 #include <vector>
 
-#include <Ogre.h>
+#include <OgreEntity.h>
+#include <OgreQuaternion.h>
+#include <OgreRoot.h>
+#include <OgreSceneNode.h>
+#include <OgreVector.h>
 
 #include "rviz_rendering/objects/covariance_visual.hpp"
 #include "../matcher.hpp"

--- a/rviz_rendering/test/rviz_rendering/objects/line_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/line_test.cpp
@@ -34,7 +34,9 @@
 #include <memory>
 #include <vector>
 
-#include <Ogre.h>
+#include <OgreRoot.h>
+#include <OgreSceneNode.h>
+#include <OgreVector.h>
 
 #include "rviz_rendering/objects/line.hpp"
 #include "../ogre_testing_environment.hpp"

--- a/rviz_rendering/test/rviz_rendering/objects/triangle_polygon_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/triangle_polygon_test.cpp
@@ -34,7 +34,10 @@
 #include <memory>
 #include <vector>
 
-#include <Ogre.h>
+#include <OgreColourValue.h>
+#include <OgreRoot.h>
+#include <OgreSceneNode.h>
+#include <OgreVector.h>
 
 #include "rviz_rendering/objects/triangle_polygon.hpp"
 #include "../ogre_testing_environment.hpp"


### PR DESCRIPTION
## Description

Optimize ogre headers

instead of adding <ogre.h> which is quite big, just include what is used.

### Did you use Generative AI?

Claude Opus 4.7 
