### PR TITLE
Add TFTrajectory display to visualize the path a TF frame has taken

### DIFF
--- a/rviz_default_plugins/CMakeLists.txt
+++ b/rviz_default_plugins/CMakeLists.txt
@@ -126,6 +126,7 @@ set(rviz_default_plugins_headers_to_moc
   include/rviz_default_plugins/displays/temperature/temperature_display.hpp
   include/rviz_default_plugins/displays/tf/frame_info.hpp
   include/rviz_default_plugins/displays/tf/tf_display.hpp
+  include/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.hpp
   include/rviz_default_plugins/displays/twist/twist_display.hpp
   include/rviz_default_plugins/displays/wrench/wrench_display.hpp
   include/rviz_default_plugins/robot/robot.hpp
@@ -213,6 +214,7 @@ set(rviz_default_plugins_source_files
   src/rviz_default_plugins/displays/tf/frame_info.cpp
   src/rviz_default_plugins/displays/tf/frame_selection_handler.cpp
   src/rviz_default_plugins/displays/tf/tf_display.cpp
+  src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp
   src/rviz_default_plugins/displays/wrench/wrench_display.cpp
   src/rviz_default_plugins/displays/twist/twist_display.cpp
   src/rviz_default_plugins/robot/robot.cpp
@@ -839,6 +841,19 @@ if(BUILD_TESTING)
     target_link_libraries(frame_transformer_tf_test
       ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
       rviz_default_plugins
+    )
+  endif()
+
+  ament_add_gmock(tf_trajectory_display_test
+    test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp
+    ${TEST_FIXTURE_OBJECTS}
+    ${SKIP_DISPLAY_TESTS})
+  if(TARGET tf_trajectory_display_test)
+    target_include_directories(tf_trajectory_display_test PRIVATE test)
+    target_link_libraries(tf_trajectory_display_test
+      ${TEST_FIXTURE_WITH_MOCK_LIBRARIES}
+      rviz_default_plugins
+      ogre_testing_environment
     )
   endif()
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.hpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2015, JSK Lab
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// This file is a ROS 2 port of jsk_rviz_plugins TFTrajectoryDisplay.
+
+#ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__TF_TRAJECTORY__TF_TRAJECTORY_DISPLAY_HPP_
+#define RVIZ_DEFAULT_PLUGINS__DISPLAYS__TF_TRAJECTORY__TF_TRAJECTORY_DISPLAY_HPP_
+
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <string>
+
+#include "rclcpp/time.hpp"
+#include "rviz_common/display.hpp"
+#include "rviz_default_plugins/visibility_control.hpp"
+
+namespace rviz_common
+{
+namespace properties
+{
+class ColorProperty;
+class FloatProperty;
+class TfFrameProperty;
+}  // namespace properties
+}  // namespace rviz_common
+
+namespace rviz_rendering
+{
+class BillboardLine;
+}  // namespace rviz_rendering
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+
+class RVIZ_DEFAULT_PLUGINS_PUBLIC TFTrajectoryDisplay : public rviz_common::Display
+{
+  Q_OBJECT
+
+public:
+  /// Constructor for testing, which skips onInitialize().
+  explicit TFTrajectoryDisplay(rviz_common::DisplayContext * context);
+  TFTrajectoryDisplay();
+  ~TFTrajectoryDisplay() override;
+
+  void onInitialize() override;
+  void onEnable() override;
+  void onDisable() override;
+  void fixedFrameChanged() override;
+  void reset() override;
+  void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
+
+private Q_SLOTS:
+  void updateFrame();
+  void updateDuration();
+  void updateColor();
+  void updateLineWidth();
+
+private:
+  struct TrajectoryPoint
+  {
+    rclcpp::Time stamp;
+    float x;
+    float y;
+    float z;
+  };
+
+  void clearTrajectory();
+  void trimExpiredPoints(const rclcpp::Time & now);
+  void redrawTrajectory();
+
+  rviz_common::properties::TfFrameProperty * frame_property_;
+  rviz_common::properties::FloatProperty * duration_property_;
+  rviz_common::properties::FloatProperty * line_width_property_;
+  rviz_common::properties::ColorProperty * color_property_;
+
+  std::unique_ptr<rviz_rendering::BillboardLine> trajectory_line_;
+  std::deque<TrajectoryPoint> trajectory_;
+  std::string frame_id_;
+};
+
+}  // namespace displays
+}  // namespace rviz_default_plugins
+
+#endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__TF_TRAJECTORY__TF_TRAJECTORY_DISPLAY_HPP_

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.hpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2026, Iori Yanokura
 // Copyright (c) 2015, JSK Lab
 // All rights reserved.
 //

--- a/rviz_default_plugins/plugins_description.xml
+++ b/rviz_default_plugins/plugins_description.xml
@@ -263,6 +263,16 @@
   </class>
 
   <class
+    name="rviz_default_plugins/TFTrajectory"
+    type="rviz_default_plugins::displays::TFTrajectoryDisplay"
+    base_class_type="rviz_common::Display"
+  >
+    <description>
+      Displays the trajectory of a selected TF frame relative to the fixed frame.
+    </description>
+  </class>
+
+  <class
     name="rviz_default_plugins/TwistStamped"
     type="rviz_default_plugins::displays::TwistStampedDisplay"
     base_class_type="rviz_common::Display"

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp
@@ -1,0 +1,310 @@
+// Copyright (c) 2015, JSK Lab
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// This file is a ROS 2 port of jsk_rviz_plugins TFTrajectoryDisplay.
+
+#include "rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <OgreQuaternion.h>
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+#include <OgreVector3.h>
+
+#include "rclcpp/duration.hpp"
+#include "rviz_common/display_context.hpp"
+#include "rviz_common/frame_manager_iface.hpp"
+#include "rviz_common/properties/color_property.hpp"
+#include "rviz_common/properties/float_property.hpp"
+#include "rviz_common/properties/status_property.hpp"
+#include "rviz_common/properties/tf_frame_property.hpp"
+#include "rviz_rendering/objects/billboard_line.hpp"
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+
+namespace
+{
+
+constexpr uint32_t kMaxElementsPerLine = 65536U / 4U;
+
+// Upper bound for the Duration property.  rclcpp::Duration::from_seconds()
+// multiplies by 1e9 into an int64, so an unbounded float overflows it.
+constexpr float kMaxDurationSeconds = 3600.0f;
+
+// Backstop against unbounded growth if duration-based trimming is ever unable
+// to make progress.  At 60 Hz this is over four hours of history.
+constexpr size_t kMaxTrajectoryPoints = 1000000U;
+
+}  // namespace
+
+TFTrajectoryDisplay::TFTrajectoryDisplay()
+: Display(),
+  frame_property_(nullptr),
+  duration_property_(nullptr),
+  line_width_property_(nullptr),
+  color_property_(nullptr)
+{
+  frame_property_ = new rviz_common::properties::TfFrameProperty(
+    "Frame", "",
+    "TF frame to visualize trajectory.",
+    this, nullptr, false, SLOT(updateFrame()), this);
+
+  duration_property_ = new rviz_common::properties::FloatProperty(
+    "Duration", 10.0f,
+    "Duration in seconds to keep trajectory history.",
+    this, SLOT(updateDuration()), this);
+  duration_property_->setMin(0.0f);
+  duration_property_->setMax(kMaxDurationSeconds);
+
+  line_width_property_ = new rviz_common::properties::FloatProperty(
+    "Line Width", 0.05f,
+    "Trajectory line width in meters.",
+    this, SLOT(updateLineWidth()), this);
+  line_width_property_->setMin(0.0f);
+
+  color_property_ = new rviz_common::properties::ColorProperty(
+    "Color", QColor(25, 255, 240),
+    "Color of the trajectory line.",
+    this, SLOT(updateColor()), this);
+}
+
+TFTrajectoryDisplay::TFTrajectoryDisplay(rviz_common::DisplayContext * context)
+: TFTrajectoryDisplay()
+{
+  context_ = context;
+  scene_manager_ = context_->getSceneManager();
+  scene_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode();
+  frame_property_->setFrameManager(context_->getFrameManager());
+  trajectory_line_ = std::make_unique<rviz_rendering::BillboardLine>(scene_manager_, scene_node_);
+}
+
+TFTrajectoryDisplay::~TFTrajectoryDisplay() = default;
+
+void TFTrajectoryDisplay::onInitialize()
+{
+  frame_property_->setFrameManager(context_->getFrameManager());
+  trajectory_line_ = std::make_unique<rviz_rendering::BillboardLine>(scene_manager_, scene_node_);
+
+  updateFrame();
+  updateDuration();
+  updateLineWidth();
+  updateColor();
+}
+
+void TFTrajectoryDisplay::onEnable()
+{
+  clearTrajectory();
+}
+
+void TFTrajectoryDisplay::onDisable()
+{
+  clearTrajectory();
+}
+
+void TFTrajectoryDisplay::fixedFrameChanged()
+{
+  clearTrajectory();
+}
+
+void TFTrajectoryDisplay::reset()
+{
+  Display::reset();
+  clearTrajectory();
+}
+
+void TFTrajectoryDisplay::update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt)
+{
+  (void) wall_dt;
+  (void) ros_dt;
+
+  if (!trajectory_line_) {
+    return;
+  }
+
+  if (frame_id_.empty()) {
+    setStatus(rviz_common::properties::StatusProperty::Warn, "Transform", "Frame is empty");
+    return;
+  }
+
+  const rclcpp::Time now = context_->getClock()->now();
+
+  // A clock-source switch (use_sim_time toggled) or a jump backwards in time
+  // (a rosbag looping) invalidates every stamp recorded so far: rclcpp::Time
+  // refuses to subtract across clock types, and points stamped in the future
+  // would outlive Duration until time caught up again.
+  if (!trajectory_.empty() &&
+    (trajectory_.back().stamp.get_clock_type() != now.get_clock_type() ||
+    now < trajectory_.back().stamp))
+  {
+    clearTrajectory();
+  }
+
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  // Ask for the latest available transform, as Axes does. Requesting it at
+  // `now` makes tf2 resolve a timestamp newer than the most recent sample, so
+  // the lookup fails by extrapolation on every frame. `now` is only used to
+  // stamp the sample for duration trimming.
+  const bool have_transform =
+    context_->getFrameManager()->getTransform(frame_id_, position, orientation);
+
+  bool appended = false;
+  if (have_transform) {
+    setTransformOk();
+    // With a paused clock (`/clock` stopped under use_sim_time) `now` never
+    // advances, so trimming can never drop anything.  Appending one sample per
+    // render tick would then grow the history without bound; only record a
+    // sample once the timestamp has actually moved forward.
+    if (trajectory_.empty() || now > trajectory_.back().stamp) {
+      trajectory_.push_back(TrajectoryPoint{
+            now,
+            position.x,
+            position.y,
+            position.z
+          });
+      appended = true;
+    }
+  } else {
+    std::string error;
+    if (context_->getFrameManager()->transformHasProblems(frame_id_, error)) {
+      setStatusStd(rviz_common::properties::StatusProperty::Error, "Transform", error);
+    } else {
+      setMissingTransformToFixedFrame(frame_id_);
+    }
+  }
+
+  // Trim on every tick, including the path where the lookup failed: once the
+  // frame stops being published the history must still expire after Duration
+  // rather than staying on screen forever.
+  const size_t size_before_trim = trajectory_.size();
+  trimExpiredPoints(now);
+
+  if (appended || trajectory_.size() != size_before_trim) {
+    redrawTrajectory();
+    context_->queueRender();
+  }
+}
+
+void TFTrajectoryDisplay::updateFrame()
+{
+  frame_id_ = frame_property_->getFrameStd();
+  clearTrajectory();
+}
+
+void TFTrajectoryDisplay::updateDuration()
+{
+  if (!context_ || trajectory_.empty()) {
+    return;
+  }
+
+  trimExpiredPoints(context_->getClock()->now());
+  redrawTrajectory();
+  context_->queueRender();
+}
+
+void TFTrajectoryDisplay::updateColor()
+{
+  if (!trajectory_line_) {
+    return;
+  }
+
+  const QColor color = color_property_->getColor();
+  trajectory_line_->setColor(color.redF(), color.greenF(), color.blueF(), 1.0f);
+  context_->queueRender();
+}
+
+void TFTrajectoryDisplay::updateLineWidth()
+{
+  if (!trajectory_line_) {
+    return;
+  }
+
+  trajectory_line_->setLineWidth(line_width_property_->getFloat());
+  context_->queueRender();
+}
+
+void TFTrajectoryDisplay::clearTrajectory()
+{
+  trajectory_.clear();
+  if (trajectory_line_) {
+    trajectory_line_->clear();
+  }
+  if (context_) {
+    context_->queueRender();
+  }
+}
+
+void TFTrajectoryDisplay::trimExpiredPoints(const rclcpp::Time & now)
+{
+  const rclcpp::Duration keep_duration = rclcpp::Duration::from_seconds(
+    std::clamp(duration_property_->getFloat(), 0.0f, kMaxDurationSeconds));
+  while (!trajectory_.empty() && now - trajectory_.front().stamp > keep_duration) {
+    trajectory_.pop_front();
+  }
+  while (trajectory_.size() > kMaxTrajectoryPoints) {
+    trajectory_.pop_front();
+  }
+}
+
+void TFTrajectoryDisplay::redrawTrajectory()
+{
+  if (!trajectory_line_) {
+    return;
+  }
+
+  trajectory_line_->clear();
+  if (trajectory_.empty()) {
+    return;
+  }
+
+  const auto point_count = static_cast<uint32_t>(trajectory_.size());
+  trajectory_line_->setNumLines((point_count - 1U) / kMaxElementsPerLine + 1U);
+  trajectory_line_->setMaxPointsPerLine(std::min(point_count, kMaxElementsPerLine));
+  trajectory_line_->setLineWidth(line_width_property_->getFloat());
+
+  const QColor color = color_property_->getColor();
+  trajectory_line_->setColor(color.redF(), color.greenF(), color.blueF(), 1.0f);
+  for (const auto & point : trajectory_) {
+    trajectory_line_->addPoint(Ogre::Vector3(point.x, point.y, point.z));
+  }
+}
+
+}  // namespace displays
+}  // namespace rviz_default_plugins
+
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
+PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::TFTrajectoryDisplay, rviz_common::Display)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2026, Iori Yanokura
 // Copyright (c) 2015, JSK Lab
 // All rights reserved.
 //

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp
@@ -1,0 +1,185 @@
+// Copyright (c) 2015, JSK Lab
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+
+#include <OgreBillboardChain.h>
+#include <OgreSceneNode.h>
+
+#include "rcl/time.h"
+#include "rclcpp/clock.hpp"
+
+#include "rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.hpp"
+
+#include "../display_test_fixture.hpp"
+#include "../../scene_graph_introspection.hpp"
+
+using namespace ::testing;  // NOLINT
+
+namespace
+{
+
+/// A ROS-time clock whose value only changes when the test says so.
+std::shared_ptr<rclcpp::Clock> createFrozenClock(int64_t nanoseconds)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_enable_ros_time_override(clock->get_clock_handle());
+  rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds);
+  return clock;
+}
+
+void setClock(const std::shared_ptr<rclcpp::Clock> & clock, int64_t nanoseconds)
+{
+  rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds);
+}
+
+size_t countTrajectoryPoints(Ogre::SceneNode * scene_node)
+{
+  auto * chain = rviz_default_plugins::findOneBillboardChain(scene_node);
+  return chain ? chain->getNumChainElements(0) : 0u;
+}
+
+constexpr int64_t kOneSecond = 1000000000;
+
+}  // namespace
+
+class TFTrajectoryTestFixture : public DisplayTestFixture
+{
+public:
+  TFTrajectoryTestFixture()
+  {
+    clock_ = createFrozenClock(100 * kOneSecond);
+    EXPECT_CALL(*context_, getClock()).WillRepeatedly(Return(clock_));
+
+    display_ = std::make_shared<rviz_default_plugins::displays::TFTrajectoryDisplay>(
+      context_.get());
+    display_->setName("TFTrajectory");
+    display_->findProperty("Frame")->setValue("moving_frame");
+  }
+
+  /// The shared fixture only mocks the timestamped overloads; this display asks
+  /// for the latest available transform, which is the three-argument one.
+  void mockLatestTransform(bool available)
+  {
+    EXPECT_CALL(*frame_manager_, getTransform(_, _, _))  // NOLINT
+    .WillRepeatedly(
+      DoAll(
+        SetArgReferee<1>(Ogre::Vector3(1, 2, 3)),
+        SetArgReferee<2>(Ogre::Quaternion::IDENTITY),
+        Return(available)));
+    EXPECT_CALL(*frame_manager_, transformHasProblems(_, _))  // NOLINT
+    .WillRepeatedly(Return(false));
+  }
+
+  void updateDisplay()
+  {
+    display_->update(std::chrono::nanoseconds(0), std::chrono::nanoseconds(0));
+  }
+
+  size_t drawnPoints()
+  {
+    return countTrajectoryPoints(scene_manager_->getRootSceneNode());
+  }
+
+  std::shared_ptr<rviz_default_plugins::displays::TFTrajectoryDisplay> display_;
+};
+
+TEST_F(TFTrajectoryTestFixture, update_draws_one_point_per_step_while_time_advances) {
+  mockLatestTransform(true);
+
+  for (int i = 1; i <= 3; ++i) {
+    setClock(clock_, (100 + i) * kOneSecond);
+    updateDisplay();
+  }
+
+  EXPECT_THAT(drawnPoints(), Eq(3u));
+}
+
+TEST_F(TFTrajectoryTestFixture, update_does_not_grow_the_history_while_the_clock_is_stopped) {
+  mockLatestTransform(true);
+
+  // Simulates use_sim_time with /clock paused: `now` never moves, so nothing
+  // can ever expire. Appending a sample per render tick would grow without
+  // bound, so a stopped clock must not add anything after the first sample.
+  for (int i = 0; i < 20; ++i) {
+    updateDisplay();
+  }
+
+  EXPECT_THAT(drawnPoints(), Eq(1u));
+}
+
+TEST_F(TFTrajectoryTestFixture, update_expires_the_history_when_the_transform_is_lost) {
+  mockLatestTransform(true);
+  setClock(clock_, 101 * kOneSecond);
+  updateDisplay();
+  setClock(clock_, 102 * kOneSecond);
+  updateDisplay();
+  ASSERT_THAT(drawnPoints(), Eq(2u));
+
+  // The frame stops being published: the lookup fails from here on. The
+  // history must still expire after Duration rather than staying on screen.
+  mockLatestTransform(false);
+
+  display_->findProperty("Duration")->setValue(5.0f);
+  setClock(clock_, 200 * kOneSecond);
+  updateDisplay();
+
+  EXPECT_THAT(drawnPoints(), Eq(0u));
+}
+
+TEST_F(TFTrajectoryTestFixture, update_clears_the_history_when_time_jumps_backwards) {
+  mockLatestTransform(true);
+  setClock(clock_, 101 * kOneSecond);
+  updateDisplay();
+  setClock(clock_, 102 * kOneSecond);
+  updateDisplay();
+  ASSERT_THAT(drawnPoints(), Eq(2u));
+
+  // A rosbag looping restarts simulated time; points stamped in the future
+  // would otherwise outlive Duration until time caught up again.
+  setClock(clock_, 10 * kOneSecond);
+  updateDisplay();
+
+  EXPECT_THAT(drawnPoints(), Eq(1u));
+}
+
+TEST_F(TFTrajectoryTestFixture, duration_property_is_clamped_to_a_representable_range) {
+  auto * duration = display_->findProperty("Duration");
+
+  // rclcpp::Duration::from_seconds() multiplies into an int64 of nanoseconds,
+  // so an unbounded value overflows it.
+  duration->setValue(1.0e9f);
+  EXPECT_THAT(duration->getValue().toFloat(), Le(3600.0f));
+
+  duration->setValue(-5.0f);
+  EXPECT_THAT(duration->getValue().toFloat(), Ge(0.0f));
+}

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, JSK Lab
+// Copyright (c) 2026, Iori Yanokura
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Ports TFTrajectory from jsk_rviz_plugins. The TF display can only show where a frame is right
now; this draws where it has been, keeping Duration seconds of history, with configurable line
width and colour. Additive only: no existing display changes behaviour, and no new dependencies.

Verified against a frame moving on a 1 m circle: Duration 20 draws the closed circle and
Duration 4 the corresponding arc — demo video below. Unit tests cover history expiry, a stopped
or rewound clock, and the Duration bounds.

Generative AI: codex (gpt-5.3-codex).


https://github.com/user-attachments/assets/2bd6d4c5-2e91-4a69-9b4d-b9b976df0aed


