### PR TITLE
Fix memory leaks related to OdometryDisplay

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/odometry/odometry_display.cpp
@@ -339,7 +339,7 @@ std::unique_ptr<rviz_rendering::Arrow> OdometryDisplay::createAndSetArrow(
   float alpha = alpha_property_->getFloat();
 
   auto arrow = std::make_unique<rviz_rendering::Arrow>(
-    scene_manager_, scene_node_->createChildSceneNode(),
+    scene_manager_, scene_node_,
     shaft_length_property_->getFloat(),
     shaft_radius_property_->getFloat(),
     head_length_property_->getFloat(),
@@ -357,7 +357,7 @@ std::unique_ptr<rviz_rendering::Axes> OdometryDisplay::createAndSetAxes(
   const Ogre::Vector3 & position, const Ogre::Quaternion & orientation, bool use_axes)
 {
   auto axes = std::make_unique<rviz_rendering::Axes>(
-    scene_manager_, scene_node_->createChildSceneNode(),
+    scene_manager_, scene_node_,
     axes_length_property_->getFloat(),
     axes_radius_property_->getFloat());
   axes->setPosition(position);
@@ -373,7 +373,7 @@ std::unique_ptr<rviz_rendering::CovarianceVisual> OdometryDisplay::createAndSetC
   nav_msgs::msg::Odometry::ConstSharedPtr message)
 {
   auto covariance_visual = std::make_unique<rviz_rendering::CovarianceVisual>(
-    scene_manager_, scene_node_->createChildSceneNode());
+    scene_manager_, scene_node_);
   covariance_visual->setPosition(position);
   covariance_visual->setOrientation(orientation);
   auto quaternion = message->pose.pose.orientation;

--- a/rviz_rendering/src/rviz_rendering/objects/covariance_visual.cpp
+++ b/rviz_rendering/src/rviz_rendering/objects/covariance_visual.cpp
@@ -347,6 +347,7 @@ CovarianceVisual::~CovarianceVisual()
   for (auto orientation_offset_node : orientation_offset_nodes_) {
     scene_manager_->destroySceneNode(orientation_offset_node);
   }
+  scene_manager_->destroySceneNode(orientation_root_node_);
 
   scene_manager_->destroySceneNode(position_scale_node_);
   scene_manager_->destroySceneNode(fixed_orientation_node_);


### PR DESCRIPTION
## Description

**OdometryDisplay:**
`OdometryDisplay` leaks 3 `Ogre::SceneNode`s per received message.

`Arrow`, `Axes`, and `CovarianceVisual` all create a new child node to pass as their respective constructor "parent_node" arguments.

```cpp
auto arrow = std::make_unique<rviz_rendering::Arrow>(
    scene_manager_, scene_node_->createChildSceneNode(),
```

Other displays pass a persistent member node:

https://github.com/paulerikf/rviz/blob/29a82250794edd0cc66bba434bf23d5cea93e05d/rviz_default_plugins/src/rviz_default_plugins/displays/pose/pose_display.cpp#L105-L116
```cpp
  arrow_ = std::make_unique<rviz_rendering::Arrow>(
    scene_manager_, scene_node_,
    ...

  axes_ = std::make_unique<rviz_rendering::Axes>(
    scene_manager_, scene_node_,
    ...
```

**CovarianceVisual** 
Never destroys `orientation_root_node_`

### Additional Information
OdometryDisplay w/ ros2 topic pub at 100 hz:
Before: +4.11 MB/min
After: +0.00 MB/min


