### PR TITLE
rviz_ogre_vendor: fix macOS SDK detection in vendored OGRE

### DIFF
--- a/rviz_ogre_vendor/patches/0007-macos-sdk-path.patch
+++ b/rviz_ogre_vendor/patches/0007-macos-sdk-path.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f4d8fd4..edfdeec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -271,12 +271,10 @@ elseif(EMSCRIPTEN)
+ elseif (APPLE AND NOT APPLE_IOS)
+ 
+   set(XCODE_ATTRIBUTE_SDKROOT macosx)
+-  if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+-    execute_process(COMMAND xcodebuild -version -sdk "${XCODE_ATTRIBUTE_SDKROOT}" Path | head -n 1 OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
+-    string(REGEX REPLACE "(\r?\n)+$" "" CMAKE_OSX_SYSROOT "${CMAKE_OSX_SYSROOT}")
+-  else()
+-    set(CMAKE_OSX_SYSROOT macosx)
+-  endif()
++  execute_process(
++    COMMAND xcrun --sdk ${XCODE_ATTRIBUTE_SDKROOT} --show-sdk-path
++    OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
++    OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 
+   # Make sure that the OpenGL render system is selected for non-iOS Apple builds
+   set(OGRE_BUILD_RENDERSYSTEM_GLES2 FALSE)


### PR DESCRIPTION
Building rviz_ogre_vendor on macOS fails on Apple Silicon. With Ninja I get:

    fatal error: 'Availability.h' file not found

and with Unix Makefiles I get a corrupted flags.make:

    OgreMain/CMakeFiles/OgreMain.dir/flags.make:10: *** missing separator.  Stop.

Both come from the same block in the pinned OGRE v1.12.10 CMakeLists.txt:

    set(XCODE_ATTRIBUTE_SDKROOT macosx)
    if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
      execute_process(COMMAND xcodebuild -version -sdk "${XCODE_ATTRIBUTE_SDKROOT}" Path | head -n 1 OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
      string(REGEX REPLACE "(\r?\n)+$" "" CMAKE_OSX_SYSROOT "${CMAKE_OSX_SYSROOT}")
    else()
      set(CMAKE_OSX_SYSROOT macosx)
    endif()

execute_process() doesn't run a shell, so `| head -n 1` isn't a pipe. Those
four tokens are passed to xcodebuild as arguments, and current Xcode rejects
`-n`:

    xcodebuild: error: option '-n' is no longer supported

xcodebuild then prints its usage text, that lands in CMAKE_OSX_SYSROOT, and
the newlines end up embedded in flags.make. Older Xcode accepted `-n` as
dry-run and ignored the rest, which is presumably why this went unnoticed.

The else() branch is the Ninja path. Setting CMAKE_OSX_SYSROOT to the literal
string "macosx" only works with the Xcode generator; everything else gets
`-isysroot macosx`, no SDK, and no Availability.h.

This patch replaces the block with a single xcrun call, which returns a clean
absolute path.

Upstream OGRE has already removed this block entirely (it's gone as of 14.6.0),
so this is only needed while rviz_ogre_vendor pins v1.12.10.

Tested on macOS 26.5.2 (arm64), Xcode 26.6.
rviz_ogre_vendor builds cleanly with this applied.
