### PR TITLE
Image display let Smooth scaling default to smooth when downscaling, crisp when upscaling

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/image_display.hpp
@@ -88,6 +88,7 @@ public:
   void onInitialize() override;
   void update(std::chrono::nanoseconds wall_dt, std::chrono::nanoseconds ros_dt) override;
   void reset() override;
+  void load(const rviz_common::Config & config) override;
 
   bool eventFilter(QObject * watched, QEvent * event) override;
 
@@ -153,7 +154,7 @@ private:
   rviz_common::properties::FloatProperty * min_property_;
   rviz_common::properties::FloatProperty * max_property_;
   rviz_common::properties::IntProperty * median_buffer_size_property_;
-  rviz_common::properties::BoolProperty * smooth_scaling_property_;
+  rviz_common::properties::EnumProperty * smooth_scaling_property_;
   bool got_float_image_;
 };
 

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -46,6 +46,7 @@
 #include <QMouseEvent>
 #include <QSet>
 #include <QString>
+#include <QVariant>
 
 #include <algorithm>
 #include <cstring>
@@ -62,6 +63,7 @@
 #include "image_transport/subscriber_plugin.hpp"
 #include "pluginlib/class_loader.hpp"
 #include "rclcpp/node.hpp"
+#include "rviz_common/config.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/properties/ros_topic_multi_type_property.hpp"
@@ -78,6 +80,22 @@ namespace rviz_default_plugins
 {
 namespace displays
 {
+
+namespace
+{
+/// "Smooth scaling" modes
+enum class SmoothScaling : int
+{
+  Always = 0,
+  WhenDownscaling = 1,
+  Never = 2,
+};
+
+// Keep these constants as-is to avoid breaking the loading of old configs
+constexpr const char * kSmoothScalingAlways = "Always";
+constexpr const char * kSmoothScalingWhenDownscaling = "When downscaling";
+constexpr const char * kSmoothScalingNever = "Never";
+}  // namespace
 
 ImageDisplay::ImageDisplay()
 : ImageDisplay(std::make_unique<ROSImageTexture>()) {}
@@ -121,12 +139,19 @@ ImageDisplay::ImageDisplay(std::unique_ptr<ROSImageTextureIface> texture)
     "Median window", 5, "Window size for median filter used for computing min/max.", this,
     SLOT(updateNormalizeOptions()));
 
-  smooth_scaling_property_ = new rviz_common::properties::BoolProperty(
-    "Smooth scaling", false,
-    "If enabled, sampling approximately weights all pixels based on area, "
-    "providing good anti-aliasing when downsampling. "
-    "If disabled, sampling uses nearest-neighbour.",
+  smooth_scaling_property_ = new rviz_common::properties::EnumProperty(
+    "Smooth scaling", kSmoothScalingWhenDownscaling,
+    "When to let the rescale sampling weight pixels based on area instead of using nearest-neighbour.\n"
+    "\"Always\": good anti-aliasing when shrinking, smooth when enlarging.\n"
+    "\"When downscaling\": same but crisp when enlarging.\n"
+    "\"Never\": not recommended because this may show aliasing.",
     this, SLOT(updateSmoothScaling()));
+  smooth_scaling_property_->addOption(
+    kSmoothScalingAlways, static_cast<int>(SmoothScaling::Always));
+  smooth_scaling_property_->addOption(
+    kSmoothScalingWhenDownscaling, static_cast<int>(SmoothScaling::WhenDownscaling));
+  smooth_scaling_property_->addOption(
+    kSmoothScalingNever, static_cast<int>(SmoothScaling::Never));
 
   got_float_image_ = false;
 }
@@ -347,7 +372,12 @@ void ImageDisplay::updateNormalizeOptions()
 
 void ImageDisplay::updateSmoothScaling()
 {
-  texture_->setSmoothScaling(smooth_scaling_property_->getBool());
+  // The texture only needs to know whether a mipmap chain is required, which
+  // both smoothing modes need; the minification-vs-magnification distinction
+  // is handled entirely by the material's texture filtering below.
+  const bool needs_mipmaps =
+    smooth_scaling_property_->getOptionInt() != static_cast<int>(SmoothScaling::Never);
+  texture_->setSmoothScaling(needs_mipmaps);
   applySmoothScalingToMaterial(material_);
 }
 
@@ -356,8 +386,22 @@ void ImageDisplay::applySmoothScalingToMaterial(const Ogre::MaterialPtr & materi
   if (!material) {return;}
   Ogre::Pass * pass = material->getTechnique(0)->getPass(0);
   if (pass->getNumTextureUnitStates() == 0) {return;}
-  pass->getTextureUnitState(0)->setTextureFiltering(
-    smooth_scaling_property_->getBool() ? Ogre::TFO_TRILINEAR : Ogre::TFO_NONE);
+  Ogre::TextureUnitState * tu = pass->getTextureUnitState(0);
+  switch (static_cast<SmoothScaling>(smooth_scaling_property_->getOptionInt())) {
+    case SmoothScaling::Always:
+      tu->setTextureFiltering(Ogre::TFO_TRILINEAR);
+      break;
+    case SmoothScaling::WhenDownscaling:
+      // Linear minification with mipmaps anti-aliases when the image is drawn
+      // smaller than native; point magnification keeps individual pixels crisp
+      // when it is drawn larger. The GPU picks min vs mag per fragment from the
+      // actual sampling footprint, so no resolution comparison is needed here.
+      tu->setTextureFiltering(Ogre::FO_LINEAR, Ogre::FO_POINT, Ogre::FO_LINEAR);
+      break;
+    case SmoothScaling::Never:
+      tu->setTextureFiltering(Ogre::TFO_NONE);
+      break;
+  }
 }
 
 void ImageDisplay::clear()
@@ -402,6 +446,23 @@ void ImageDisplay::reset()
   Display::reset();
   messages_received_ = 0;
   clear();
+}
+
+void ImageDisplay::load(const rviz_common::Config & config)
+{
+  _RosTopicDisplay::load(config);
+
+  // Migrate configs written before "Smooth scaling" became an enum
+  // (was a boolean before) such that their appearance stays identical.
+  QVariant legacy;
+  if (config.mapGetValue("Smooth scaling", &legacy)) {
+    const QString value = legacy.toString();
+    if (value == "true" || value == "false") {
+      smooth_scaling_property_->setStringStd(
+        value == "true" ? kSmoothScalingAlways : kSmoothScalingNever);
+      updateSmoothScaling();
+    }
+  }
 }
 
 /* This is called by incomingMessage(). */

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/image_display.cpp
@@ -141,7 +141,7 @@ ImageDisplay::ImageDisplay(std::unique_ptr<ROSImageTextureIface> texture)
 
   smooth_scaling_property_ = new rviz_common::properties::EnumProperty(
     "Smooth scaling", kSmoothScalingWhenDownscaling,
-    "When to let the rescale sampling weight pixels based on area instead of using nearest-neighbour.\n"
+    "When to rescale area-weighted instead of using nearest-neighbour.\n"
     "\"Always\": good anti-aliasing when shrinking, smooth when enlarging.\n"
     "\"When downscaling\": same but crisp when enlarging.\n"
     "\"Never\": not recommended because this may show aliasing.",

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/image/image_display_test.cpp
@@ -38,6 +38,7 @@
 #include <OgreRectangle2D.h>  // NOLINT
 
 #include "../../ogre_testing_environment.hpp"
+#include "rviz_common/config.hpp"
 #include "rviz_common/viewport_mouse_event.hpp"
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
@@ -143,10 +144,31 @@ TEST_F(ImageDisplayTestFixture, initialize_propagates_smooth_scaling_to_texture)
   EXPECT_CALL(*window_manager_, addPane(_, _, _, _)).WillOnce(Return(panelDockWidget));
   EXPECT_CALL(*context_, getFixedFrame()).WillOnce(Return(""));
 
+  EXPECT_CALL(*texture_, setSmoothScaling(true)).Times(AtLeast(1));
+
+  ImageDisplay imageDisplay(std::move(texture_));
+  imageDisplay.initialize(context_.get());
+}
+
+TEST_F(ImageDisplayTestFixture, legacy_false_smooth_scaling_config_disables_mipmaps) {
+  auto panelDockWidget = new rviz_common::PanelDockWidget("panelDockWidget");
+  EXPECT_CALL(*window_manager_, addPane(_, _, _, _)).WillOnce(Return(panelDockWidget));
+  EXPECT_CALL(*context_, getFixedFrame()).WillRepeatedly(Return(""));
+
+  // Loading a pre-enum config with "Smooth scaling: false" must map to "Never"
+  // (nearest, no mipmaps) so the image looks identical to before. The default
+  // "When downscaling" enables mipmaps at init, so allow those calls too and
+  // assert the migration flips the texture back off.
+  EXPECT_CALL(*texture_, setSmoothScaling(_)).Times(AnyNumber());
   EXPECT_CALL(*texture_, setSmoothScaling(false)).Times(AtLeast(1));
 
   ImageDisplay imageDisplay(std::move(texture_));
   imageDisplay.initialize(context_.get());
+
+  rviz_common::Config config;
+  config.mapSetValue("Enabled", false);
+  config.mapSetValue("Smooth scaling", "false");
+  imageDisplay.load(config);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description
Add the ability to enable smooth scaling when downscaling and disable when upscaling, and do so by default.

Reasoning:
- Current options for Smooth scaling (introduced in https://github.com/ros2/rviz/pull/1740) are binary (always on and always off).
- It makes sense that Smooth scaling is enabled by default when downscaling because this avoids showing artifacts to the user (afaik there's not much of a reason to _not_ anti-aliase when downscaling).
- However, enabling it always also means that by default images get smoothed when upscaling, which is likely to be undesirable for users with low-resolution thermal cameras, who expect a blocky view (with each pixel clearly rendered) by default.
- Therefore, introduce (and default to) a third option "When downscaling" - apply smooth scaling when downscaling and nearest-neighbour when upscaling.

Follow-up on https://github.com/ros2/rviz/pull/1740.

### Is this user-facing behavior change?

Yes.

### Did you use Generative AI?

Opus 4.8

### Additional Information

- The Image display "Smooth scaling" feature can be easily tested using the current `osrf/ros:rolling-desktop` Docker image.
- Feedback welcome!
