### PR TITLE
Fix render surface size on scaled displays

### DIFF
--- a/rviz_common/include/rviz_common/viewport_mouse_event.hpp
+++ b/rviz_common/include/rviz_common/viewport_mouse_event.hpp
@@ -90,7 +90,15 @@ public:
 
   RenderPanel * panel;
   QEvent::Type type;
+  /// Display scale factor, truncated to an integer. Retained for compatibility only.
+  /**
+   * Do not use this to convert coordinates. Fractional scale factors such as 1.25 and
+   * 1.5 are common on desktop and truncate to 1 here, which silently drops the
+   * conversion. The coordinates below are scaled with the full-precision ratio instead;
+   * see rviz_rendering/pixel_scaling.hpp.
+   */
   int device_pixel_ratio;
+  /// Cursor position in device pixels, matching the Ogre viewport's dimensions.
   int x;
   int y;
   /// Angle that the common vertical mouse wheel was rotated

--- a/rviz_common/src/rviz_common/view_controller.cpp
+++ b/rviz_common/src/rviz_common/view_controller.cpp
@@ -43,6 +43,7 @@
 
 #include "rclcpp/node.hpp"
 
+#include "rviz_rendering/pixel_scaling.hpp"
 #include "rviz_rendering/render_window.hpp"
 
 #include "rviz_common/display_context.hpp"
@@ -232,7 +233,11 @@ void ViewController::save(Config config) const
 void ViewController::handleKeyEvent(QKeyEvent * event, RenderPanel * panel)
 {
   if (event->key() == Qt::Key_F && context_->getViewPicker()) {
-    QPoint mouse_rel_panel = panel->mapFromGlobal(QCursor::pos());
+    // mapFromGlobal returns logical pixels, but the picker works in the viewport's
+    // device pixels, the same space ViewportMouseEvent delivers its coordinates in.
+    const qreal pixel_ratio = panel->getRenderWindow()->devicePixelRatio();
+    QPoint mouse_rel_panel = rviz_rendering::toDevicePixels(
+      panel->mapFromGlobal(QCursor::pos()), pixel_ratio);
     Ogre::Vector3 point_rel_world;  // output of get3DPoint().
     if (
       context_->getViewPicker()->get3DPoint(

--- a/rviz_common/src/rviz_common/viewport_mouse_event.cpp
+++ b/rviz_common/src/rviz_common/viewport_mouse_event.cpp
@@ -34,39 +34,51 @@
 #include <QWheelEvent>
 
 #include "rviz_common/render_panel.hpp"
+#include "rviz_rendering/pixel_scaling.hpp"
 #include "rviz_rendering/render_window.hpp"
 
 namespace rviz_common
 {
 
+// Qt reports positions in logical pixels, the Ogre viewport is in device pixels.
 ViewportMouseEvent::ViewportMouseEvent(RenderPanel * p, QMouseEvent * e, int lx, int ly)
 : panel(p),
   type(e->type()),
   device_pixel_ratio(static_cast<int>(panel->getRenderWindow()->devicePixelRatio())),
-  x(e->position().x() * device_pixel_ratio),
-  y(e->position().y() * device_pixel_ratio),
+  x(0),
+  y(0),
   wheel_delta(0),
   acting_button(e->button()),
   buttons_down(e->buttons()),
   modifiers(e->modifiers()),
-  last_x(lx * device_pixel_ratio),
-  last_y(ly * device_pixel_ratio)
+  last_x(0),
+  last_y(0)
 {
+  const qreal pixel_ratio = panel->getRenderWindow()->devicePixelRatio();
+  x = rviz_rendering::toDevicePixels(e->position().x(), pixel_ratio);
+  y = rviz_rendering::toDevicePixels(e->position().y(), pixel_ratio);
+  last_x = rviz_rendering::toDevicePixels(lx, pixel_ratio);
+  last_y = rviz_rendering::toDevicePixels(ly, pixel_ratio);
 }
 
 ViewportMouseEvent::ViewportMouseEvent(RenderPanel * p, QWheelEvent * e, int lx, int ly)
 : panel(p),
   type(e->type()),
   device_pixel_ratio(static_cast<int>(panel->getRenderWindow()->devicePixelRatio())),
-  x(e->position().x() * device_pixel_ratio),
-  y(e->position().y() * device_pixel_ratio),
+  x(0),
+  y(0),
   wheel_delta(e->angleDelta().y()),
   acting_button(Qt::NoButton),
   buttons_down(e->buttons()),
   modifiers(e->modifiers()),
-  last_x(lx * device_pixel_ratio),
-  last_y(ly * device_pixel_ratio)
+  last_x(0),
+  last_y(0)
 {
+  const qreal pixel_ratio = panel->getRenderWindow()->devicePixelRatio();
+  x = rviz_rendering::toDevicePixels(e->position().x(), pixel_ratio);
+  y = rviz_rendering::toDevicePixels(e->position().y(), pixel_ratio);
+  last_x = rviz_rendering::toDevicePixels(lx, pixel_ratio);
+  last_y = rviz_rendering::toDevicePixels(ly, pixel_ratio);
 }
 
 bool ViewportMouseEvent::left()

--- a/rviz_common/src/rviz_common/visualization_manager.cpp
+++ b/rviz_common/src/rviz_common/visualization_manager.cpp
@@ -56,7 +56,6 @@
 #include <QKeyEvent>  // NOLINT: cpplint cannot handle include order here
 #include <QString>  // NOLINT: cpplint cannot handle include order here
 #include <QTimer>  // NOLINT: cpplint cannot handle include order here
-#include <QWindow>  // NOLINT: cpplint cannot handle include order here
 
 #include "rclcpp/clock.hpp"
 #include "rclcpp/node.hpp"
@@ -616,16 +615,8 @@ void VisualizationManager::handleMouseEvent(const ViewportMouseEvent & vme)
 
   int flags = 0;
   if (current_tool) {
+    // Scaling the coordinates here again used to apply the device pixel ratio twice.
     ViewportMouseEvent _vme = vme;
-
-    QWindow * window = vme.panel->windowHandle();
-    if (window) {
-      double pixel_ratio = window->devicePixelRatio();
-      _vme.x = static_cast<int>(pixel_ratio * _vme.x);
-      _vme.y = static_cast<int>(pixel_ratio * _vme.y);
-      _vme.last_x = static_cast<int>(pixel_ratio * _vme.last_x);
-      _vme.last_y = static_cast<int>(pixel_ratio * _vme.last_y);
-    }
 
     flags = current_tool->processMouseEvent(_vme);
     vme.panel->setCursor(current_tool->getCursor());

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker.cpp
@@ -59,6 +59,7 @@
 #include "rviz_common/logging.hpp"
 #include "rviz_common/render_panel.hpp"
 #include "rviz_rendering/geometry.hpp"
+#include "rviz_rendering/pixel_scaling.hpp"
 #include "rviz_rendering/render_window.hpp"
 
 #include "rviz_default_plugins/displays/interactive_markers/integer_action.hpp"
@@ -369,7 +370,11 @@ bool InteractiveMarker::handle3DCursorEvent(
       Ogre::Vector2 mouse_pos = rviz_rendering::project3DPointToViewportXY(
         rviz_rendering::RenderWindowOgreAdapter::getOgreViewport(event.panel->getRenderWindow()),
         cursor_pos);
-      QCursor::setPos(event.panel->mapToGlobal(QPoint(mouse_pos.x, mouse_pos.y)));
+      // The projection is in viewport (device) pixels; mapToGlobal expects logical ones.
+      const qreal pixel_ratio = event.panel->getRenderWindow()->devicePixelRatio();
+      QCursor::setPos(
+        event.panel->mapToGlobal(
+          rviz_rendering::toLogicalPixels(QPoint(mouse_pos.x, mouse_pos.y), pixel_ratio)));
       showMenu(event, control_name, three_d_point, valid_point);
       return true;
     }

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/interactive_markers/interactive_marker_control.cpp
@@ -58,6 +58,7 @@
 #include "rviz_common/window_manager_interface.hpp"
 #include "rviz_rendering/geometry.hpp"
 #include "rviz_rendering/objects/line.hpp"
+#include "rviz_rendering/pixel_scaling.hpp"
 #include "rviz_rendering/render_window.hpp"
 
 #include "rviz_default_plugins/displays/marker/markers/shape_marker.hpp"
@@ -1124,7 +1125,11 @@ void InteractiveMarkerControl::handle3DCursorEvent(
         Ogre::Vector2 mouse_pos = rviz_rendering::project3DPointToViewportXY(
           rviz_rendering::RenderWindowOgreAdapter::getOgreViewport(event.panel->getRenderWindow()),
           three_d_point);
-        QCursor::setPos(event.panel->mapToGlobal(QPoint(mouse_pos.x, mouse_pos.y)));
+        // The projection is in viewport (device) pixels; mapToGlobal expects logical ones.
+        const qreal pixel_ratio = event.panel->getRenderWindow()->devicePixelRatio();
+        QCursor::setPos(
+          event.panel->mapToGlobal(
+            rviz_rendering::toLogicalPixels(QPoint(mouse_pos.x, mouse_pos.y), pixel_ratio)));
         parent_->showMenu(event, name_, three_d_point, valid_point);
       }
       break;
@@ -1361,6 +1366,7 @@ void InteractiveMarkerControl::beginMouseMovement(
   parent_position_at_mouse_down_ = parent_->getPosition();
   parent_orientation_at_mouse_down_ = parent_->getOrientation();
 
+  // Mixed units are harmless: event.x is added back in getRelativeMouseMotion().
   QPoint absolute_mouse = QCursor::pos();
   mouse_relative_to_absolute_x_ = absolute_mouse.x() - event.x;
   mouse_relative_to_absolute_y_ = absolute_mouse.y() - event.y;

--- a/rviz_rendering/include/rviz_rendering/pixel_scaling.hpp
+++ b/rviz_rendering/include/rviz_rendering/pixel_scaling.hpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2026, Open Source Robotics Foundation, Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+#ifndef RVIZ_RENDERING__PIXEL_SCALING_HPP_
+#define RVIZ_RENDERING__PIXEL_SCALING_HPP_
+
+#include <QPoint>  // NOLINT: cpplint cannot handle include order here
+#include <QtGlobal>  // NOLINT: cpplint cannot handle include order here
+
+namespace rviz_rendering
+{
+
+/// Conversions between the two pixel units that meet at the Qt/Ogre boundary.
+/**
+ * Qt expresses window geometry and input events in logical pixels,
+ * hiding the display scale factor from the application. Ogre has no notion
+ * of a scale factor at all: it renders into a native surface and works purely in
+ * device pixels.
+ */
+inline int
+toDevicePixels(qreal logical, qreal pixel_ratio)
+{
+  return qRound(logical * pixel_ratio);
+}
+
+/// Convert a length in device pixels to logical pixels.
+inline int
+toLogicalPixels(qreal device, qreal pixel_ratio)
+{
+  return qRound(device / pixel_ratio);
+}
+
+/// Convert a point in logical pixels to device pixels.
+inline QPoint
+toDevicePixels(const QPoint & logical, qreal pixel_ratio)
+{
+  return QPoint(
+    toDevicePixels(logical.x(), pixel_ratio),
+    toDevicePixels(logical.y(), pixel_ratio));
+}
+
+/// Convert a point in device pixels to logical pixels.
+inline QPoint
+toLogicalPixels(const QPoint & device, qreal pixel_ratio)
+{
+  return QPoint(
+    toLogicalPixels(device.x(), pixel_ratio),
+    toLogicalPixels(device.y(), pixel_ratio));
+}
+
+}  // namespace rviz_rendering
+
+#endif  // RVIZ_RENDERING__PIXEL_SCALING_HPP_

--- a/rviz_rendering/include/rviz_rendering/render_system.hpp
+++ b/rviz_rendering/include/rviz_rendering/render_system.hpp
@@ -68,6 +68,15 @@ public:
   RenderSystem *
   get();
 
+  /// Create an Ogre render window bound to an existing native window.
+  /**
+   * \param width surface width in device pixels, not logical pixels
+   * \param height surface height in device pixels, not logical pixels
+   * \param pixel_ratio display scale factor, forwarded to Ogre as
+   *   "contentScalingFactor"; Ogre documents it as iOS/Android specific and the
+   *   desktop GL render systems ignore it, so the caller is responsible for
+   *   supplying already-scaled dimensions
+   */
   Ogre::RenderWindow *
   makeRenderWindow(
     WindowIDType window_id,

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -34,6 +34,8 @@
 #include <cstdlib>
 #include <functional>
 
+#include <QSize>  // NOLINT: cpplint cannot handle include order here
+
 #include "OgreEntity.h"
 #include "OgreCamera.h"
 #include "OgreGpuProgramManager.h"
@@ -53,6 +55,26 @@
 
 namespace rviz_rendering
 {
+
+
+// Qt expresses window geometry in logical (device independent) pixels, but
+// the surface Ogre renders into is sized in device pixels.  Ogre has no
+// notion of the display scale factor here. So the conversion shall happen here
+static
+QSize
+toOgreSurfaceSize(const QWindow * window, int logical_width, int logical_height)
+{
+#if __APPLE__
+  // Ogre on apple has different scaling mechanism, so
+  // left unchanged because this path could not be tested
+  (void) window;
+  return QSize(logical_width, logical_height);
+#else
+  const qreal pixel_ratio = window->devicePixelRatio();
+  return QSize(qRound(logical_width * pixel_ratio), qRound(logical_height * pixel_ratio));
+#endif
+}
+
 
 RenderWindowImpl::RenderWindowImpl(QWindow * parent)
 : parent_(parent),
@@ -179,8 +201,9 @@ RenderWindowImpl::initialize()
 {
   render_system_ = RenderSystem::get();
   double pixel_ratio = parent_->devicePixelRatio();
+  QSize surface_size = toOgreSurfaceSize(parent_, parent_->width(), parent_->height());
   ogre_render_window_ = render_system_->makeRenderWindow(
-    parent_->winId(), parent_->width(), parent_->height(), pixel_ratio);
+    parent_->winId(), surface_size.width(), surface_size.height(), pixel_ratio);
 
   Ogre::Root * ogre_root = render_system_->getOgreRoot();
   if (!ogre_root) {
@@ -244,9 +267,11 @@ RenderWindowImpl::resize(size_t width, size_t height)
   }
   if (ogre_render_window_) {
     this->setCameraAspectRatio();
+    QSize surface_size = toOgreSurfaceSize(
+      parent_, static_cast<int>(width), static_cast<int>(height));
     ogre_render_window_->resize(
-      static_cast<unsigned int>(width),  // NOLINT
-      static_cast<unsigned int>(height)  // NOLINT
+      static_cast<unsigned int>(surface_size.width()),  // NOLINT
+      static_cast<unsigned int>(surface_size.height())  // NOLINT
     );
     ogre_render_window_->windowMovedOrResized();
   }

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.cpp
@@ -49,6 +49,7 @@
 #include "OgreViewport.h"
 
 #include "rviz_rendering/orthographic.hpp"
+#include "rviz_rendering/pixel_scaling.hpp"
 #include "rviz_rendering/render_system.hpp"
 #include "rviz_rendering/objects/grid.hpp"
 #include "rviz_rendering/logging.hpp"
@@ -71,7 +72,9 @@ toOgreSurfaceSize(const QWindow * window, int logical_width, int logical_height)
   return QSize(logical_width, logical_height);
 #else
   const qreal pixel_ratio = window->devicePixelRatio();
-  return QSize(qRound(logical_width * pixel_ratio), qRound(logical_height * pixel_ratio));
+  return QSize(
+    toDevicePixels(logical_width, pixel_ratio),
+    toDevicePixels(logical_height, pixel_ratio));
 #endif
 }
 

--- a/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
+++ b/rviz_rendering/src/rviz_rendering/ogre_render_window_impl.hpp
@@ -87,6 +87,10 @@ public:
   void
   renderNow();
 
+  /// Resize the render surface.
+  /**
+   * \param width, height - these are expressed in logical Qt pixels
+   */
   void
   resize(size_t width, size_t height);
 


### PR DESCRIPTION
## Description

Qt expresses window geometry in logical (device independent) pixels, but the
surface Ogre renders into is sized in device pixels. rviz passed Qt's numbers to
Ogre unchanged, so on any display with a scale factor the two disagreed.

What made this hard to spot is that the mismatch only appears on the first `QEvent::Resize`: there `RenderWindowImpl::resize()` forwarded `QWindow::width()`/`height()` unchanged, and Ogre applies those with `XResizeWindow`, shrinking its GL child window inside the parent. That is why the view renders correctly at startup and only starts flickering after the first interaction.

The scale factor was already being read and passed to Ogre as
`contentScalingFactor`, but Ogre documents that parameter as iOS/Android specific
and GL doesn't read it, so it was a no-op on desktop.

This converts at the Qt/Ogre boundary instead, in both `initialize()` and
`resize()` so a later resize cannot undo the initial sizing. Rounding matches
`QSize::operator*(qreal)`, which is how Qt derives the native window geometry, so
the surface and the window agree exactly at fractional scale factors where
rounding and truncation differ.

The Apple branch deliberately keeps the previous behavior (at least I tried to keep code unchanged fro Apple)


Fixes #1052

### Is this user-facing behavior change?

Yes, on displays with a scale factor other than 1:

- The 3D view fills its panel and no longer flickers or mis-sizes after the first
  interaction.
- The scene is now rendered at the display's native resolution, so it is sharper,
  but the render target is larger (1.25^2 at 125%) and costs correspondingly
  more GPU time.

### Did you use Generative AI?

Claude Opus 5 - helped to find root cause and open PR via fork (never done that before)

### Additional

Verified on Ubuntu 24.04 / Jazzy in distrobox docker container, host OS - Kubuntu 26 (KDE Plasma 6 (Wayland + XWayland)), with `QT_SCALE_FACTOR=1.2`. The flicker after first interaction is gone.