### PR TITLE
Fix RViz crash when an InteractiveMarkerControl embeds a MESH_RESOURCE marker

### DIFF
--- a/rviz_common/CMakeLists.txt
+++ b/rviz_common/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(resource_retriever REQUIRED)
+find_package(resource_retriever_service_plugin REQUIRED)
 find_package(rviz_rendering REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -261,6 +262,7 @@ target_link_libraries(rviz_common PUBLIC
 
 target_link_libraries(rviz_common PRIVATE
   resource_retriever::resource_retriever
+  resource_retriever_service_plugin::resource_retriever_service_plugin
   tinyxml2::tinyxml2
 )
 

--- a/rviz_common/include/rviz_common/display_context.hpp
+++ b/rviz_common/include/rviz_common/display_context.hpp
@@ -54,6 +54,11 @@ namespace rclcpp
 class Clock;
 }  // namespace rclcpp
 
+namespace resource_retriever
+{
+class Retriever;
+}  // namespace resource_retriever
+
 // namespace tf
 // {
 // class TransformListener;
@@ -169,6 +174,11 @@ public:
   virtual
   ros_integration::RosNodeAbstractionIface::WeakPtr
   getRosNodeAbstraction() const = 0;
+
+  /// Return the resource retriever shared by all displays.
+  virtual
+  resource_retriever::Retriever &
+  getResourceRetriever() = 0;
 
   /// Handle a single key event for a given RenderPanel.
   virtual

--- a/rviz_common/include/rviz_common/visualization_manager.hpp
+++ b/rviz_common/include/rviz_common/visualization_manager.hpp
@@ -254,6 +254,8 @@ public:
 
   ros_integration::RosNodeAbstractionIface::WeakPtr getRosNodeAbstraction() const override;
 
+  resource_retriever::Retriever & getResourceRetriever() override;
+
   /// Return the FrameManager instance.
   FrameManagerIface * getFrameManager() const override;
 
@@ -409,6 +411,7 @@ private:
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
   ros_integration::RosNodeAbstractionIface::WeakPtr rviz_ros_node_;
   rviz_common::transformation::TransformationManager * transformation_manager_;
+  std::unique_ptr<resource_retriever::Retriever> resource_retriever_;
 };
 
 }  // namespace rviz_common

--- a/rviz_common/package.xml
+++ b/rviz_common/package.xml
@@ -43,6 +43,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>resource_retriever</depend>
+  <depend>resource_retriever_service_plugin</depend>
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>
   <depend>sensor_msgs</depend>

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -62,6 +62,8 @@
 #include "rclcpp/node.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "resource_retriever/retriever.hpp"
+#include "resource_retriever_service_plugin/resource_retriever_service_plugin.hpp"
 #include "rviz_rendering/material_manager.hpp"
 #include "rviz_rendering/render_window.hpp"
 
@@ -104,6 +106,7 @@ using rviz_common::interaction::HandlerManager;
 using rviz_common::interaction::SelectionManager;
 using rviz_common::interaction::ViewPicker;
 using rviz_common::interaction::M_Picked;
+using ::resource_retriever_service_plugin::RosServiceResourceRetriever;
 
 // helper class needed to display an icon besides "Global Options"
 class IconizedProperty : public rviz_common::properties::Property
@@ -280,6 +283,19 @@ ros_integration::RosNodeAbstractionIface::WeakPtr
 VisualizationManager::getRosNodeAbstraction() const
 {
   return rviz_ros_node_;
+}
+
+resource_retriever::Retriever & VisualizationManager::getResourceRetriever()
+{
+  if (!resource_retriever_) {
+    resource_retriever::RetrieverVec plugins = resource_retriever::default_plugins();
+    auto ros_iface = rviz_ros_node_.lock();
+    if (ros_iface) {
+      plugins.push_back(std::make_shared<RosServiceResourceRetriever>(*ros_iface->get_raw_node()));
+    }
+    resource_retriever_ = std::make_unique<resource_retriever::Retriever>(std::move(plugins));
+  }
+  return *resource_retriever_;
 }
 
 void VisualizationManager::startUpdate()

--- a/rviz_common/test/mock_display_context.hpp
+++ b/rviz_common/test/mock_display_context.hpp
@@ -40,6 +40,8 @@
 #include "rclcpp/clock.hpp"
 #include "rclcpp/node.hpp"
 
+#include "resource_retriever/retriever.hpp"
+
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
@@ -67,6 +69,8 @@ public:
     updatePluginMessageTypes, void(const QString & class_id, const QSet<QString> & message_types));
   MOCK_CONST_METHOD0(
     getRosNodeAbstraction, rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr());
+
+  MOCK_METHOD0(getResourceRetriever, resource_retriever::Retriever & ());
 
   MOCK_METHOD1(addNodeToMainExecutor, void(std::shared_ptr<rclcpp::Node> node));
   MOCK_METHOD1(removeNodeFromMainExecutor, void(std::shared_ptr<rclcpp::Node> node));

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_common.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/marker_common.hpp
@@ -45,7 +45,6 @@
 
 #include <QString>  // NOLINT: cpplint is unable to handle the include order here
 
-#include "resource_retriever/retriever.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
@@ -124,8 +123,6 @@ public:
   void setMarkerStatus(MarkerID id, StatusLevel level, const std::string & text);
   void deleteMarkerStatus(MarkerID id);
 
-  resource_retriever::Retriever * getResourceRetriever();
-
 private:
   /** @brief Change the visibility for all markers in the given namespace. */
   void setVisibilityForMarkersInNamespace(const std::string & ns, bool visible);
@@ -185,8 +182,6 @@ private:
   rviz_common::Display * display_;
   rviz_common::DisplayContext * context_;
   Ogre::SceneNode * scene_node_;
-
-  resource_retriever::Retriever retriever_;
 
   bool all_namespaces_enabled_ = true;
 

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
@@ -37,6 +37,8 @@
 
 #include <OgreMaterial.h>
 
+#include "resource_retriever/retriever.hpp"
+
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
@@ -84,6 +86,8 @@ protected:
 
   Ogre::Entity * entity_;
   S_MaterialPtr materials_;
+
+  resource_retriever::Retriever retriever_;
 
 private:
   void destroyEntity();

--- a/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.hpp
@@ -37,8 +37,6 @@
 
 #include <OgreMaterial.h>
 
-#include "resource_retriever/retriever.hpp"
-
 #include "rviz_default_plugins/displays/marker/markers/marker_base.hpp"
 #include "rviz_default_plugins/visibility_control.hpp"
 
@@ -86,8 +84,6 @@ protected:
 
   Ogre::Entity * entity_;
   S_MaterialPtr materials_;
-
-  resource_retriever::Retriever retriever_;
 
 private:
   void destroyEntity();

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/marker_common.cpp
@@ -52,15 +52,10 @@
 
 #include "rviz_default_plugins/displays/marker/markers/marker_factory.hpp"
 
-#include "resource_retriever/retriever.hpp"
-#include "resource_retriever_service_plugin/resource_retriever_service_plugin.hpp"
-
 namespace rviz_default_plugins
 {
 namespace displays
 {
-
-using ::resource_retriever_service_plugin::RosServiceResourceRetriever;
 
 MarkerCommon::MarkerCommon(rviz_common::Display * display)
 : display_(display)
@@ -79,16 +74,6 @@ void MarkerCommon::initialize(rviz_common::DisplayContext * context, Ogre::Scene
 {
   context_ = context;
   scene_node_ = scene_node;
-
-  resource_retriever::RetrieverVec plugins = resource_retriever::default_plugins();
-
-  auto ros_iface = context_->getRosNodeAbstraction().lock();
-  if (ros_iface) {
-    plugins.push_back(std::make_shared<RosServiceResourceRetriever>(*ros_iface->get_raw_node()));
-  } else {
-    throw std::invalid_argument("ROS node abstraction interface not valid");
-  }
-  retriever_ = resource_retriever::Retriever(plugins);
 
   namespace_config_enabled_state_.clear();
 
@@ -196,11 +181,6 @@ void MarkerCommon::deleteMarkerStatus(MarkerID id)
 {
   std::string marker_name = id.first + "/" + std::to_string(id.second);
   display_->deleteStatusStd(marker_name);
-}
-
-resource_retriever::Retriever * MarkerCommon::getResourceRetriever()
-{
-  return &this->retriever_;
 }
 
 void MarkerCommon::addMessage(const visualization_msgs::msg::Marker::ConstSharedPtr marker)

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
@@ -42,6 +42,9 @@
 #include <OgreTechnique.h>
 #include <OgreTextureManager.h>
 
+#include "resource_retriever/retriever.hpp"
+#include "resource_retriever_service_plugin/resource_retriever_service_plugin.hpp"
+
 #include "rviz_rendering/mesh_loader.hpp"
 #include "rviz_rendering/material_manager.hpp"
 #include "rviz_common/display_context.hpp"
@@ -57,10 +60,24 @@ namespace displays
 namespace markers
 {
 
+using ::resource_retriever_service_plugin::RosServiceResourceRetriever;
+
 MeshResourceMarker::MeshResourceMarker(
   MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node)
 : MarkerBase(owner, context, parent_node), entity_(nullptr)
-{}
+{
+  if (owner_ == nullptr) {
+    resource_retriever::RetrieverVec plugins = resource_retriever::default_plugins();
+
+    auto ros_iface = context_->getRosNodeAbstraction().lock();
+    if (ros_iface) {
+      plugins.push_back(std::make_shared<RosServiceResourceRetriever>(*ros_iface->get_raw_node()));
+    } else {
+      throw std::invalid_argument("ROS node abstraction interface not valid");
+    }
+    retriever_ = resource_retriever::Retriever(plugins);
+  }
+}
 
 MeshResourceMarker::~MeshResourceMarker()
 {
@@ -112,7 +129,7 @@ void MeshResourceMarker::onNewMessage(
 
     if (
       !rviz_rendering::loadMeshFromResource(
-        owner_->getResourceRetriever(),
+        owner_ ? owner_->getResourceRetriever() : &retriever_,
         new_message->mesh_resource))
     {
       printMeshLoadingError(new_message);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/marker/markers/mesh_resource_marker.cpp
@@ -42,9 +42,6 @@
 #include <OgreTechnique.h>
 #include <OgreTextureManager.h>
 
-#include "resource_retriever/retriever.hpp"
-#include "resource_retriever_service_plugin/resource_retriever_service_plugin.hpp"
-
 #include "rviz_rendering/mesh_loader.hpp"
 #include "rviz_rendering/material_manager.hpp"
 #include "rviz_common/display_context.hpp"
@@ -60,24 +57,10 @@ namespace displays
 namespace markers
 {
 
-using ::resource_retriever_service_plugin::RosServiceResourceRetriever;
-
 MeshResourceMarker::MeshResourceMarker(
   MarkerCommon * owner, rviz_common::DisplayContext * context, Ogre::SceneNode * parent_node)
 : MarkerBase(owner, context, parent_node), entity_(nullptr)
-{
-  if (owner_ == nullptr) {
-    resource_retriever::RetrieverVec plugins = resource_retriever::default_plugins();
-
-    auto ros_iface = context_->getRosNodeAbstraction().lock();
-    if (ros_iface) {
-      plugins.push_back(std::make_shared<RosServiceResourceRetriever>(*ros_iface->get_raw_node()));
-    } else {
-      throw std::invalid_argument("ROS node abstraction interface not valid");
-    }
-    retriever_ = resource_retriever::Retriever(plugins);
-  }
-}
+{}
 
 MeshResourceMarker::~MeshResourceMarker()
 {
@@ -129,7 +112,7 @@ void MeshResourceMarker::onNewMessage(
 
     if (
       !rviz_rendering::loadMeshFromResource(
-        owner_ ? owner_->getResourceRetriever() : &retriever_,
+        &context_->getResourceRetriever(),
         new_message->mesh_resource))
     {
       printMeshLoadingError(new_message);

--- a/rviz_default_plugins/test/rviz_default_plugins/mock_display_context.hpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/mock_display_context.hpp
@@ -39,6 +39,8 @@
 
 #include "rclcpp/clock.hpp"
 
+#include "resource_retriever/retriever.hpp"
+
 #include "rviz_common/display_context.hpp"
 #include "rviz_common/frame_manager_iface.hpp"
 #include "rviz_common/panel_dock_widget.hpp"
@@ -67,6 +69,8 @@ public:
     updatePluginMessageTypes, void(const QString & class_id, const QSet<QString> & message_types));
   MOCK_CONST_METHOD0(
     getRosNodeAbstraction, rviz_common::ros_integration::RosNodeAbstractionIface::WeakPtr());
+
+  MOCK_METHOD0(getResourceRetriever, resource_retriever::Retriever & ());
 
   MOCK_METHOD2(handleChar, void(QKeyEvent * event, rviz_common::RenderPanel * panel));
   MOCK_METHOD1(handleMouseEvent, void(const rviz_common::ViewportMouseEvent & even));


### PR DESCRIPTION
## Description

`MeshResourceMarker` crashes RViz with null-pointer dereference when a `MESH_RESOURCE` marker is embedded in an `InteractiveMarkerControl`. [The marker gets created with a null owner](https://github.com/ros2/rviz/blob/48241da921ba713248f56f54597cd9282f1c0566/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp#L158), but `onNewMessage()` fetches its retriever via `owner_->getResourceRetriever()`.

Fixes #1865 

### Is this user-facing behavior change?

Interactive markers that embed a `MESH_RESOURCE` no longer crash RViz.

### Did you use Generative AI?

Claude Opus 4.8 to find the code path causing the crash.