### PR TITLE
Remove unused point_idx variable

### DIFF
--- a/rviz_common/src/rviz_common/depth_cloud_mld.cpp
+++ b/rviz_common/src/rviz_common/depth_cloud_mld.cpp
@@ -219,7 +219,6 @@ MultiLayerDepth::generatePointCloudSL(
   float * cloud_data_ptr = reinterpret_cast<float *>(cloud_msg->data.data());
 
   std::size_t point_count = 0;
-  std::size_t point_idx = 0;
 
   const T * depth_img_ptr = reinterpret_cast<const T *>(depth_msg->data.data());
 
@@ -232,7 +231,7 @@ MultiLayerDepth::generatePointCloudSL(
   // iterate over projection matrix
   for (proj_y = projection_map_y_.begin(); proj_y != proj_y_end; ++proj_y) {
     for (proj_x = projection_map_x_.begin(); proj_x != proj_x_end;
-      ++proj_x, ++point_idx, ++depth_img_ptr)
+      ++proj_x, ++depth_img_ptr)
     {
       T depth_raw = *depth_img_ptr;
       if (DepthTraits<T>::valid(depth_raw)) {


### PR DESCRIPTION
## Description

Removed unused variable 'point_idx' from depth cloud processing.


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
