### PR TITLE
Fix implicit narrowing in tf2 time conversion

### DIFF
--- a/rviz_common/src/rviz_common/transformation/tf2_helpers/tf2_conversion_helpers.cpp
+++ b/rviz_common/src/rviz_common/transformation/tf2_helpers/tf2_conversion_helpers.cpp
@@ -59,7 +59,9 @@ fromTf2TimePoint(const tf2::TimePoint & tf2_time)
   const auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(tf2_time);
   const auto nanoseconds = std::chrono::time_point_cast<std::chrono::nanoseconds>(tf2_time) -
     std::chrono::time_point_cast<std::chrono::nanoseconds>(seconds);
-  return rclcpp::Time(seconds.time_since_epoch().count(), nanoseconds.count());
+  return rclcpp::Time(
+    static_cast<std::int32_t>(seconds.time_since_epoch().count()),
+    static_cast<std::uint32_t>(nanoseconds.count()));
 }
 
 tf2::TimePoint


### PR DESCRIPTION
## Description

Fixes #1832.

`fromTf2TimePoint()` passes 64-bit chrono counts to the `rclcpp::Time(int32_t, uint32_t)` constructor. Add explicit fixed-width casts, matching the adjacent `createHeader()` implementation and preventing MSVC C4244 warnings.

### Is this user-facing behavior change?

No.

## Testing

- Focused build of the actual translation unit with GCC 11.4.0 and `-Wconversion -Werror` (failed on the two implicit conversions before the change; passed after)
- Focused conversion/round-trip CTest: 1/1 passed
- `ament_uncrustify`: passed
- `ament_cpplint`: passed
- `git diff --check`: passed

Native MSVC and the full Rolling `rviz_common` suite were not available locally; the host ROS Humble underlay lacks `ament_cmake_ros_core`, so tier-1 CI remains the final platform-specific validation.

Generated-by: OpenAI Codex (GPT-5)