### PR TITLE
Fix TF trajectory build warnings

### DIFF
--- a/rviz_default_plugins/src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp
@@ -38,10 +38,10 @@
 #include <memory>
 #include <string>
 
+#include <OgreVector.h>
 #include <OgreQuaternion.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
-#include <OgreVector3.h>
 
 #include "rclcpp/duration.hpp"
 #include "rviz_common/display_context.hpp"

--- a/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp
+++ b/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp
@@ -52,14 +52,14 @@ namespace
 std::shared_ptr<rclcpp::Clock> createFrozenClock(int64_t nanoseconds)
 {
   auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  rcl_enable_ros_time_override(clock->get_clock_handle());
-  rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds);
+  EXPECT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(clock->get_clock_handle()));
+  EXPECT_EQ(RCL_RET_OK, rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds));
   return clock;
 }
 
 void setClock(const std::shared_ptr<rclcpp::Clock> & clock, int64_t nanoseconds)
 {
-  rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds);
+  EXPECT_EQ(RCL_RET_OK, rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds));
 }
 
 size_t countTrajectoryPoints(Ogre::SceneNode * scene_node)


### PR DESCRIPTION
## Description

Fix the warnings:

```
--- stderr: rviz_default_plugins
In file included from /root/rcl_ws/src/rviz/rviz_default_plugins/src/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display.cpp:44:
/root/rcl_ws/install/rviz_ogre_vendor/opt/rviz_ogre_vendor/include/OGRE/OgreVector3.h:2:62: note: ‘#pragma message: /root/rcl_ws/install/rviz_ogre_vendor/opt/rviz_ogre_vendor/include/OGRE/OgreVector3.h is deprecated, migrate to Ogre.h’
    2 | #pragma message( __FILE__ " is deprecated, migrate to Ogre.h")
      |                                                              ^
/root/rcl_ws/src/rviz/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp: In function ‘std::shared_ptr<rclcpp::Clock> {anonymous}::createFrozenClock(int64_t)’:
/root/rcl_ws/src/rviz/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp:55:31: warning: ignoring return value of ‘rcl_ret_t rcl_enable_ros_time_override(rcl_clock_t*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   55 |   rcl_enable_ros_time_override(clock->get_clock_handle());
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/rcl_ws/src/rviz/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp:56:28: warning: ignoring return value of ‘rcl_ret_t rcl_set_ros_time_override(rcl_clock_t*, rcl_time_point_value_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   56 |   rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/rcl_ws/src/rviz/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp: In function ‘void {anonymous}::setClock(const std::shared_ptr<rclcpp::Clock>&, int64_t)’:
/root/rcl_ws/src/rviz/rviz_default_plugins/test/rviz_default_plugins/displays/tf_trajectory/tf_trajectory_display_test.cpp:62:28: warning: ignoring return value of ‘rcl_ret_t rcl_set_ros_time_override(rcl_clock_t*, rcl_time_point_value_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   62 |   rcl_set_ros_time_override(clock->get_clock_handle(), nanoseconds);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Originally observed in https://ci.ros2.org/job/ci_linux/30459/gcc/

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Yes, Codex 5.6 Sol 

### Additional Information

