### PR TITLE
Cleanup headers

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -216,7 +216,7 @@ set(rviz_common_source_files
   src/rviz_common/scaled_image_widget.cpp
   src/rviz_common/screenshot_dialog.cpp
   src/rviz_common/selection_panel.cpp
-  src/rviz_common/interaction/forwards.cpp
+  src/rviz_common/interaction/color_conversion.cpp
   src/rviz_common/interaction/handler_manager.cpp
   src/rviz_common/interaction/selection_handler.cpp
   src/rviz_common/interaction/selection_manager.cpp

--- a/rviz_common/include/rviz_common/adapter_filter_display.hpp
+++ b/rviz_common/include/rviz_common/adapter_filter_display.hpp
@@ -41,6 +41,7 @@
 
 #include <tf2_ros/message_filter.hpp>
 
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/int_property.hpp"
 

--- a/rviz_common/include/rviz_common/config.hpp
+++ b/rviz_common/include/rviz_common/config.hpp
@@ -33,7 +33,6 @@
 #define RVIZ_COMMON__CONFIG_HPP_
 
 #include <algorithm>
-#include <cstdio>
 #include <memory>
 #include <string>
 

--- a/rviz_common/include/rviz_common/depth_cloud_mld.hpp
+++ b/rviz_common/include/rviz_common/depth_cloud_mld.hpp
@@ -37,7 +37,6 @@
 #include <stdexcept>
 #include <exception>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 

--- a/rviz_common/include/rviz_common/display.hpp
+++ b/rviz_common/include/rviz_common/display.hpp
@@ -35,7 +35,6 @@
 #include <string>
 
 #include <QIcon>  // NOLINT: cpplint is unable to handle the include order here
-#include <QSet>  // NOLINT: cpplint is unable to handle the include order here
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rclcpp/time.hpp"

--- a/rviz_common/include/rviz_common/display_context.hpp
+++ b/rviz_common/include/rviz_common/display_context.hpp
@@ -41,7 +41,6 @@
 
 #include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
 #include "rviz_common/visibility_control.hpp"
-#include "frame_manager_iface.hpp"
 
 class QKeyEvent;
 
@@ -83,6 +82,7 @@ class BitAllocator;
 class DisplayFactory;
 class DisplayGroup;
 class FrameManager;
+class FrameManagerIface;
 class RenderPanel;
 class ToolManager;
 class ViewportMouseEvent;

--- a/rviz_common/include/rviz_common/frame_manager_iface.hpp
+++ b/rviz_common/include/rviz_common/frame_manager_iface.hpp
@@ -32,9 +32,7 @@
 #ifndef RVIZ_COMMON__FRAME_MANAGER_IFACE_HPP_
 #define RVIZ_COMMON__FRAME_MANAGER_IFACE_HPP_
 
-#include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 

--- a/rviz_common/include/rviz_common/interaction/color_conversion.hpp
+++ b/rviz_common/include/rviz_common/interaction/color_conversion.hpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2018, Bosch Software Innovations GmbH.
+// Copyright (c) 2008, Willow Garage, Inc.
+// Copyright (c) 2017, Open Source Robotics Foundation, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -28,61 +29,29 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 
-#ifndef RVIZ_DEFAULT_PLUGINS__PUBLISHERS__POINT_CLOUD2_PUBLISHER_HPP_
-#define RVIZ_DEFAULT_PLUGINS__PUBLISHERS__POINT_CLOUD2_PUBLISHER_HPP_
+#ifndef RVIZ_COMMON__INTERACTION__COLOR_CONVERSION_HPP_
+#define RVIZ_COMMON__INTERACTION__COLOR_CONVERSION_HPP_
 
-#include <chrono>
-#include <string>
-#include <vector>
+#include <cstdint>
 
-#include "geometry_msgs/msg/transform_stamped.hpp"
-#include "tf2/LinearMath/Quaternion.hpp"
-#include "rclcpp/node.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
-#include "std_msgs/msg/header.hpp"
+#include <OgrePixelFormat.h>
+#include <OgreColourValue.h>
 
-#include "../pointcloud_messages.hpp"
+#include "rviz_common/interaction/forwards.hpp"
+#include "rviz_common/visibility_control.hpp"
 
-using namespace std::chrono_literals;  // NOLINT
-
-namespace nodes
+namespace rviz_common
+{
+namespace interaction
 {
 
-geometry_msgs::msg::Point32 createPoint(float x, float y, float z)
-{
-  geometry_msgs::msg::Point32 point;
-  point.x = x;
-  point.y = y;
-  point.z = z;
+RVIZ_COMMON_PUBLIC
+uint32_t colorToHandle(Ogre::PixelFormat fmt, uint32_t col);
 
-  return point;
-}
+RVIZ_COMMON_PUBLIC
+CollObjectHandle colorToHandle(const Ogre::ColourValue & color);
 
-class PointCloud2Publisher : public rclcpp::Node
-{
-public:
-  PointCloud2Publisher()
-  : Node("pointcloud2_publisher"),
-    timer_(nullptr),
-    publisher_(nullptr)
-  {
-    publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("pointcloud2", 10);
-    timer_ = this->create_wall_timer(500ms, std::bind(&PointCloud2Publisher::timer_callback, this));
-  }
+}  // namespace interaction
+}  // namespace rviz_common
 
-private:
-  void timer_callback()
-  {
-    auto message = rviz_default_plugins::createPointCloud2WithPoints({{0, 0, 0}});
-    message->header.frame_id = "pointcloud2_frame";
-
-    publisher_->publish(*message);
-  }
-
-  rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr publisher_;
-};
-
-}  // namespace nodes
-
-#endif  // RVIZ_DEFAULT_PLUGINS__PUBLISHERS__POINT_CLOUD2_PUBLISHER_HPP_
+#endif  // RVIZ_COMMON__INTERACTION__COLOR_CONVERSION_HPP_

--- a/rviz_common/include/rviz_common/interaction/forwards.hpp
+++ b/rviz_common/include/rviz_common/interaction/forwards.hpp
@@ -32,13 +32,10 @@
 #ifndef RVIZ_COMMON__INTERACTION__FORWARDS_HPP_
 #define RVIZ_COMMON__INTERACTION__FORWARDS_HPP_
 
-#include <map>
+#include <cstdint>
 #include <set>
 #include <unordered_map>
 #include <vector>
-
-#include <OgrePixelFormat.h>
-#include <OgreColourValue.h>
 
 #include "rviz_common/visibility_control.hpp"
 
@@ -68,13 +65,6 @@ struct Picked
 };
 
 using M_Picked = std::unordered_map<CollObjectHandle, Picked>;
-
-RVIZ_COMMON_PUBLIC
-uint32_t colorToHandle(Ogre::PixelFormat fmt, uint32_t col);
-
-RVIZ_COMMON_PUBLIC
-CollObjectHandle colorToHandle(const Ogre::ColourValue & color);
-
 
 }  // namespace interaction
 }  // namespace rviz_common

--- a/rviz_common/include/rviz_common/interaction/selection_manager.hpp
+++ b/rviz_common/include/rviz_common/interaction/selection_manager.hpp
@@ -40,10 +40,9 @@
 #include <mutex>
 #include <utility>
 
-#include <OgreMaterialManager.h>
-#include <OgreRenderQueueListener.h>
-
-#include <QObject>  // NOLINT: cpplint is unable to handle the include order here
+#include <OgreColourValue.h>
+#include <OgrePixelFormat.h>
+#include <OgreTexture.h>
 
 #include "rviz_common/interaction/forwards.hpp"
 #include "rviz_common/interaction/handler_manager_iface.hpp"

--- a/rviz_common/include/rviz_common/interaction/selection_manager_iface.hpp
+++ b/rviz_common/include/rviz_common/interaction/selection_manager_iface.hpp
@@ -32,14 +32,10 @@
 #ifndef RVIZ_COMMON__INTERACTION__SELECTION_MANAGER_IFACE_HPP_
 #define RVIZ_COMMON__INTERACTION__SELECTION_MANAGER_IFACE_HPP_
 
-#include <map>
 #include <memory>
-#include <mutex>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <vector>
 
 #include <QObject>  // NOLINT: cpplint is unable to handle the include order here
 

--- a/rviz_common/include/rviz_common/interaction/selection_renderer.hpp
+++ b/rviz_common/include/rviz_common/interaction/selection_renderer.hpp
@@ -31,7 +31,6 @@
 #ifndef RVIZ_COMMON__INTERACTION__SELECTION_RENDERER_HPP_
 #define RVIZ_COMMON__INTERACTION__SELECTION_RENDERER_HPP_
 
-#include <map>
 #include <memory>
 #include <string>
 

--- a/rviz_common/include/rviz_common/interaction/view_picker.hpp
+++ b/rviz_common/include/rviz_common/interaction/view_picker.hpp
@@ -38,11 +38,9 @@
 #include <memory>
 #include <vector>
 
-#include <OgreMaterialManager.h>
-#include <OgreRenderQueueListener.h>
+#include <OgrePixelFormat.h>
+#include <OgreTexture.h>
 #include <OgreVector.h>
-
-#include <QObject>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/interaction/forwards.hpp"
 #include "rviz_common/interaction/selection_handler.hpp"

--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -39,6 +39,7 @@
 
 #include <message_filters/subscriber.hpp>
 
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/int_property.hpp"
 

--- a/rviz_common/include/rviz_common/properties/covariance_property.hpp
+++ b/rviz_common/include/rviz_common/properties/covariance_property.hpp
@@ -32,7 +32,6 @@
 #ifndef RVIZ_COMMON__PROPERTIES__COVARIANCE_PROPERTY_HPP_
 #define RVIZ_COMMON__PROPERTIES__COVARIANCE_PROPERTY_HPP_
 
-#include <deque>
 #include <memory>
 
 #include <OgreColourValue.h>

--- a/rviz_common/include/rviz_common/properties/display_visibility_property.hpp
+++ b/rviz_common/include/rviz_common/properties/display_visibility_property.hpp
@@ -32,7 +32,6 @@
 #define RVIZ_COMMON__PROPERTIES__DISPLAY_VISIBILITY_PROPERTY_HPP_
 
 #include <cstdint>
-#include <map>
 #include <string>
 
 #include <QObject>  // NOLINT: cpplint cannot handle the include order here

--- a/rviz_common/include/rviz_common/properties/regex_filter_property.hpp
+++ b/rviz_common/include/rviz_common/properties/regex_filter_property.hpp
@@ -36,7 +36,6 @@
 #include <QValidator>  // NOLINT: cpplint is unable to handle the include order here
 #include <QLineEdit>  // NOLINT: cpplint is unable to handle the include order here
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
-#include <QToolTip>  // NOLINT: cpplint is unable to handle the include order here
 #include <QWidget>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/properties/string_property.hpp"

--- a/rviz_common/include/rviz_common/render_panel.hpp
+++ b/rviz_common/include/rviz_common/render_panel.hpp
@@ -32,10 +32,8 @@
 #ifndef RVIZ_COMMON__RENDER_PANEL_HPP_
 #define RVIZ_COMMON__RENDER_PANEL_HPP_
 
-#include <map>
 #include <memory>
 #include <mutex>
-#include <vector>
 
 #include <OgreVector.h>
 

--- a/rviz_common/include/rviz_common/ros_topic_display.hpp
+++ b/rviz_common/include/rviz_common/ros_topic_display.hpp
@@ -37,9 +37,6 @@
 #include <sstream>
 #include <string>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #endif
@@ -49,7 +46,6 @@
 
 #include "rviz_common/display.hpp"
 #include "rviz_common/display_context.hpp"
-#include "frame_manager_iface.hpp"
 #include "rviz_common/properties/ros_topic_property.hpp"
 #include "rviz_common/properties/qos_profile_property.hpp"
 #include "rviz_common/properties/status_property.hpp"

--- a/rviz_common/include/rviz_common/transformation/frame_transformer.hpp
+++ b/rviz_common/include/rviz_common/transformation/frame_transformer.hpp
@@ -34,7 +34,6 @@
 #include <chrono>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "tf2/buffer_core_interface.hpp"
 #include "tf2/exceptions.hpp"

--- a/rviz_common/include/rviz_common/validate_floats.hpp
+++ b/rviz_common/include/rviz_common/validate_floats.hpp
@@ -31,10 +31,8 @@
 #ifndef RVIZ_COMMON__VALIDATE_FLOATS_HPP_
 #define RVIZ_COMMON__VALIDATE_FLOATS_HPP_
 
-#include <array>
 #include <cmath>
 #include <ranges>  // NOLINT(build/include_order) cpplint predates C++20 headers
-#include <vector>
 
 #include <OgreVector.h>
 #include <OgreQuaternion.h>

--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -32,7 +32,6 @@
 #ifndef RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 #define RVIZ_COMMON__VISUALIZATION_MANAGER_HPP_
 
-#include <deque>
 #include <memory>
 
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here

--- a/rviz_common/include/rviz_common/visualizer_app.hpp
+++ b/rviz_common/include/rviz_common/visualizer_app.hpp
@@ -34,7 +34,6 @@
 
 #include <memory>
 
-#include <QApplication>  // NOLINT: cpplint is unable to handle the include order here
 #include <QObject>  // NOLINT: cpplint is unable to handle the include order here
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
@@ -43,6 +42,7 @@
 
 #include "rviz_rendering/render_window.hpp"
 
+class QApplication;
 class QTimer;
 
 namespace rviz_common

--- a/rviz_common/src/rviz_common/display.cpp
+++ b/rviz_common/src/rviz_common/display.cpp
@@ -50,6 +50,7 @@
 #include "rviz_rendering/apply_visibility_bits.hpp"
 
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/logging.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
 #include "rviz_common/properties/property_tree_model.hpp"

--- a/rviz_common/src/rviz_common/interaction/color_conversion.cpp
+++ b/rviz_common/src/rviz_common/interaction/color_conversion.cpp
@@ -27,7 +27,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "rviz_common/interaction/forwards.hpp"
+#include "rviz_common/interaction/color_conversion.hpp"
 
 #include <cstdint>
 

--- a/rviz_common/src/rviz_common/interaction/selection_manager.cpp
+++ b/rviz_common/src/rviz_common/interaction/selection_manager.cpp
@@ -60,6 +60,7 @@
 #include "rviz_common/logging.hpp"
 #include "rviz_common/render_panel.hpp"
 #include "rviz_common/view_manager.hpp"
+#include "rviz_common/interaction/color_conversion.hpp"
 #include "rviz_common/interaction/handler_manager_iface.hpp"
 #include "rviz_common/interaction/selection_renderer.hpp"
 #include "rviz_common/properties/property.hpp"

--- a/rviz_common/src/rviz_common/transformation_panel.cpp
+++ b/rviz_common/src/rviz_common/transformation_panel.cpp
@@ -35,10 +35,13 @@
 #include <utility>
 #include <vector>
 
+#include <QHBoxLayout>  // NOLINT
+#include <QModelIndex>  // NOLINT
 #include <QPushButton>  // NOLINT
 #include <QString>  // NOLINT
+#include <QTreeView>  // NOLINT
 #include <QVBoxLayout>  // NOLINT
-#include <QtWidgets>  // NOLINT
+#include <QWidget>  // NOLINT
 
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/properties/grouped_checkbox_property.hpp"

--- a/rviz_common/test/mock_display_context.hpp
+++ b/rviz_common/test/mock_display_context.hpp
@@ -38,6 +38,7 @@
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"
 #include "rviz_common/window_manager_interface.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/camera/camera_display.hpp
@@ -53,6 +53,7 @@
 # include "sensor_msgs/msg/camera_info.hpp"
 # include "tf2_ros/message_filter.hpp"
 
+# include "rviz_common/transformation/frame_transformer.hpp"
 # include "rviz_default_plugins/displays/image/image_display.hpp"
 # include "rviz_default_plugins/displays/image/ros_image_texture_iface.hpp"
 # include "rviz_default_plugins/visibility_control.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/depth_cloud/depth_cloud_display.hpp
@@ -32,7 +32,6 @@
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__DEPTH_CLOUD__DEPTH_CLOUD_DISPLAY_HPP_
 
 #ifndef Q_MOC_RUN
-#include <QObject>  // NOLINT: cpplint cannot handle the include order here
 #include <OgreQuaternion.h>
 #include <OgreVector.h>
 
@@ -70,7 +69,6 @@
 
 #include "rviz_default_plugins/visibility_control.hpp"
 
-#include <QMap>  // NOLINT: cpplint cannot handle the include order here
 #include <QString>  // NOLINT: cpplint cannot handle the include order here
 
 namespace rviz_default_plugins

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
@@ -47,7 +47,6 @@
 
 #include <sensor_msgs/msg/image.hpp>
 
-#include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/properties/enum_property.hpp"
 #include "rviz_common/properties/float_property.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/laser_scan/laser_scan_display.hpp
@@ -40,11 +40,9 @@
 #include "laser_geometry/laser_geometry.hpp"
 
 #include "rviz_common/message_filter_display.hpp"
-#include "rviz_common/transformation/frame_transformer.hpp"
 
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_default_plugins/transformation/transformer_guard.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
 #include "rviz_default_plugins/transformation/tf_frame_transformer.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/point/point_stamped_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/point/point_stamped_display.hpp
@@ -35,8 +35,6 @@
 #include <deque>
 #include <memory>
 
-#include <QtCore>  // NOLINT cpplint cannot handle include order here
-
 #include "geometry_msgs/msg/point_stamped.hpp"
 
 // TODO(Martin-Idel-SI): Add again when available

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/pointcloud/point_cloud_scalar_display.hpp
@@ -35,16 +35,12 @@
 #include <memory>
 #include <string>
 
-#include <OgreSceneNode.h>
-#include <OgreSceneManager.h>
-
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/message_filter_display.hpp"
 #include "rviz_common/validate_floats.hpp"
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_common.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
-#include "rviz_rendering/objects/point_cloud.hpp"
 
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/polygon/polygon_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/polygon/polygon_display.hpp
@@ -30,6 +30,8 @@
 #ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__POLYGON__POLYGON_DISPLAY_HPP_
 #define RVIZ_DEFAULT_PLUGINS__DISPLAYS__POLYGON__POLYGON_DISPLAY_HPP_
 
+#include <OgreMaterial.h>
+
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 
 #include "rviz_common/message_filter_display.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/transformation/tf_frame_transformer.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/transformation/tf_frame_transformer.hpp
@@ -39,7 +39,7 @@
 #include <OgreQuaternion.h>
 
 #include "rviz_common/transformation/frame_transformer.hpp"
-#include "rviz_common/ros_integration/ros_node_abstraction.hpp"
+#include "rviz_common/ros_integration/ros_node_abstraction_iface.hpp"
 #include "rviz_default_plugins/transformation/tf_wrapper.hpp"
 
 #include "rviz_default_plugins/visibility_control.hpp"

--- a/rviz_default_plugins/include/rviz_default_plugins/transformation/transformer_guard.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/transformation/transformer_guard.hpp
@@ -39,9 +39,9 @@
 
 #include "rviz_common/display.hpp"
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/transformation/frame_transformer.hpp"
 #include "rviz_common/transformation/transformation_manager.hpp"
-#include "rviz_default_plugins/transformation/tf_wrapper.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
 namespace rviz_default_plugins

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/camera_info/camera_info_display.cpp
@@ -40,6 +40,8 @@
 #include <OgreTextureManager.h>
 #include <OgreTechnique.h>
 #include <OgreHardwarePixelBuffer.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
 
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/effort/effort_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/effort/effort_display.cpp
@@ -42,6 +42,10 @@
 
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+
+#include <rviz_common/frame_manager_iface.hpp>
 #include <rviz_common/validate_floats.hpp>
 
 #include <rviz_common/properties/property.hpp>

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/grid_cells/grid_cells_display.cpp
@@ -37,6 +37,8 @@
 
 #include <OgreBillboardSet.h>
 #include <OgreManualObject.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
 
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/point_cloud.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
@@ -49,9 +49,11 @@
 
 #include "interactive_markers/tools.hpp"
 
+#include "geometry_msgs/msg/transform_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/interaction/view_picker_iface.hpp"
 #include "rviz_common/logging.hpp"
 #include "rviz_common/render_panel.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
@@ -48,6 +48,7 @@
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/interaction/handler_manager.hpp"
 #include "rviz_common/interaction/view_picker_iface.hpp"
 #include "rviz_common/load_resource.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_display.cpp
@@ -41,6 +41,7 @@
 #include "rviz_common/properties/bool_property.hpp"
 #include "rviz_common/validate_floats.hpp"
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/logging.hpp"
 
 #include \

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/points_marker.cpp
@@ -33,6 +33,8 @@
 
 #include <vector>
 
+#include <OgreSceneNode.h>
+
 #include "rviz_common/interaction/selection_manager.hpp"
 
 #include "rviz_default_plugins/displays/marker/marker_common.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/shape_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/shape_marker.cpp
@@ -33,6 +33,8 @@
 
 #include <memory>
 
+#include <OgreSceneNode.h>
+
 #include "rviz_rendering/objects/shape.hpp"
 #include "rviz_common/display_context.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
@@ -34,6 +34,8 @@
 #include <memory>
 #include <string>
 
+#include <OgreSceneNode.h>
+
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/axes.hpp"
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/path/path_display.cpp
@@ -38,6 +38,8 @@
 #include <OgreBillboardSet.h>
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
 #include <OgreTechnique.h>
 
 #include "rviz_common/logging.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pointcloud/point_cloud_common.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <utility>
 
+#include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 #include <OgreWireBoundingBox.h>
 
@@ -47,6 +48,7 @@
 #include "rviz_default_plugins/displays/pointcloud/point_cloud_helpers.hpp"
 #include "rviz_common/display.hpp"
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/logging.hpp"
 #include "rviz_common/properties/enum_property.hpp"
 #include "rviz_common/properties/float_property.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_array/pose_array_display.cpp
@@ -35,6 +35,7 @@
 #include <string>
 
 #include <OgreManualObject.h>
+#include <OgreSceneNode.h>
 #include <OgreMaterialManager.h>
 #include <OgreTechnique.h>
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/pose_covariance/pose_with_covariance_display.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 
 #include <OgreEntity.h>
+#include <OgreSceneNode.h>
 
 #include "rviz_rendering/objects/arrow.hpp"
 #include "rviz_rendering/objects/axes.hpp"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/range/range_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/range/range_display.cpp
@@ -33,6 +33,8 @@
 #include <limits>
 #include <memory>
 
+#include <OgreSceneManager.h>
+
 #include "rviz_rendering/objects/shape.hpp"
 #include "rviz_common/properties/color_property.hpp"
 #include "rviz_common/properties/float_property.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_display_context.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_display_context.hpp
@@ -38,6 +38,7 @@
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"
 #include "rviz_common/window_manager_interface.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/accel_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/accel_publisher.hpp
@@ -34,7 +34,7 @@
 #include <chrono>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 #include "geometry_msgs/msg/accel_stamped.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/camera_info_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/camera_info_publisher.hpp
@@ -34,7 +34,7 @@
 #include <chrono>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/effort_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/effort_publisher.hpp
@@ -34,7 +34,7 @@
 #include <chrono>
 #include <string>
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/node.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 
 using namespace std::chrono_literals;  // NOLINT

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/fluid_pressure_publisher.hpp
@@ -34,7 +34,7 @@
 #include <string>
 #include <chrono>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 #include "sensor_msgs/msg/fluid_pressure.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/grid_cells_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/grid_cells_publisher.hpp
@@ -34,7 +34,7 @@
 #include <chrono>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "nav_msgs/msg/grid_cells.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/illuminance_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/illuminance_publisher.hpp
@@ -34,7 +34,7 @@
 #include <string>
 #include <chrono>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 #include "sensor_msgs/msg/illuminance.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/image_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/image_publisher.hpp
@@ -37,7 +37,7 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/laser_scan_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/laser_scan_publisher.hpp
@@ -36,7 +36,7 @@
 #include <cmath>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "tf2/LinearMath/Quaternion.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/map_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/map_publisher.hpp
@@ -36,7 +36,7 @@
 #include <memory>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/marker_array_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/marker_array_publisher.hpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "std_msgs/msg/header.hpp"
 
 // TODO(greimela): Workaround for duplicate constant definition

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/marker_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/marker_publisher.hpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "std_msgs/msg/header.hpp"
 
 // TODO(greimela): Workaround for duplicate constant definition

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/odometry_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/odometry_publisher.hpp
@@ -38,7 +38,7 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/path_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/path_publisher.hpp
@@ -36,7 +36,7 @@
 #include <cmath>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/point_cloud_publisher.hpp
@@ -36,7 +36,7 @@
 
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2/LinearMath/Quaternion.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "sensor_msgs/msg/point_cloud.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/point_stamped_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/point_stamped_publisher.hpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include "geometry_msgs/msg/point_stamped.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_array_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_array_publisher.hpp
@@ -34,7 +34,7 @@
 #include <chrono>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "geometry_msgs/msg/pose.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_publisher.hpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_with_covariance_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/pose_with_covariance_publisher.hpp
@@ -42,7 +42,7 @@
 
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "rclcpp/clock.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "tf2_ros/transform_broadcaster.hpp"
 

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/range_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/range_publisher.hpp
@@ -36,7 +36,7 @@
 #include <cmath>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "sensor_msgs/msg/range.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/relative_humidity_publisher.hpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <chrono>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 #include "sensor_msgs/msg/relative_humidity.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/single_marker_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/single_marker_publisher.hpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 #include "std_msgs/msg/header.hpp"
 
 // TODO(greimela): Workaround for duplicate constant definition

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/temperature_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/temperature_publisher.hpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <chrono>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 #include "sensor_msgs/msg/temperature.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/twist_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/twist_publisher.hpp
@@ -34,7 +34,7 @@
 #include <chrono>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/publishers/wrench_publisher.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/publishers/wrench_publisher.hpp
@@ -34,7 +34,7 @@
 #include <string>
 #include <chrono>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 #include "geometry_msgs/msg/wrench_stamped.hpp"
 #include "std_msgs/msg/header.hpp"

--- a/rviz_rendering/include/rviz_rendering/objects/axes.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/axes.hpp
@@ -35,7 +35,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <vector>
 
 #include <OgreVector.h>
 

--- a/rviz_rendering/include/rviz_rendering/objects/grid.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/grid.hpp
@@ -34,7 +34,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <vector>
 
 #include <OgreColourValue.h>
 #include <OgreMaterial.h>

--- a/rviz_rendering/include/rviz_rendering/objects/point_cloud.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/point_cloud.hpp
@@ -33,7 +33,6 @@
 #define RVIZ_RENDERING__OBJECTS__POINT_CLOUD_HPP_
 
 #include <cstdint>
-#include <deque>
 #include <memory>
 #include <string>
 #include <vector>
@@ -45,8 +44,6 @@
 #include <OgreVector.h>
 #include <OgreMaterial.h>
 #include <OgreColourValue.h>
-#include <OgreRoot.h>
-#include <OgreHardwareBufferManager.h>
 #include <OgreSharedPtr.h>
 
 #include "point_cloud_renderable.hpp"

--- a/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
+++ b/rviz_rendering/include/rviz_rendering/objects/point_cloud_renderable.hpp
@@ -41,8 +41,7 @@
 #include <OgreVector.h>
 #include <OgreMaterial.h>
 #include <OgreColourValue.h>
-#include <OgreRoot.h>
-#include <OgreHardwareBufferManager.h>
+#include <OgreHardwareVertexBuffer.h>
 #include <OgreSharedPtr.h>
 
 #include "rviz_rendering/visibility_control.hpp"

--- a/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/point_cloud.cpp
@@ -36,6 +36,7 @@
 #include <sstream>
 #include <vector>
 
+#include <OgreHardwareBuffer.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 #include <OgreVector.h>

--- a/rviz_rendering/src/rviz_rendering/objects/point_cloud_renderable.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/point_cloud_renderable.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 
 #include <OgreCamera.h>
+#include <OgreHardwareBufferManager.h>
 
 #include "rviz_rendering/objects/point_cloud.hpp"
 

--- a/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
+++ b/rviz_rendering/test/rviz_rendering/objects/point_cloud_renderable_test.cpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include <OgreCamera.h>
+#include <OgreRoot.h>
 
 #include "rviz_rendering/objects/point_cloud.hpp"
 #include "rviz_rendering/objects/point_cloud_renderable.hpp"

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/display_handler.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/display_handler.hpp
@@ -34,6 +34,7 @@
 #include <memory>
 #include <vector>
 
+#include <QPushButton>  // NOLINT: cpplint is unable to handle the include order here
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_visual_testing_framework/page_objects/base_page_object.hpp"

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/image_tester.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/image_tester.hpp
@@ -34,7 +34,8 @@
 # pragma warning(push)
 # pragma warning(disable : 4996)
 #endif
-#include <Ogre.h>
+#include <OgreImage.h>
+#include <OgreString.h>
 #ifdef _WIN32
 # pragma warning(pop)
 #endif

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/rviz_scene_test.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/rviz_scene_test.hpp
@@ -36,9 +36,11 @@
 # pragma warning(push)
 # pragma warning(disable : 4996)
 #endif
-#include <Ogre.h>
-#include <OgreSceneManager.h>
 #include <OgreCamera.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreString.h>
+#include <OgreVector.h>
 #ifdef _WIN32
 # pragma warning(pop)
 #endif

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/visual_test.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/internal/visual_test.hpp
@@ -36,7 +36,8 @@
 # pragma warning(push)
 # pragma warning(disable : 4996)
 #endif
-#include <Ogre.h>
+#include <OgreString.h>
+#include <OgreVector.h>
 #ifdef _WIN32
 # pragma warning(pop)
 #endif

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/page_objects/base_page_object.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/page_objects/base_page_object.hpp
@@ -36,8 +36,9 @@
 #include <memory>
 #include <vector>
 
+#include <QModelIndex>  // NOLINT
+#include <QObject>  // NOLINT
 #include <QString>  // NOLINT
-#include <QtWidgets>  // NOLINT
 
 #include "rviz_visual_testing_framework/internal/executor.hpp"
 

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/visual_test_fixture.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/visual_test_fixture.hpp
@@ -34,8 +34,6 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/clock.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "tf2/LinearMath/Quaternion.hpp"
@@ -45,6 +43,8 @@
 #include "rviz_visual_testing_framework/internal/executor.hpp"
 #include "rviz_visual_testing_framework/internal/visual_test.hpp"
 #include "rviz_visual_testing_framework/page_objects/page_object_with_window.hpp"
+
+class QApplication;
 
 class VisualTestFixture : public testing::Test
 {

--- a/rviz_visual_testing_framework/include/rviz_visual_testing_framework/visual_test_publisher.hpp
+++ b/rviz_visual_testing_framework/include/rviz_visual_testing_framework/visual_test_publisher.hpp
@@ -36,7 +36,7 @@
 #include <thread>
 #include <vector>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
 
 struct PublisherWithFrame
 {

--- a/rviz_visual_testing_framework/src/internal/display_handler.cpp
+++ b/rviz_visual_testing_framework/src/internal/display_handler.cpp
@@ -32,8 +32,16 @@
 #include <memory>
 #include <vector>
 
+#include <QApplication>  // NOLINT
+#include <QDialog>  // NOLINT
+#include <QDialogButtonBox>  // NOLINT
+#include <QPushButton>  // NOLINT
+#include <QRect>  // NOLINT
+#include <QTabWidget>  // NOLINT
+#include <QTreeWidget>  // NOLINT
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
+#include <QWidget>  // NOLINT
 
 #include "rviz_visual_testing_framework/test_helpers.hpp"
 

--- a/rviz_visual_testing_framework/src/internal/image_tester.cpp
+++ b/rviz_visual_testing_framework/src/internal/image_tester.cpp
@@ -31,6 +31,10 @@
 
 #include <gtest/gtest.h>
 
+#include <OgreColourValue.h>
+#include <OgreDataStream.h>
+#include <OgreMath.h>
+
 ImageTester::ImageTester(Ogre::String reference_directory_path, Ogre::String test_directory_path)
 : reference_directory_path_(reference_directory_path),
   test_directory_path_(test_directory_path),

--- a/rviz_visual_testing_framework/src/internal/rviz_scene_test.cpp
+++ b/rviz_visual_testing_framework/src/internal/rviz_scene_test.cpp
@@ -29,6 +29,8 @@
 
 #include "rviz_visual_testing_framework/internal/rviz_scene_test.hpp"
 
+#include <OgreNode.h>
+
 #include <iostream>
 #include <memory>
 #include <string>

--- a/rviz_visual_testing_framework/src/internal/visual_test.cpp
+++ b/rviz_visual_testing_framework/src/internal/visual_test.cpp
@@ -30,6 +30,8 @@
 
 #include <gtest/gtest.h>
 
+#include <OgreMeshManager.h>
+
 #include <memory>
 #ifdef _WIN32
 #include <stdlib.h>

--- a/rviz_visual_testing_framework/src/page_objects/base_page_object.cpp
+++ b/rviz_visual_testing_framework/src/page_objects/base_page_object.cpp
@@ -34,6 +34,8 @@
 #include <utility>
 #include <vector>
 
+#include <QComboBox>  // NOLINT
+#include <QLocale>  // NOLINT
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 #include <QTest>  // NOLINT
 

--- a/rviz_visual_testing_framework/src/test_helpers.cpp
+++ b/rviz_visual_testing_framework/src/test_helpers.cpp
@@ -33,6 +33,7 @@
 
 #include <QApplication>  // NOLINT
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
+#include <QWidget>  // NOLINT
 
 namespace helpers
 {

--- a/rviz_visual_testing_framework/src/visual_test_fixture.cpp
+++ b/rviz_visual_testing_framework/src/visual_test_fixture.cpp
@@ -34,6 +34,9 @@
 #include <string>
 #include <vector>
 
+#include <QApplication>  // NOLINT
+#include <QDir>  // NOLINT
+#include <QLocale>  // NOLINT
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include "rviz_common/ros_integration/ros_client_abstraction.hpp"


### PR DESCRIPTION
## Description

Cleanup headers. Saves 26.4 seconds on a clean build of the six rviz packages

### Did you use Generative AI?

Claude Opus 4.7
