### PR TITLE
consolidate test binaries

### DIFF
--- a/rviz_common/src/rviz_common/ros_integration/ros_client_abstraction.cpp
+++ b/rviz_common/src/rviz_common/ros_integration/ros_client_abstraction.cpp
@@ -77,6 +77,10 @@ RosClientAbstraction::ok()
 void
 RosClientAbstraction::shutdown()
 {
+  // Destroy the node before shutting down the context it was created with,
+  // otherwise it is destroyed during static destruction at process exit,
+  // which aborts.
+  rviz_ros_node_.reset();
   rclcpp::shutdown();
 }
 

--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -388,70 +388,12 @@ if(BUILD_TESTING)
     ogre_testing_environment
   )
 
-  ament_add_gmock(fps_view_controller_test
-    test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET fps_view_controller_test)
-    target_include_directories(fps_view_controller_test PRIVATE ${TEST_INCLUDE_DIRS})
-    target_link_libraries(fps_view_controller_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-      Qt${QT_VERSION_MAJOR}::Widgets
-      ogre_testing_environment
-    )
-  endif()
-
-  ament_add_gmock(frame_view_controller_test
-    test/rviz_default_plugins/view_controllers/frame/frame_view_controller_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET frame_view_controller_test)
-    target_include_directories(frame_view_controller_test PRIVATE ${TEST_INCLUDE_DIRS})
-    target_link_libraries(frame_view_controller_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-      Qt${QT_VERSION_MAJOR}::Widgets
-      ogre_testing_environment
-    )
-  endif()
-
-  ament_add_gmock(frame_info_test
-    test/rviz_default_plugins/displays/tf/frame_info_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET frame_info_test)
-    target_include_directories(frame_info_test PRIVATE test)
-    target_link_libraries(frame_info_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
   ament_add_gmock(get_transport_from_topic_test
     test/rviz_default_plugins/displays/image/get_transport_from_topic_test.cpp
     ${TEST_FIXTURE_OBJECTS})
   if(TARGET get_transport_from_topic_test)
     target_include_directories(get_transport_from_topic_test PRIVATE test)
     target_link_libraries(get_transport_from_topic_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(grid_cells_display_test
-    test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET grid_cells_display_test)
-    target_include_directories(grid_cells_display_test PRIVATE test)
-    target_link_libraries(grid_cells_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(image_display_test
-    test/rviz_default_plugins/displays/image/image_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET image_display_test)
-    target_include_directories(image_display_test PRIVATE test)
-    target_link_libraries(image_display_test
-      rviz_default_plugins
-      ogre_testing_environment
-    )
   endif()
 
   add_library(marker_messages STATIC test/rviz_default_plugins/displays/marker/marker_messages.cpp)
@@ -462,7 +404,19 @@ if(BUILD_TESTING)
     rviz_ogre_vendor::OgreMain
   )
 
-  ament_add_gmock(marker_test
+  add_library(pointcloud_messages STATIC test/rviz_default_plugins/pointcloud_messages.cpp)
+  target_link_libraries(pointcloud_messages PRIVATE
+    sensor_msgs::sensor_msgs
+    rclcpp::rclcpp
+  )
+
+  ament_add_gmock(rviz_default_plugins_display_tests
+    test/rviz_default_plugins/display_tests_main.cpp
+    test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
+    test/rviz_default_plugins/view_controllers/frame/frame_view_controller_test.cpp
+    test/rviz_default_plugins/displays/tf/frame_info_test.cpp
+    test/rviz_default_plugins/displays/grid_cells/grid_cells_display_test.cpp
+    test/rviz_default_plugins/displays/image/image_display_test.cpp
     test/rviz_default_plugins/displays/marker/markers/arrow_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/line_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/mesh_resource_marker_test.cpp
@@ -471,277 +425,48 @@ if(BUILD_TESTING)
     test/rviz_default_plugins/displays/marker/markers/text_view_facing_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/triangle_list_marker_test.cpp
     test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET marker_test)
-    target_include_directories(marker_test PRIVATE test)
-    target_link_libraries(marker_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-      marker_messages
-      visualization_msgs::visualization_msgs
-      ogre_testing_environment
-    )
-  endif()
-
-  ament_add_gmock(marker_common_test
     test/rviz_default_plugins/displays/marker/marker_common_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET marker_common_test)
-    target_include_directories(marker_common_test PRIVATE test)
-    target_link_libraries(marker_common_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      visualization_msgs::visualization_msgs
-      rviz_default_plugins
-      marker_messages
-      ogre_testing_environment
-    )
-  endif()
-
-  ament_add_gmock(map_display_test
-    ${TEST_FIXTURE_OBJECTS}
     test/rviz_default_plugins/displays/map/map_display_test.cpp
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET map_display_test)
-    target_include_directories(map_display_test PRIVATE test)
-    target_link_libraries(map_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(measure_tool_test
     test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET measure_tool_test)
-    target_include_directories(measure_tool_test PRIVATE test)
-    target_link_libraries(measure_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(odometry_display_test
     test/rviz_default_plugins/displays/odometry/odometry_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET odometry_display_test)
-    target_include_directories(odometry_display_test PRIVATE test)
-    target_link_libraries(odometry_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(odometry_ogre_helper_test
     test/rviz_default_plugins/displays/odometry/quaternion_helper_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET odometry_ogre_helper_test)
-    target_include_directories(odometry_ogre_helper_test PRIVATE test)
-    target_link_libraries(odometry_ogre_helper_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET orbit_view_controller_test)
-    target_include_directories(orbit_view_controller_test PRIVATE test)
-    target_link_libraries(orbit_view_controller_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      Qt${QT_VERSION_MAJOR}::Widgets
-      rviz_default_plugins
-      ogre_testing_environment
-    )
-  endif()
-
-  ament_add_gmock(ortho_view_controller_test
     test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET ortho_view_controller_test)
-    target_include_directories(ortho_view_controller_test PRIVATE test)
-    target_link_libraries(ortho_view_controller_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-    )
-  endif()
-
-  ament_add_gmock(palette_builder_test
     test/rviz_default_plugins/displays/map/palette_builder_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET palette_builder_test)
-    target_include_directories(palette_builder_test PRIVATE test)
-    target_link_libraries(palette_builder_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(path_display_test
     test/rviz_default_plugins/displays/path/path_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET path_display_test)
-    target_include_directories(path_display_test PRIVATE test)
-    target_link_libraries(path_display_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      visualization_msgs::visualization_msgs
-      rviz_default_plugins
-      ogre_testing_environment
-    )
-  endif()
-
-  add_library(pointcloud_messages STATIC test/rviz_default_plugins/pointcloud_messages.cpp)
-  target_link_libraries(pointcloud_messages PRIVATE
-    sensor_msgs::sensor_msgs
-    rclcpp::rclcpp
-  )
-
-  ament_add_gmock(point_cloud2_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud2_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET point_cloud2_display_test)
-    target_include_directories(point_cloud2_display_test PRIVATE test)
-    target_link_libraries(point_cloud2_display_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-      pointcloud_messages
-    )
-  endif()
-
-  ament_add_gmock(point_cloud_common_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET point_cloud_common_test)
-    target_include_directories(point_cloud_common_test PRIVATE test)
-    target_link_libraries(point_cloud_common_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-      pointcloud_messages
-    )
-  endif()
-
-  ament_add_gmock(point_cloud_scalar_display_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET point_cloud_scalar_display_test)
-    target_include_directories(point_cloud_scalar_display_test PRIVATE test)
-    target_link_libraries(point_cloud_scalar_display_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-      rviz_ogre_vendor::OgreMain
-    )
-  endif()
-
-  ament_add_gmock(point_cloud_transformers_test
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/axis_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/flat_color_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/intensity_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgb8_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/rgbf32_pc_transformer_test.cpp
     test/rviz_default_plugins/displays/pointcloud/point_cloud_transformers/xyz_pc_transformer_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET point_cloud_transformers_test)
-    target_include_directories(point_cloud_transformers_test PRIVATE test)
-    target_link_libraries(point_cloud_transformers_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-      pointcloud_messages
-    )
-  endif()
-
-  ament_add_gmock(point_display_test
     test/rviz_default_plugins/displays/point/point_stamped_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET point_display_test)
-    target_include_directories(point_display_test PRIVATE test)
-    target_link_libraries(point_display_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      geometry_msgs::geometry_msgs
-      rviz_default_plugins
-      ogre_testing_environment
-    )
-  endif()
-
-  ament_add_gmock(pose_array_display_test
     test/rviz_default_plugins/displays/pose_array/pose_array_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET pose_array_display_test)
-    target_include_directories(pose_array_display_test PRIVATE test)
-    target_link_libraries(pose_array_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(pose_tool_test
     test/rviz_default_plugins/tools/pose/pose_tool_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET pose_tool_test)
-    target_include_directories(pose_tool_test PRIVATE test)
-    target_link_libraries(pose_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(range_display_test
     test/rviz_default_plugins/displays/range/range_display_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET range_display_test)
-    target_include_directories(range_display_test PRIVATE test)
-    target_link_libraries(range_display_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(robot_test
     test/rviz_default_plugins/robot/robot_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET robot_test)
-    target_include_directories(robot_test PRIVATE test)
-    target_link_libraries(robot_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-    )
-  endif()
-
-  ament_add_gmock(ros_image_texture_test
     test/rviz_default_plugins/displays/image/ros_image_texture_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET ros_image_texture_test)
-    target_include_directories(ros_image_texture_test PRIVATE test)
-    target_link_libraries(ros_image_texture_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-    )
-  endif()
-
-  ament_add_gmock(selection_tool_test
     test/rviz_default_plugins/tools/select/selection_tool_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET selection_tool_test)
-    target_include_directories(selection_tool_test PRIVATE test)
-    target_link_libraries(selection_tool_test ${TEST_FIXTURE_WITH_MOCK_LIBRARIES} rviz_default_plugins ogre_testing_environment)
-  endif()
-
-  ament_add_gmock(xy_orbit_view_controller_test
     test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
-    ${TEST_FIXTURE_OBJECTS}
-    ${SKIP_DISPLAY_TESTS})
-  if(TARGET xy_orbit_view_controller_test)
-    target_include_directories(xy_orbit_view_controller_test PRIVATE test)
-    target_link_libraries(xy_orbit_view_controller_test
-      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
-      rviz_default_plugins
-    )
-  endif()
-
-  ament_add_gmock(frame_transformer_tf_test
     test/rviz_default_plugins/transformation/frame_transformer_tf_test.cpp
     ${TEST_FIXTURE_OBJECTS}
+    TIMEOUT 300
     ${SKIP_DISPLAY_TESTS})
-  if(TARGET frame_transformer_tf_test)
-    target_include_directories(frame_transformer_tf_test PRIVATE test)
-    target_link_libraries(frame_transformer_tf_test
+  if(TARGET rviz_default_plugins_display_tests)
+    target_include_directories(rviz_default_plugins_display_tests PRIVATE test)
+    target_link_libraries(rviz_default_plugins_display_tests
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
+      ogre_testing_environment
+      marker_messages
+      pointcloud_messages
+      geometry_msgs::geometry_msgs
+      visualization_msgs::visualization_msgs
+      Qt${QT_VERSION_MAJOR}::Widgets
+      rviz_ogre_vendor::OgreMain
     )
   endif()
 

--- a/rviz_default_plugins/test/rviz_default_plugins/display_tests_main.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/display_tests_main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Bosch Software Innovations GmbH.
+// Copyright (c) 2026, Open Source Robotics Foundation, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -28,40 +28,16 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#include "ogre_testing_environment.hpp"
+#include <gmock/gmock.h>
 
-#include <string>
+#include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
 
-#include <OgreLogManager.h>
-
-#include "rviz_rendering/render_window.hpp"
-#include "rviz_rendering/render_system.hpp"
-
-namespace rviz_default_plugins
+// Shared main for the consolidated display tests binary.  Some of the test
+// suites drive Qt widgets, so a QApplication has to exist for the whole run.
+// Suites that need rclcpp manage init/shutdown themselves in their fixtures.
+int main(int argc, char ** argv)
 {
-
-void OgreTestingEnvironment::setUpOgreTestEnvironment(bool debug)
-{
-  // Ogre::LogManager is a singleton, creating it twice is not allowed.
-  // SetUpTestCase() runs once per test suite, and a consolidated test binary
-  // runs several suites in the same process.
-  if (!debug && Ogre::LogManager::getSingletonPtr() == nullptr) {
-    const std::string & name = "";
-    auto lm = new Ogre::LogManager();
-    lm->createLog(name, false, debug, true);
-  }
-  setUpRenderSystem();
+  QApplication app(argc, argv);
+  testing::InitGoogleMock(&argc, argv);
+  return RUN_ALL_TESTS();
 }
-
-void OgreTestingEnvironment::setUpRenderSystem()
-{
-  rviz_rendering::RenderSystem::get();
-}
-
-Ogre::RenderWindow * OgreTestingEnvironment::createOgreRenderWindow()
-{
-  auto test = new rviz_rendering::RenderWindow();
-  return rviz_rendering::RenderSystem::get()->makeRenderWindow(test->winId(), 10, 10, 1.0);
-}
-
-}  // end namespace rviz_default_plugins

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <memory>
@@ -77,6 +76,9 @@ public:
   static void TearDownTestCase()
   {
     transformation_manager_.reset();
+    // Destroy the node before shutting down its context, otherwise it lives
+    // until static destruction at process exit, which aborts.
+    ros_client_abstraction_.reset();
     rclcpp::shutdown();
   }
 
@@ -147,11 +149,4 @@ TEST_F(ImageDisplayTestFixture, initialize_propagates_smooth_scaling_to_texture)
 
   ImageDisplay imageDisplay(std::move(texture_));
   imageDisplay.initialize(context_.get());
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_common_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/marker/marker_common_test.cpp
@@ -79,6 +79,9 @@ public:
   static void TearDownTestCase()
   {
     DisplayTestFixture::TearDownTestCase();
+    // Destroy the node before shutting down its context, otherwise it lives
+    // until static destruction at process exit, which aborts.
+    ros_client_abstraction_.reset();
     rclcpp::shutdown();
   }
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/marker/markers/markers_test_fixture.cpp
@@ -61,6 +61,9 @@ void MarkersTestFixture::SetUpTestCase()
 void MarkersTestFixture::TearDownTestCase()
 {
   DisplayTestFixture::TearDownTestCase();
+  // Destroy the node before shutting down its context, otherwise it lives
+  // until static destruction at process exit, which aborts.
+  ros_client_abstraction_.reset();
   rclcpp::shutdown();
 }
 

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/pointcloud/point_cloud_common_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -233,11 +232,4 @@ TEST_F(
 
   auto point_clouds = rviz_default_plugins::findAllPointClouds(scene_manager_->getRootSceneNode());
   ASSERT_THAT(point_clouds.size(), Eq(0u));
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/robot/robot_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/robot/robot_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <cmath>
@@ -401,7 +400,6 @@ TEST_F(RobotTestFixture, changedExpandTree_hides_link_and_joint_properties_on_de
   EXPECT_FALSE(test_robot_link->isExpanded());
 }
 
-
 TEST_F(RobotTestFixture, changedExpandLinkDetails_shows_link_details) {
   robot_->load(urdf_model_);
 
@@ -475,11 +473,4 @@ TEST_F(RobotTestFixture, changedEnableAllLinks_toggles_all_links) {
   EXPECT_FALSE(prop->childAt(6)->getValue().toBool());
   EXPECT_FALSE(prop->childAt(7)->getValue().toBool());
   EXPECT_FALSE(prop->childAt(8)->getValue().toBool());
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/tools/measure/measure_tool_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <memory>
@@ -72,7 +71,6 @@ public:
 
   std::shared_ptr<rviz_default_plugins::tools::MeasureTool> measure_tool_;
 };
-
 
 TEST_F(MeasureToolTestFixture, choosing_two_objects_shows_a_line_and_the_distance) {
   auto obj1 = addVisible3DObject(10, 10, {1.0, 1.0, 0.0});
@@ -130,11 +128,4 @@ TEST_F(MeasureToolTestFixture, right_clicking_removes_the_measurement_line) {
   measure_tool_->processMouseEvent(click);
 
   ASSERT_FALSE(line->isVisible());
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/tools/pose/pose_tool_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/tools/pose/pose_tool_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <memory>
@@ -131,12 +130,4 @@ TEST_F(PoseToolTestFixture, deactivate_makes_arrow_invisible) {
   auto arrows = rviz_default_plugins::findAllArrows(scene_manager_->getRootSceneNode());
   ASSERT_THAT(arrows, SizeIs(1));
   EXPECT_FALSE(rviz_default_plugins::arrowIsVisible(arrows[0]));
-}
-
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/tools/select/selection_tool_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/tools/select/selection_tool_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <memory>
@@ -125,11 +124,4 @@ TEST_F(SelectionToolTestFixture, processKeyEvent_F_key_should_focus_on_selection
 
   QKeyEvent * keyEvent = new QKeyEvent(QKeyEvent::KeyPress, Qt::Key_F, Qt::NoModifier);
   selection_tool_->processKeyEvent(keyEvent, nullptr);
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/fps/fps_view_controller_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <memory>
@@ -213,11 +212,4 @@ TEST_F(FPSViewControllerTestFixture, mimic_does_not_change_view_when_given_any_v
   EXPECT_THAT(x_position->getValue().toFloat(), FloatNear(orbit_camera_position.x, 0.001f));
   EXPECT_THAT(y_position->getValue().toFloat(), FloatNear(orbit_camera_position.y, 0.001f));
   EXPECT_THAT(z_position->getValue().toFloat(), FloatNear(orbit_camera_position.z, 0.001f));
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/frame/frame_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/frame/frame_view_controller_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <memory>
@@ -82,7 +81,6 @@ public:
     auto enum_property = dynamic_cast<rviz_common::properties::EnumProperty *>(axis_property);
     return enum_property->getOptionInt();
   }
-
 
   void setAxisPropertyOption(int option)
   {
@@ -249,11 +247,4 @@ TEST_F(FrameViewControllerTestFixture,
   frame_->update(zero, zero);
 
   checkCameraLooksAlong(Ogre::Vector3(0, 0, -1));
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/orbit/orbit_view_controller_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <memory>
@@ -244,11 +243,4 @@ TEST_F(OrbitViewControllerTestFixture, mimic_does_not_move_camera_when_given_sam
   EXPECT_THAT(z_property->getValue().toFloat(), FloatNear(old_z_value, 0.001f));
   EXPECT_THAT(yaw_property->getValue().toFloat(), FloatNear(0, 0.001f));
   EXPECT_THAT(pitch_property->getValue().toFloat(), FloatNear(0.5f, 0.001f));
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/ortho/ortho_view_controller_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -199,11 +198,4 @@ TEST_F(
   EXPECT_THAT(y_property->getNameStd(), StrEq("Y"));
   EXPECT_THAT(x_property->getValue().toFloat(), FloatNear(0, 0.001f));
   EXPECT_THAT(y_property->getValue().toFloat(), FloatNear(0, 0.001f));
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/view_controllers/xy_orbit/xy_orbit_view_controller_test.cpp
@@ -27,7 +27,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 #include <gmock/gmock.h>
 
 #include <cmath>
@@ -306,11 +305,4 @@ TEST_F(
 
   float motion_magnitude = std::sqrt(new_x * new_x + new_y * new_y);
   EXPECT_THAT(motion_magnitude, Le(1.1f));
-}
-
-int main(int argc, char ** argv)
-{
-  QApplication app(argc, argv);
-  InitGoogleMock(&argc, argv);
-  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Description

In order to build faster. Consolidate 28 single-suite gmock binaries into one shared-main test executable.

@mjcarroll do you have an opinion here ?

Around 1 min less ot time in my computer.

### Did you use Generative AI?

Claude Opus 4.7

