### PR TITLE
Report incompatible QoS in message filter displays

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -383,6 +383,7 @@ if(BUILD_TESTING)
     test/uniform_string_stream_test.cpp
     test/property_test.cpp
     test/display_test.cpp
+    test/message_filter_display_test.cpp
     test/mock_display_group.cpp
     test/properties/qos_profile_property_test.cpp
     test/visualizer_app_test.cpp

--- a/rviz_common/include/rviz_common/message_filter_display.hpp
+++ b/rviz_common/include/rviz_common/message_filter_display.hpp
@@ -38,6 +38,8 @@
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
 #include <message_filters/subscriber.hpp>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/subscription_options.hpp>
 
 #include "rviz_common/ros_topic_display.hpp"
 #include "rviz_common/properties/int_property.hpp"
@@ -110,6 +112,30 @@ protected:
     resetSubscription();
   }
 
+  rclcpp::SubscriptionOptions createSubscriptionOptions(
+    const rclcpp::Logger & logger, const std::string & topic)
+  {
+    rclcpp::SubscriptionOptions options;
+    options.event_callbacks.incompatible_qos_callback =
+      [this, logger, topic](rclcpp::QOSRequestedIncompatibleQoSInfo & info)
+      {
+        const std::string policy_name =
+          rclcpp::qos_policy_name_from_kind(info.last_policy_kind);
+        RCLCPP_WARN(
+          logger,
+          "New publisher discovered on topic '%s', offering incompatible QoS. "
+          "No messages will be received from it. Last incompatible policy: %s",
+          topic.c_str(), policy_name.c_str());
+        setStatus(
+          properties::StatusProperty::Error,
+          "Topic",
+          QString("Incompatible QoS. No messages will be received from this publisher. "
+            "Last incompatible policy: %1")
+          .arg(QString::fromStdString(policy_name)));
+      };
+    return options;
+  }
+
   virtual void subscribe()
   {
     if (!isEnabled()) {
@@ -124,10 +150,15 @@ protected:
 
     try {
       rclcpp::Node::SharedPtr node = rviz_ros_node_.lock()->get_raw_node();
+      const std::string topic = topic_property_->getTopicStd();
+      // Incompatible QoS discovery may run as soon as the subscription is created.
+      // Set the initial status first so that an event cannot be overwritten with a false OK.
+      setStatus(properties::StatusProperty::Ok, "Topic", "OK");
       subscription_ = std::make_shared<message_filters::Subscriber<MessageType>>(
         node,
-        topic_property_->getTopicStd(),
-        qos_profile);
+        topic,
+        qos_profile,
+        createSubscriptionOptions(node->get_logger(), topic));
       subscription_start_time_ = node->now();
       tf_filter_ =
         std::make_shared<tf2_ros::MessageFilter<MessageType, transformation::FrameTransformer>>(
@@ -140,7 +171,6 @@ protected:
         std::bind(
           &MessageFilterDisplay<MessageType>::messageTaken, this,
           std::placeholders::_1));
-      setStatus(properties::StatusProperty::Ok, "Topic", "OK");
     } catch (rclcpp::exceptions::InvalidTopicNameError & e) {
       setStatus(
         properties::StatusProperty::Error, "Topic", QString("Error subscribing: ") + e.what());

--- a/rviz_common/test/message_filter_display_test.cpp
+++ b/rviz_common/test/message_filter_display_test.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2026, Dylan Gallagher.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/subscription_options.hpp"
+#include "rmw/qos_policy_kind.h"
+#include "rviz_common/message_filter_display.hpp"
+#include "rviz_common/properties/status_property.hpp"
+
+using testing::HasSubstr;
+
+class TestMessageFilterDisplay
+  : public rviz_common::MessageFilterDisplay<geometry_msgs::msg::PoseStamped>
+{
+public:
+  rclcpp::SubscriptionOptions subscriptionOptions()
+  {
+    return createSubscriptionOptions(rclcpp::get_logger("message_filter_display_test"), "/pose");
+  }
+
+  void receiveMessage(const geometry_msgs::msg::PoseStamped::ConstSharedPtr & message)
+  {
+    processTypeErasedMessage(std::static_pointer_cast<const void>(message));
+  }
+
+  void setStatus(
+    rviz_common::properties::StatusProperty::Level level,
+    const QString & name,
+    const QString & text) override
+  {
+    status_level_ = level;
+    status_name_ = name;
+    status_text_ = text;
+  }
+
+  rviz_common::properties::StatusProperty::Level status_level_ =
+    rviz_common::properties::StatusProperty::Ok;
+  QString status_name_;
+  QString status_text_;
+  size_t processed_messages_ = 0;
+
+protected:
+  void processMessage(geometry_msgs::msg::PoseStamped::ConstSharedPtr) override
+  {
+    ++processed_messages_;
+  }
+};
+
+TEST(MessageFilterDisplay, incompatible_qos_updates_topic_status_and_compatible_message_recovers)
+{
+  TestMessageFilterDisplay display;
+  auto options = display.subscriptionOptions();
+  ASSERT_TRUE(options.event_callbacks.incompatible_qos_callback);
+
+  rclcpp::QOSRequestedIncompatibleQoSInfo info{};
+  info.total_count = 1;
+  info.total_count_change = 1;
+  info.last_policy_kind = RMW_QOS_POLICY_RELIABILITY;
+  options.event_callbacks.incompatible_qos_callback(info);
+
+  EXPECT_EQ(rviz_common::properties::StatusProperty::Error, display.status_level_);
+  EXPECT_EQ("Topic", display.status_name_);
+  EXPECT_THAT(display.status_text_.toStdString(), HasSubstr("Incompatible QoS"));
+  EXPECT_THAT(display.status_text_.toStdString(), HasSubstr("RELIABILITY_QOS_POLICY"));
+  EXPECT_EQ(0u, display.processed_messages_);
+
+  display.receiveMessage(std::make_shared<const geometry_msgs::msg::PoseStamped>());
+
+  EXPECT_EQ(rviz_common::properties::StatusProperty::Ok, display.status_level_);
+  EXPECT_EQ("Topic", display.status_name_);
+  EXPECT_THAT(display.status_text_.toStdString(), HasSubstr("1 messages received"));
+  EXPECT_EQ(1u, display.processed_messages_);
+}


### PR DESCRIPTION
## Summary

- report requested-incompatible-QoS discovery as an Error in the generic `MessageFilterDisplay` Topic status
- queue the initial OK status before creating the subscription so an immediate discovery event cannot be overwritten by setup
- preserve the existing recovery behavior: the first compatible message replaces the error with the normal received-message status
- add deterministic coverage for the callback text, policy name, severity, and compatible-message recovery

Closes #1818.

## Validation

- `rviz_common`: full build and 10/10 CTest entries passed under Xvfb, covering 70/70 executable tests
- `rviz_common` linters: copyright, cppcheck, cpplint, lint_cmake, uncrustify, and xmllint passed
- `rviz_default_plugins`: full downstream overlay build passed; all 36 enabled non-visual CTest entries passed (one visual-marked helper remained skipped by the upstream test option)
- Fast DDS + Xvfb + software OpenGL: a reliable Wrench subscription visibly changed from `Status: Error` for a BEST_EFFORT-only publisher to `Status: Ok` with received messages after a RELIABLE publisher started

## Generative tools disclosure

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-17)
